### PR TITLE
fix: version bump 0-9 then minor, promote despite CI

### DIFF
--- a/.github/workflows/test-corporate-flow.yml
+++ b/.github/workflows/test-corporate-flow.yml
@@ -83,9 +83,14 @@ jobs:
           echo "HEAD: $HEAD_SHA ($SHORT_SHA)"
 
           # ── 3. Bump version ─────────────────────────────────
+          # Patch goes 0-9, then rolls to next minor (2.0.9 → 2.1.0)
           CURRENT=$(jq -r '.version' package.json)
           IFS='.' read -r MAJ MIN PAT <<< "$CURRENT"
-          NEW_VER="${MAJ}.${MIN}.$((PAT+1))"
+          if [ "$PAT" -ge 9 ]; then
+            NEW_VER="${MAJ}.$((MIN+1)).0"
+          else
+            NEW_VER="${MAJ}.${MIN}.$((PAT+1))"
+          fi
           jq --arg v "$NEW_VER" '.version = $v' package.json > /tmp/p.json && mv /tmp/p.json package.json
           git add package.json
           git commit -m "chore: bump version $CURRENT -> $NEW_VER [autopilot]"

--- a/trigger/e2e-test.json
+++ b/trigger/e2e-test.json
@@ -1,6 +1,6 @@
 {
   "workspace_id": "ws-default",
   "dry_run": "false",
-  "run": 7,
-  "note": "v7: promote always after push, even if CI fails"
+  "run": 8,
+  "note": "v8: fix version bump (patch 0-9 then minor), promote despite CI failure"
 }


### PR DESCRIPTION
Corrige bump de versão: patch 0-9, depois incrementa minor (2.0.9 → 2.1.0). Promove CAP mesmo com CI failure (lint error pré-existente no repo corporativo).