### PR TITLE
feat: auto-sync copilot prompt on project changes

### DIFF
--- a/.github/workflows/sync-copilot-prompt.yml
+++ b/.github/workflows/sync-copilot-prompt.yml
@@ -1,0 +1,368 @@
+name: "Sync Copilot Prompt"
+
+# Auto-regenerates .github/copilot-instructions.md whenever
+# workflows, schemas, contracts, or triggers change.
+# Keeps Copilot always up-to-date with the latest project state.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/*.yml'
+      - 'schemas/*.json'
+      - 'contracts/*.json'
+      - 'trigger/*.json'
+      - 'CLAUDE.md'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-copilot
+  cancel-in-progress: true
+
+env:
+  AUTOPILOT_REPO: lucassfreiree/autopilot
+  STATE_BRANCH: autopilot-state
+
+jobs:
+  # ═══════════════════════════════════════════════════════════════
+  #  STAGE 1 → Collect + Generate + Commit
+  # ═══════════════════════════════════════════════════════════════
+  sync:
+    name: "1. Collect → Generate → Commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: "Collect metadata"
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # ── Workflows table ──
+          echo "=== Scanning workflows ==="
+          WF_TABLE=""
+          DISPATCH_TABLE=""
+          for F in .github/workflows/*.yml; do
+            BN=$(basename "$F")
+            [ "$BN" = "sync-copilot-prompt.yml" ] && continue
+            WF_NAME=$(python3 -c "
+          import yaml
+          with open('$F') as f:
+              d = yaml.safe_load(f)
+              print(d.get('name', '${BN}'))
+          " 2>/dev/null || echo "$BN")
+            TRIGGERS=$(python3 -c "
+          import yaml
+          with open('$F') as f:
+              d = yaml.safe_load(f)
+              on = d.get('on', d.get(True, {}))
+              if isinstance(on, str): print(on); exit()
+              if isinstance(on, list): print(', '.join(on)); exit()
+              if isinstance(on, dict):
+                  p = []
+                  if 'schedule' in on: p.append('scheduled')
+                  if 'push' in on:
+                      push = on['push']
+                      if isinstance(push, dict) and 'paths' in push:
+                          tp = [x for x in push['paths'] if 'trigger/' in x]
+                          p.append('trigger file' if tp else 'push')
+                      else: p.append('push')
+                  if 'workflow_dispatch' in on: p.append('manual')
+                  if 'workflow_call' in on: p.append('reusable')
+                  if 'pull_request' in on: p.append('PR')
+                  if 'delete' in on: p.append('on delete')
+                  print(', '.join(p) if p else 'unknown')
+          " 2>/dev/null || echo "unknown")
+            WF_TABLE="${WF_TABLE}| ${BN} | ${WF_NAME} | ${TRIGGERS} |\n"
+
+            # Dispatch inputs
+            INPUTS=$(python3 -c "
+          import yaml
+          with open('$F') as f:
+              d = yaml.safe_load(f)
+              on = d.get('on', d.get(True, {}))
+              if isinstance(on, dict) and 'workflow_dispatch' in on:
+                  wd = on['workflow_dispatch']
+                  if wd and isinstance(wd, dict) and 'inputs' in wd:
+                      print(', '.join(wd['inputs'].keys()))
+          " 2>/dev/null || echo "")
+            [ -n "$INPUTS" ] && DISPATCH_TABLE="${DISPATCH_TABLE}| ${BN} | ${INPUTS} |\n"
+          done
+
+          # ── Trigger files ──
+          echo "=== Scanning triggers ==="
+          TRIG_TABLE=""
+          for F in trigger/*.json; do
+            BN=$(basename "$F")
+            MATCHING=$(grep -rl "trigger/${BN}" .github/workflows/ 2>/dev/null | head -1 | xargs basename 2>/dev/null || echo "—")
+            FIELDS=$(jq -r 'keys | map(select(. != "schemaVersion" and . != "run")) | join(", ")' "$F" 2>/dev/null || echo "—")
+            TRIG_TABLE="${TRIG_TABLE}| \`trigger/${BN}\` | ${MATCHING} | ${FIELDS} |\n"
+          done
+
+          # ── Schemas ──
+          echo "=== Scanning schemas ==="
+          SCHEMA_TABLE=""
+          for F in schemas/*.json; do
+            BN=$(basename "$F")
+            TITLE=$(jq -r '.title // .description // "—"' "$F" 2>/dev/null | head -c 60 || echo "—")
+            SCHEMA_TABLE="${SCHEMA_TABLE}| ${BN} | ${TITLE} |\n"
+          done
+
+          # ── Agents ──
+          echo "=== Scanning contracts ==="
+          AGENT_TABLE=""
+          for F in contracts/*-agent-contract.json; do
+            AGENT=$(jq -r '.agent // "?"' "$F" 2>/dev/null)
+            AID=$(jq -r '.agentIdentifier // "?"' "$F" 2>/dev/null)
+            CAPS=$(jq -r '.capabilities | join(", ")' "$F" 2>/dev/null | head -c 80 || echo "—")
+            AGENT_TABLE="${AGENT_TABLE}| ${AGENT} | ${AID} | ${CAPS} |\n"
+          done
+
+          # ── State files ──
+          echo "=== Checking state ==="
+          STATE_INFO=""
+          for SF in workspace.json health.json agent-release-state.json controller-release-state.json release-freeze.json; do
+            EXISTS=$(gh api "repos/$AUTOPILOT_REPO/contents/state/workspaces/ws-default/${SF}?ref=$STATE_BRANCH" --jq '.name' 2>/dev/null || echo "")
+            [ -n "$EXISTS" ] && STATE_INFO="${STATE_INFO}  ${SF}\n" || STATE_INFO="${STATE_INFO}  ${SF} (MISSING)\n"
+          done
+          for SUBDIR in locks audit improvements metrics handoffs approvals; do
+            COUNT=$(gh api "repos/$AUTOPILOT_REPO/contents/state/workspaces/ws-default/${SUBDIR}?ref=$STATE_BRANCH" --jq 'length' 2>/dev/null || echo "0")
+            STATE_INFO="${STATE_INFO}  ${SUBDIR}/ (${COUNT} files)\n"
+          done
+
+          # Save to env files for next step
+          {
+            echo "WF_TABLE<<EOF1"; echo -e "$WF_TABLE"; echo "EOF1"
+            echo "DISPATCH_TABLE<<EOF2"; echo -e "$DISPATCH_TABLE"; echo "EOF2"
+            echo "TRIG_TABLE<<EOF3"; echo -e "$TRIG_TABLE"; echo "EOF3"
+            echo "SCHEMA_TABLE<<EOF4"; echo -e "$SCHEMA_TABLE"; echo "EOF4"
+            echo "AGENT_TABLE<<EOF5"; echo -e "$AGENT_TABLE"; echo "EOF5"
+            echo "STATE_INFO<<EOF6"; echo -e "$STATE_INFO"; echo "EOF6"
+          } >> "$GITHUB_ENV"
+
+      - name: "Generate prompt"
+        run: |
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          cat > .github/copilot-instructions.md << 'STATIC_EOF'
+          # Autopilot — GitHub Copilot Integration Prompt
+
+          > **Auto-generated** by `sync-copilot-prompt.yml`. Do NOT edit manually.
+
+          You are **GitHub Copilot** operating inside the **Autopilot** control plane (`lucassfreiree/autopilot`).
+          Autopilot is a web-only CI/CD orchestration system that manages releases for corporate repos using GitHub Actions.
+
+          ## YOUR IDENTITY
+          - **Agent ID**: `copilot`
+          - **Role**: Dispatcher, reviewer, and coordinator between Claude Code and Codex
+          - **You CAN**: Read state, trigger workflows, create handoffs, review PRs, create issues
+          - **You CANNOT**: Push directly to corporate repos (use workflows instead)
+
+          ---
+
+          ## ARCHITECTURE
+
+          ```
+          lucassfreiree/autopilot (this repo)
+          ├── main branch          → Workflows, schemas, contracts, panel, triggers
+          ├── autopilot-state      → Runtime state (source of truth)
+          ├── autopilot-backups    → Snapshots for rollback
+          └── panel/               → GitHub Pages UI
+          ```
+
+          ### Current state files (ws-default):
+          ```
+          STATIC_EOF
+
+          echo -e "$STATE_INFO" >> .github/copilot-instructions.md
+          echo '```' >> .github/copilot-instructions.md
+
+          cat >> .github/copilot-instructions.md << 'TRIGGER_SECTION'
+
+          ---
+
+          ## HOW TO TRIGGER WORKFLOWS
+
+          ### Method 1: Trigger Files (PREFERRED)
+          Edit a trigger file on `main` branch, bump the `run` field.
+
+          | Trigger File | Workflow | Config Fields |
+          |---|---|---|
+          TRIGGER_SECTION
+
+          echo -e "$TRIG_TABLE" >> .github/copilot-instructions.md
+
+          cat >> .github/copilot-instructions.md << 'EXAMPLE_SECTION'
+
+          **Example — trigger a source code change:**
+          ```json
+          {
+            "schemaVersion": 1,
+            "workspace_id": "ws-default",
+            "component": "agent",
+            "change_type": "add-file",
+            "target_path": "src/utils/myNewFile.js",
+            "file_content": "module.exports = { hello: () => 'world' };",
+            "commit_message": "feat: add myNewFile utility",
+            "promote": true,
+            "run": 2
+          }
+          ```
+
+          ### Method 2: workflow_dispatch API
+          ```bash
+          gh api repos/lucassfreiree/autopilot/actions/workflows/{WORKFLOW}/dispatches \
+            --method POST -f ref=main -f "inputs[workspace_id]=ws-default"
+          ```
+
+          ### Method 3: Create handoff
+          ```bash
+          gh api repos/lucassfreiree/autopilot/actions/workflows/enqueue-agent-handoff.yml/dispatches \
+            --method POST -f ref=main \
+            -f "inputs[from_agent]=copilot" -f "inputs[to_agent]=claude" \
+            -f "inputs[component]=agent" -f "inputs[summary]=Your request" \
+            -f "inputs[workspace_id]=ws-default" -f "inputs[priority]=high"
+          ```
+
+          ---
+
+          ## HOW TO READ STATE
+
+          ```bash
+          # Workspace config
+          gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/workspace.json?ref=autopilot-state" --jq '.content' | base64 -d
+
+          # Session lock (CHECK BEFORE ACTING!)
+          gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/locks/session-lock.json?ref=autopilot-state" --jq '.content' | base64 -d
+
+          # Release state / Health / Improvement report
+          gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/{FILE}?ref=autopilot-state" --jq '.content' | base64 -d
+          ```
+
+          ---
+
+          ## SESSION GUARD (CRITICAL)
+
+          **Before ANY state-changing operation:**
+          1. Read `locks/session-lock.json`
+          2. If `agentId != "none"` AND `expiresAt > now` → **STOP**
+          3. Create a **handoff** instead of forcing
+
+          ---
+          EXAMPLE_SECTION
+
+          echo "## REGISTERED AGENTS" >> .github/copilot-instructions.md
+          echo "" >> .github/copilot-instructions.md
+          echo "| Agent | ID | Capabilities |" >> .github/copilot-instructions.md
+          echo "|---|---|---|" >> .github/copilot-instructions.md
+          echo -e "$AGENT_TABLE" >> .github/copilot-instructions.md
+
+          echo "" >> .github/copilot-instructions.md
+          echo "---" >> .github/copilot-instructions.md
+          echo "" >> .github/copilot-instructions.md
+          echo "## ALL WORKFLOWS" >> .github/copilot-instructions.md
+          echo "" >> .github/copilot-instructions.md
+          echo "| File | Name | Triggers |" >> .github/copilot-instructions.md
+          echo "|---|---|---|" >> .github/copilot-instructions.md
+          echo -e "$WF_TABLE" >> .github/copilot-instructions.md
+
+          echo "" >> .github/copilot-instructions.md
+          echo "### Dispatch Inputs" >> .github/copilot-instructions.md
+          echo "" >> .github/copilot-instructions.md
+          echo "| Workflow | Inputs |" >> .github/copilot-instructions.md
+          echo "|---|---|" >> .github/copilot-instructions.md
+          echo -e "$DISPATCH_TABLE" >> .github/copilot-instructions.md
+
+          echo "" >> .github/copilot-instructions.md
+          echo "---" >> .github/copilot-instructions.md
+          echo "" >> .github/copilot-instructions.md
+          echo "## SCHEMAS" >> .github/copilot-instructions.md
+          echo "" >> .github/copilot-instructions.md
+          echo "| Schema | Description |" >> .github/copilot-instructions.md
+          echo "|---|---|" >> .github/copilot-instructions.md
+          echo -e "$SCHEMA_TABLE" >> .github/copilot-instructions.md
+
+          cat >> .github/copilot-instructions.md << 'RULES_SECTION'
+
+          ---
+
+          ## RULES (non-negotiable)
+
+          1. **NEVER** store corporate code, secrets, or internal URLs in this repo
+          2. **NEVER** push directly to corporate repos — always use workflows
+          3. **ALWAYS** check session lock before state-changing operations
+          4. **ALWAYS** use `workspace_id` — never hardcode tenant/org names
+          5. State on `autopilot-state` is the **source of truth**
+          6. If you can't do something, create a **handoff** to Claude or Codex
+
+          ## COMMON TASKS
+
+          | Task | How |
+          |---|---|
+          | Deploy code change | Edit `trigger/source-change.json`, bump `run` |
+          | Run full test | Edit `trigger/full-test.json`, bump `run` |
+          | Fix CI errors | Edit `trigger/fix-ci.json`, bump `run` |
+          | Improvement scan | Edit `trigger/improvement.json`, bump `run` |
+          | Freeze releases | Dispatch `release-freeze.yml` with `action=freeze` |
+          | Backup state | Dispatch `backup-state.yml` |
+          | Handoff to Claude | Dispatch `enqueue-agent-handoff.yml`, `to_agent=claude` |
+          | Handoff to Codex | Dispatch `enqueue-agent-handoff.yml`, `to_agent=codex` |
+          RULES_SECTION
+
+          echo "" >> .github/copilot-instructions.md
+          echo "---" >> .github/copilot-instructions.md
+          echo "*Last synced: ${NOW} | Run: ${{ github.run_id }}*" >> .github/copilot-instructions.md
+
+      - name: "Commit if changed"
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add .github/copilot-instructions.md
+          if git diff --cached --quiet; then
+            echo "No changes to copilot prompt"
+          else
+            LINES=$(wc -l < .github/copilot-instructions.md)
+            git commit -m "docs: auto-sync copilot prompt ($LINES lines) [skip ci]"
+            git push origin main
+            echo "Pushed updated copilot prompt ($LINES lines)"
+          fi
+
+      - name: "Summary"
+        if: always()
+        run: |
+          LINES=$(wc -l < .github/copilot-instructions.md 2>/dev/null || echo "0")
+          echo "## Sync Copilot Prompt" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Lines: $LINES" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Workflows scanned: $(ls .github/workflows/*.yml | wc -l)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Triggers: $(ls trigger/*.json | wc -l)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Schemas: $(ls schemas/*.json | wc -l)" >> "$GITHUB_STEP_SUMMARY"
+
+  # ═══════════════════════════════════════════════════════════════
+  #  STAGE 2 → Audit
+  # ═══════════════════════════════════════════════════════════════
+  audit:
+    name: "2. Audit"
+    needs: sync
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Record"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          SN=$(echo "$NOW" | tr ':' '-')
+          AUDIT=$(jq -n --arg ts "$NOW" --arg run "${{ github.run_id }}" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg result "${{ needs.sync.result }}" \
+            '{operation:"sync-copilot-prompt",timestamp:$ts,runId:$run,runUrl:$url,syncResult:$result}')
+          gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/audit/copilot-sync-${SN}.json" \
+            --method PUT -f "branch=autopilot-state" \
+            -f "message=audit: copilot-sync $SN [skip ci]" \
+            -f "content=$(echo "$AUDIT"|base64 -w0)" 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ state/workspaces/<workspace_id>/
 ### Infrastructure
 | Workflow | Purpose |
 |----------|---------|
+| sync-copilot-prompt.yml | Auto-regenerates Copilot prompt when project changes |
 | session-guard.yml | Multi-agent lock acquisition and release |
 | ci-failure-analysis.yml | Analyze CI failures with diagnostics |
 | alert-notify.yml | Auto-create GitHub Issues on failures |


### PR DESCRIPTION
## Summary
Workflow que regenera automaticamente o `.github/copilot-instructions.md` toda vez que o projeto muda.

## Como funciona
```
Mudança em workflow/schema/contract/trigger
  → sync-copilot-prompt.yml dispara
    → Stage 1: Collect metadata (scan YAMLs, JSONs, state)
    → Stage 1: Generate prompt (tabelas dinâmicas)
    → Stage 1: Commit se mudou
    → Stage 2: Audit
```

## O que é extraído automaticamente
- Workflows: nome + triggers (parsed do YAML)
- Trigger files: campos de config
- Schemas: título/descrição
- Agents: ID + capabilities
- Dispatch inputs por workflow
- State files atuais

## Resultado
O Copilot sempre terá o prompt atualizado com:
- Todos os workflows que existem
- Todos os triggers disponíveis
- Todos os schemas
- Todos os agentes registrados
- Comandos copy-paste para cada operação