### PR TITLE
feat: session guard + multi-agent safety

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -152,11 +152,87 @@ jobs:
           echo "| Target | \`$TARGET_PATH\` |" >> "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════════════════════════════════════════════════════
+  #  STAGE 1.5 → Session Guard: prevent concurrent agent conflicts
+  # ═══════════════════════════════════════════════════════════════
+  session-guard:
+    name: "1.5 Session Guard"
+    needs: setup
+    runs-on: ubuntu-latest
+    outputs:
+      lock_acquired: ${{ steps.lock.outputs.acquired }}
+      lock_id: ${{ steps.lock.outputs.lock_id }}
+      blocked_by: ${{ steps.lock.outputs.blocked_by }}
+    steps:
+      - name: "Acquire session lock"
+        id: lock
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          AGENT="claude-code"
+          OP="source-change"
+          WS="${{ needs.setup.outputs.ws_id }}"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          LOCK_ID="${AGENT}-$(date -u +%s)-${RANDOM}"
+          LOCK_PATH="state/workspaces/${WS}/locks/session-lock.json"
+
+          echo "=== Session Guard ==="
+          echo "Agent: $AGENT | Operation: $OP | Workspace: $WS"
+
+          # Check existing lock
+          EXISTING=$(gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}?ref=$STATE_BRANCH" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo "{}")
+          EXISTING_AGENT=$(echo "$EXISTING" | jq -r '.agentId // ""')
+          EXISTING_EXPIRES=$(echo "$EXISTING" | jq -r '.expiresAt // ""')
+          EXISTING_SHA=$(gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}?ref=$STATE_BRANCH" \
+            --jq '.sha' 2>/dev/null || echo "")
+
+          BLOCKED=false
+          if [ -n "$EXISTING_AGENT" ] && [ "$EXISTING_AGENT" != "" ] && [ "$EXISTING_AGENT" != "null" ]; then
+            NOW_EPOCH=$(date -u +%s)
+            EXPIRES_EPOCH=$(date -d "$EXISTING_EXPIRES" +%s 2>/dev/null || echo "0")
+            if [ "$NOW_EPOCH" -lt "$EXPIRES_EPOCH" ] && [ "$EXISTING_AGENT" != "$AGENT" ]; then
+              echo "::error ::BLOCKED by $EXISTING_AGENT (expires $EXISTING_EXPIRES)"
+              echo "acquired=false" >> "$GITHUB_OUTPUT"
+              echo "blocked_by=$EXISTING_AGENT" >> "$GITHUB_OUTPUT"
+              echo "lock_id=" >> "$GITHUB_OUTPUT"
+              BLOCKED=true
+            elif [ "$NOW_EPOCH" -ge "$EXPIRES_EPOCH" ]; then
+              echo "Existing lock from $EXISTING_AGENT expired, overriding"
+            else
+              echo "Lock held by same agent, refreshing"
+            fi
+          fi
+
+          if [ "$BLOCKED" = "true" ]; then exit 0; fi
+
+          # Acquire
+          EXPIRES_AT=$(date -u -d "+30 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "2099-01-01T00:00:00Z")
+          LOCK=$(jq -n --arg id "$LOCK_ID" --arg a "$AGENT" --arg op "$OP" --arg ws "$WS" \
+            --arg ts "$NOW" --arg exp "$EXPIRES_AT" --arg run "${{ github.run_id }}" \
+            '{lockId:$id,agentId:$a,operation:$op,workspaceId:$ws,acquiredAt:$ts,expiresAt:$exp,runId:$run}')
+
+          ARGS=(-f "branch=$STATE_BRANCH" -f "message=lock: session $AGENT [skip ci]" -f "content=$(echo "$LOCK"|base64 -w0)")
+          [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" != "null" ] && [ "$EXISTING_SHA" != "" ] && ARGS+=(-f "sha=$EXISTING_SHA")
+          gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}" --method PUT "${ARGS[@]}" > /dev/null 2>&1
+
+          echo "Lock acquired: $LOCK_ID"
+          echo "acquired=true" >> "$GITHUB_OUTPUT"
+          echo "lock_id=$LOCK_ID" >> "$GITHUB_OUTPUT"
+          echo "blocked_by=" >> "$GITHUB_OUTPUT"
+
+      - name: "Block if locked"
+        if: steps.lock.outputs.acquired == 'false'
+        run: |
+          echo "::error ::Another agent (${{ steps.lock.outputs.blocked_by }}) is active. Aborting."
+          exit 1
+
+  # ═══════════════════════════════════════════════════════════════
   #  STAGE 2 → Apply & Push: clone, apply change, lint, push
   # ═══════════════════════════════════════════════════════════════
   apply-and-push:
     name: "2. Apply & Push (${{ matrix.component }})"
-    needs: setup
+    needs: [setup, session-guard]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -665,11 +741,30 @@ jobs:
   #  STAGE 6 → Audit: record audit trail
   # ═══════════════════════════════════════════════════════════════
   audit:
-    name: "6. Audit"
-    needs: [setup, apply-and-push, ci-gate, promote, save-state]
+    name: "6. Audit & Release Lock"
+    needs: [setup, session-guard, apply-and-push, ci-gate, promote, save-state]
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: "Release session lock"
+        if: needs.session-guard.outputs.lock_acquired == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          WS="${{ needs.setup.outputs.ws_id }}"
+          LOCK_PATH="state/workspaces/${WS}/locks/session-lock.json"
+          FSHA=$(gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}?ref=$STATE_BRANCH" --jq '.sha' 2>/dev/null || echo "")
+          if [ -n "$FSHA" ] && [ "$FSHA" != "null" ]; then
+            NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            RELEASED=$(jq -n --arg ts "$NOW" '{lockId:"released",agentId:"none",operation:"none",acquiredAt:$ts,expiresAt:$ts}')
+            gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}" --method PUT \
+              -f "branch=$STATE_BRANCH" \
+              -f "message=lock: session released [skip ci]" \
+              -f "content=$(echo "$RELEASED"|base64 -w0)" \
+              -f "sha=$FSHA" > /dev/null 2>&1 || true
+            echo "Session lock released"
+          fi
+
       - name: "Record audit"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/session-guard.yml
+++ b/.github/workflows/session-guard.yml
@@ -1,0 +1,132 @@
+name: "Session Guard: Prevent Concurrent Agent Conflicts"
+
+# This workflow protects against concurrent modifications from
+# different agents (Claude Code vs Codex) sharing the same account.
+# It acquires a session lock before any state-changing operation
+# and blocks if another agent is already active.
+
+on:
+  workflow_call:
+    inputs:
+      agent_id:
+        description: "Agent identifier (claude-code, codex, manual)"
+        required: true
+        type: string
+      operation:
+        description: "Operation being performed"
+        required: true
+        type: string
+      workspace_id:
+        description: "Workspace ID"
+        required: false
+        type: string
+        default: "ws-default"
+      lock_ttl_minutes:
+        description: "Lock TTL in minutes"
+        required: false
+        type: number
+        default: 30
+    outputs:
+      lock_acquired:
+        description: "Whether lock was acquired"
+        value: ${{ jobs.guard.outputs.lock_acquired }}
+      lock_id:
+        description: "Lock ID for release"
+        value: ${{ jobs.guard.outputs.lock_id }}
+      blocked_by:
+        description: "Agent that blocked us (if any)"
+        value: ${{ jobs.guard.outputs.blocked_by }}
+
+env:
+  AUTOPILOT_REPO: lucassfreiree/autopilot
+  STATE_BRANCH: autopilot-state
+
+jobs:
+  guard:
+    name: "Session Guard"
+    runs-on: ubuntu-latest
+    outputs:
+      lock_acquired: ${{ steps.lock.outputs.acquired }}
+      lock_id: ${{ steps.lock.outputs.lock_id }}
+      blocked_by: ${{ steps.lock.outputs.blocked_by }}
+    steps:
+      - name: "Check & acquire session lock"
+        id: lock
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          AGENT="${{ inputs.agent_id }}"
+          OP="${{ inputs.operation }}"
+          WS="${{ inputs.workspace_id }}"
+          TTL="${{ inputs.lock_ttl_minutes }}"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          LOCK_ID="${AGENT}-$(date -u +%s)-${RANDOM}"
+          LOCK_PATH="state/workspaces/${WS}/locks/session-lock.json"
+
+          echo "=== Session Guard ==="
+          echo "Agent: $AGENT"
+          echo "Operation: $OP"
+          echo "Workspace: $WS"
+
+          # Check if a session lock already exists
+          EXISTING=$(gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}?ref=$STATE_BRANCH" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo "{}")
+          EXISTING_AGENT=$(echo "$EXISTING" | jq -r '.agentId // ""')
+          EXISTING_EXPIRES=$(echo "$EXISTING" | jq -r '.expiresAt // ""')
+          EXISTING_SHA=$(gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}?ref=$STATE_BRANCH" \
+            --jq '.sha' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_AGENT" ] && [ "$EXISTING_AGENT" != "" ]; then
+            # Check if lock has expired
+            if [ -n "$EXISTING_EXPIRES" ]; then
+              EXPIRES_EPOCH=$(date -d "$EXISTING_EXPIRES" +%s 2>/dev/null || echo "0")
+              NOW_EPOCH=$(date -u +%s)
+              if [ "$NOW_EPOCH" -lt "$EXPIRES_EPOCH" ]; then
+                # Lock is still valid
+                if [ "$EXISTING_AGENT" = "$AGENT" ]; then
+                  echo "Lock held by same agent ($AGENT), refreshing..."
+                else
+                  echo "::error ::BLOCKED! Lock held by '$EXISTING_AGENT' until $EXISTING_EXPIRES"
+                  echo "acquired=false" >> "$GITHUB_OUTPUT"
+                  echo "blocked_by=$EXISTING_AGENT" >> "$GITHUB_OUTPUT"
+                  echo "lock_id=" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
+              else
+                echo "Existing lock from '$EXISTING_AGENT' expired at $EXISTING_EXPIRES, overriding..."
+              fi
+            fi
+          fi
+
+          # Acquire lock
+          EXPIRES_AT=$(date -u -d "+${TTL} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+            date -u -v+${TTL}M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+            echo "2099-01-01T00:00:00Z")
+
+          LOCK=$(jq -n \
+            --arg id "$LOCK_ID" \
+            --arg agent "$AGENT" \
+            --arg op "$OP" \
+            --arg ws "$WS" \
+            --arg ts "$NOW" \
+            --arg exp "$EXPIRES_AT" \
+            --arg run "${{ github.run_id }}" \
+            '{lockId:$id,agentId:$agent,operation:$op,workspaceId:$ws,acquiredAt:$ts,expiresAt:$exp,runId:$run}')
+
+          ARGS=(-f "branch=$STATE_BRANCH" -f "message=lock: session acquired by $AGENT [skip ci]" -f "content=$(echo "$LOCK"|base64 -w0)")
+          [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" != "null" ] && [ "$EXISTING_SHA" != "" ] && ARGS+=(-f "sha=$EXISTING_SHA")
+
+          gh api "repos/$AUTOPILOT_REPO/contents/${LOCK_PATH}" --method PUT "${ARGS[@]}" > /dev/null 2>&1 || {
+            echo "::error ::Failed to acquire lock (race condition?)"
+            echo "acquired=false" >> "$GITHUB_OUTPUT"
+            echo "blocked_by=unknown" >> "$GITHUB_OUTPUT"
+            echo "lock_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          echo "Lock acquired: $LOCK_ID (expires $EXPIRES_AT)"
+          echo "acquired=true" >> "$GITHUB_OUTPUT"
+          echo "lock_id=$LOCK_ID" >> "$GITHUB_OUTPUT"
+          echo "blocked_by=" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,29 @@ state/workspaces/<workspace_id>/
 | drift-correction.yml | Detect and auto-correct source/deploy drift |
 | deploy-panel.yml | Deploy GitHub Pages panel |
 
+## Multi-Agent Safety (CRITICAL)
+Multiple agents (Claude Code, Codex) may share the same GitHub account.
+To prevent conflicts:
+
+1. **Session Guard**: All state-changing workflows MUST call `session-guard.yml` first
+2. **Lock before write**: Acquire session lock before modifying corporate repos or state
+3. **Agent identification**: Every commit must identify the agent (claude-code or codex)
+4. **Protected repos**: NEVER modify these without session lock:
+   - Corporate source repos (agent, controller)
+   - CAP/deploy repos
+   - `autopilot-state` branch
+5. **Concurrent protection**: If another agent holds a lock, WAIT or ABORT — never force
+
+### Protected Operations
+| Operation | Requires Lock | Agent Must Identify |
+|-----------|:---:|:---:|
+| Push to corporate repo | Yes | Yes |
+| Modify state branch | Yes | Yes |
+| Promote to CAP | Yes | Yes |
+| Read workspace config | No | No |
+| Run health check | No | No |
+| Read audit/metrics | No | No |
+
 ## Agent Compatibility
 This architecture is operable by Claude, ChatGPT, and Codex web.
 See `contracts/` for per-agent instructions.


### PR DESCRIPTION
## Summary
- **Session Guard** (stage 1.5): lock antes de modificar repos corporativos
- Bloqueia se outro agente (ex: Codex do irmão) já está ativo
- Lock com TTL (30min), auto-release no audit stage
- CLAUDE.md atualizado com regras de segurança multi-agent

## Problema
Dois agentes (Claude Code + Codex) compartilhando a mesma conta podem fazer alterações conflitantes nos repos corporativos simultaneamente.

## Solução
Pipeline agora tem 7 stages:
```
1. Setup → config
1.5 Session Guard → lock (bloqueia se outro agent ativo)
2. Apply & Push → clone + apply + fix lint + push
3. CI Gate → wait CI + smart comparison
4. Promote → CAP
5. Save State → state
6. Audit & Release Lock → audit + unlock
```