### PR TITLE
fix: corrigir condicao if do bootstrap + heredoc YAML

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   bootstrap:
-    if: github.event.inputs.confirm == 'EXECUTAR'
+    if: ${{ github.event.inputs.confirm == 'EXECUTAR' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problema\n- Heredoc sem indentacao quebrava YAML (linha 79)\n- Condicao `if` sem `${{ }}` fazia o job ser sempre Skipped\n\n## Solucao\n- Substituido heredoc por printf single-line\n- Adicionado `${{ }}` na expressao if do job