### PR TITLE
fix: tag format version-only, no hash

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -139,7 +139,7 @@ jobs:
           VERSION=$(gh api "repos/${{ github.repository }}/contents/package.json?ref=$SHA" \
             --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | jq -r '.version // ""' || echo "")
           [ -z "$VERSION" ] || [ "$VERSION" = "null" ] && VERSION="0.0.0"
-          TAG="${VERSION}-${{ steps.state.outputs.short_sha }}"
+          TAG="${VERSION}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -146,7 +146,7 @@ jobs:
           if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
             VERSION="0.0.0"
           fi
-          TAG="${VERSION}-${{ steps.state.outputs.short_sha }}"
+          TAG="${VERSION}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-corporate-flow.yml
+++ b/.github/workflows/test-corporate-flow.yml
@@ -148,7 +148,7 @@ jobs:
           echo "- Result: $CI_RESULT ($CI_DETAIL)" >> "$GITHUB_STEP_SUMMARY"
 
           # ── 6. Promote tag in CAP ───────────────────────────
-          TAG="${NEW_VER}-${NEW_SHORT}"
+          TAG="${NEW_VER}"
           PROMOTED="false"
           PROCEED="false"
           if [ "$PUSHED" = "true" ]; then

--- a/.github/workflows/test-full-flow.yml
+++ b/.github/workflows/test-full-flow.yml
@@ -197,7 +197,7 @@ jobs:
           SHA="${{ env.sha }}"
           SHORT="${SHA:0:7}"
           VER="${{ env.version }}"
-          TAG="${VER}-${SHORT}"
+          TAG="${VER}"
           FSHA=$(gh api "repos/$AUTOPILOT_REPO/contents/${FILE}?ref=$STATE_BRANCH" --jq '.sha' 2>/dev/null || echo "")
           STATE=$(jq -n --arg ws "${{ needs.setup.outputs.ws_id }}" --arg sha "$SHA" --arg tag "$TAG" \
             --arg ver "$VER" --arg ts "$NOW" --arg run "${{ github.run_id }}" \
@@ -309,7 +309,7 @@ jobs:
           CAP_BRANCH="${{ needs.setup.outputs.cap_branch }}"
           CAP_VALUES="${{ needs.setup.outputs.cap_values }}"
           IMAGE_PATTERN="${{ needs.setup.outputs.image_pattern }}"
-          TAG="${{ env.version }}-${{ env.short_sha }}"
+          TAG="${{ env.version }}"
           echo "Promoting $TAG to $CAP_REPO"
 
           if [ -z "$CAP_REPO" ] || [ "$CAP_REPO" = "null" ]; then

--- a/trigger/full-test.json
+++ b/trigger/full-test.json
@@ -2,5 +2,5 @@
   "workspace_id": "ws-default",
   "test_type": "both",
   "include_lint_error": false,
-  "run": 2
+  "run": 3
 }


### PR DESCRIPTION
Tag no values.yaml agora usa só a versão (ex: 2.1.4), sem hash do commit. Corrigido em todos os 4 workflows.