### PR TITLE
feat: add LangChain, Kubernetes, and n8n integrations

### DIFF
--- a/.github/workflows/langchain-orchestrator.yml
+++ b/.github/workflows/langchain-orchestrator.yml
@@ -1,0 +1,88 @@
+name: "LangChain Orchestrator"
+
+# Intelligent agent orchestration powered by LangChain + Claude.
+# Replaces rigid shell scripts with context-aware AI decision-making.
+# Zero cost: runs in GitHub Actions, uses Claude API.
+
+on:
+  workflow_dispatch:
+    inputs:
+      workspace_id:
+        description: "Workspace ID"
+        required: true
+        default: "ws-default"
+      task:
+        description: "Task type"
+        required: true
+        type: choice
+        options:
+          - analyze-ci-failure
+          - smart-release
+          - triage-handoff
+          - health-response
+          - custom
+      context:
+        description: "Additional context for the task"
+        required: false
+        default: ""
+  workflow_call:
+    inputs:
+      workspace_id:
+        type: string
+        required: true
+      task:
+        type: string
+        required: true
+      context:
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  orchestrate:
+    name: "LangChain Agent"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "integrations/langchain/requirements.txt"
+
+      - name: "Install dependencies"
+        run: pip install -r integrations/langchain/requirements.txt
+
+      - name: "Run orchestrator"
+        id: run
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        working-directory: integrations/langchain
+        run: |
+          set -euo pipefail
+          RESULT=$(python orchestrator.py \
+            --task "${{ inputs.task }}" \
+            --workspace "${{ inputs.workspace_id }}" \
+            --context "${{ inputs.context }}")
+
+          echo "## LangChain Orchestrator Result" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          echo "$RESULT" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          STATUS=$(echo "$RESULT" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+          DECISION=$(echo "$RESULT" | jq -r '.decision // "no decision"' 2>/dev/null || echo "no decision")
+          echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
+
+      - name: "Check result"
+        if: steps.run.outputs.status == 'blocked'
+        run: |
+          echo "::warning ::Orchestrator was blocked — check session lock or create handoff"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,32 @@ Zero local dependencies. 100% GitHub-native.
 - `panel/` — GitHub Pages control plane UI
 - `compliance/` — Data governance policies
 - `trigger/` — Trigger input files for workflow dispatch (bumping `run` field triggers the workflow)
+- `integrations/` — External tool integrations (LangChain, Kubernetes, n8n)
+
+## Integrations (all zero-cost, open-source)
+
+### LangChain (`integrations/langchain/`)
+Intelligent agent orchestration replacing rigid shell-script decision trees.
+- `orchestrator.py` — Main LangChain agent with tool-calling loop
+- `tools.py` — Custom tools (read state, trigger workflows, create handoffs)
+- `memory.py` — RAG memory from autopilot-state branch
+- Workflow: `langchain-orchestrator.yml` (runs in GitHub Actions)
+- Tasks: `analyze-ci-failure`, `smart-release`, `triage-handoff`, `health-response`
+
+### Kubernetes (`integrations/kubernetes/`)
+K8s manifests for self-hosted infrastructure (deploy on any free cluster).
+- `namespace.yml` — Workspace namespace + resource quotas
+- `runner-deployment.yml` — Self-hosted GitHub Actions runner
+- `cronjobs.yml` — Health check, improvement scan, backup, lock GC
+- `kustomization.yml` — Deploy all: `kubectl apply -k integrations/kubernetes/`
+
+### n8n (`integrations/n8n/`)
+Visual automation and external integrations (100% self-hosted, open-source).
+- `docker-compose.yml` — Run locally: `docker compose up -d`
+- `workflows/ci-failure-alert.json` — CI failure → Slack + auto-fix
+- `workflows/release-notify.json` — Release complete → Slack
+- `workflows/health-monitor.json` — Periodic health → alert if degraded
+- `workflows/approval-gate.json` — Interactive Slack approval for releases
 
 ## Rules
 1. Never store corporate code, secrets, or internal URLs in this repo
@@ -103,6 +129,7 @@ state/workspaces/<workspace_id>/
 | deploy-panel.yml | Deploy GitHub Pages panel |
 | enqueue-agent-handoff.yml | Create agent handoff |
 | record-improvement.yml | Record improvements |
+| langchain-orchestrator.yml | Intelligent agent orchestration via LangChain + Claude |
 
 ### Trigger Files
 | File | Triggers Workflow |

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -1,0 +1,35 @@
+# Kubernetes Integration — Autopilot
+
+> Zero cost to create. Deploy on any free-tier K8s cluster (Oracle Cloud Free, k3s, minikube).
+
+## What it provides
+Pre-built K8s manifests for running Autopilot infrastructure:
+- **Self-hosted GitHub Actions runners** — cheaper than GitHub-hosted at scale
+- **CronJobs** — replace `schedule:` triggers with K8s-native scheduling
+- **Namespace isolation** — each workspace gets its own namespace
+
+## Files
+| File | Purpose |
+|------|---------|
+| `namespace.yml` | Workspace namespace + resource quotas |
+| `runner-deployment.yml` | Self-hosted GitHub Actions runner (actions-runner-controller) |
+| `cronjobs.yml` | Health check + improvement scan + metrics on schedule |
+| `secrets.yml` | Template for required secrets (DO NOT commit values!) |
+| `kustomization.yml` | Kustomize overlay for easy deployment |
+
+## Quick Start
+```bash
+# 1. Create namespace
+kubectl apply -f integrations/kubernetes/namespace.yml
+
+# 2. Create secrets (edit with real values first!)
+kubectl apply -f integrations/kubernetes/secrets.yml
+
+# 3. Deploy everything
+kubectl apply -k integrations/kubernetes/
+```
+
+## Requirements
+- Any Kubernetes cluster (k3s, minikube, EKS, GKE, Oracle Cloud Free)
+- `kubectl` configured
+- GitHub PAT with `repo` + `workflow` scopes

--- a/integrations/kubernetes/cronjobs.yml
+++ b/integrations/kubernetes/cronjobs.yml
@@ -1,0 +1,197 @@
+# CronJobs for scheduled Autopilot operations.
+# Replace GitHub Actions schedule triggers with K8s-native scheduling.
+# Uses gh CLI to dispatch workflows — zero infrastructure dependency.
+---
+# Health check — every 4 hours
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: autopilot-health-check
+  namespace: autopilot-ws-default
+  labels:
+    app: autopilot
+    task: health-check
+spec:
+  schedule: "0 */4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          containers:
+            - name: dispatch
+              image: ghcr.io/cli/cli:latest
+              command: ["gh"]
+              args:
+                - "api"
+                - "repos/lucassfreiree/autopilot/actions/workflows/health-check.yml/dispatches"
+                - "--method"
+                - "POST"
+                - "-f"
+                - "ref=main"
+                - "-f"
+                - "inputs[workspace_id]=ws-default"
+              env:
+                - name: GH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: autopilot-secrets
+                      key: GITHUB_PAT
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          restartPolicy: Never
+---
+# Continuous improvement — every Monday at 06:00 UTC
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: autopilot-improvement-scan
+  namespace: autopilot-ws-default
+  labels:
+    app: autopilot
+    task: improvement
+spec:
+  schedule: "0 6 * * 1"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          containers:
+            - name: dispatch
+              image: ghcr.io/cli/cli:latest
+              command: ["gh"]
+              args:
+                - "api"
+                - "repos/lucassfreiree/autopilot/actions/workflows/continuous-improvement.yml/dispatches"
+                - "--method"
+                - "POST"
+                - "-f"
+                - "ref=main"
+                - "-f"
+                - "inputs[workspace_id]=ws-default"
+                - "-f"
+                - "inputs[auto_fix]=true"
+              env:
+                - name: GH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: autopilot-secrets
+                      key: GITHUB_PAT
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          restartPolicy: Never
+---
+# Backup state — daily at 02:00 UTC
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: autopilot-backup
+  namespace: autopilot-ws-default
+  labels:
+    app: autopilot
+    task: backup
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          containers:
+            - name: dispatch
+              image: ghcr.io/cli/cli:latest
+              command: ["gh"]
+              args:
+                - "api"
+                - "repos/lucassfreiree/autopilot/actions/workflows/backup-state.yml/dispatches"
+                - "--method"
+                - "POST"
+                - "-f"
+                - "ref=main"
+                - "-f"
+                - "inputs[workspace_id]=ws-default"
+              env:
+                - name: GH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: autopilot-secrets
+                      key: GITHUB_PAT
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          restartPolicy: Never
+---
+# Lock garbage collection — every 15 minutes
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: autopilot-lock-gc
+  namespace: autopilot-ws-default
+  labels:
+    app: autopilot
+    task: lock-gc
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          containers:
+            - name: dispatch
+              image: ghcr.io/cli/cli:latest
+              command: ["gh"]
+              args:
+                - "api"
+                - "repos/lucassfreiree/autopilot/actions/workflows/workspace-lock-gc.yml/dispatches"
+                - "--method"
+                - "POST"
+                - "-f"
+                - "ref=main"
+                - "-f"
+                - "inputs[workspace_id]=ws-default"
+              env:
+                - name: GH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: autopilot-secrets
+                      key: GITHUB_PAT
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          restartPolicy: Never

--- a/integrations/kubernetes/kustomization.yml
+++ b/integrations/kubernetes/kustomization.yml
@@ -1,0 +1,16 @@
+# Kustomize overlay for deploying all Autopilot K8s resources.
+# Usage: kubectl apply -k integrations/kubernetes/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: autopilot-ws-default
+
+resources:
+  - namespace.yml
+  - runner-deployment.yml
+  - cronjobs.yml
+  # NOTE: secrets.yml is NOT included — apply manually with real values
+
+commonLabels:
+  app: autopilot
+  managed-by: autopilot-k8s

--- a/integrations/kubernetes/namespace.yml
+++ b/integrations/kubernetes/namespace.yml
@@ -1,0 +1,39 @@
+# Namespace per workspace — provides isolation and resource control.
+# Each workspace_id maps to a K8s namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: autopilot-ws-default
+  labels:
+    app: autopilot
+    workspace: ws-default
+---
+# Resource quota to prevent runaway costs on free-tier clusters
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: autopilot-quota
+  namespace: autopilot-ws-default
+spec:
+  hard:
+    requests.cpu: "2"
+    requests.memory: 2Gi
+    limits.cpu: "4"
+    limits.memory: 4Gi
+    pods: "10"
+---
+# LimitRange for default pod limits
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: autopilot-limits
+  namespace: autopilot-ws-default
+spec:
+  limits:
+    - default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      type: Container

--- a/integrations/kubernetes/runner-deployment.yml
+++ b/integrations/kubernetes/runner-deployment.yml
@@ -1,0 +1,58 @@
+# Self-hosted GitHub Actions runner for Autopilot.
+# Uses the official actions-runner image.
+# Replaces GitHub-hosted runners — free on your own infra.
+#
+# Prerequisites: Install actions-runner-controller (ARC) OR use this standalone runner.
+# Docs: https://github.com/actions/runner
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autopilot-runner
+  namespace: autopilot-ws-default
+  labels:
+    app: autopilot
+    component: runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autopilot
+      component: runner
+  template:
+    metadata:
+      labels:
+        app: autopilot
+        component: runner
+    spec:
+      containers:
+        - name: runner
+          image: ghcr.io/actions/actions-runner:latest
+          env:
+            - name: RUNNER_NAME
+              value: "autopilot-k8s-runner"
+            - name: RUNNER_LABELS
+              value: "autopilot,self-hosted,linux"
+            - name: GITHUB_URL
+              value: "https://github.com/lucassfreiree/autopilot"
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: autopilot-secrets
+                  key: GITHUB_PAT
+            - name: RUNNER_WORKDIR
+              value: "/home/runner/_work"
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: runner-work
+              mountPath: /home/runner/_work
+      volumes:
+        - name: runner-work
+          emptyDir:
+            sizeLimit: 2Gi
+      restartPolicy: Always

--- a/integrations/kubernetes/secrets.yml
+++ b/integrations/kubernetes/secrets.yml
@@ -1,0 +1,29 @@
+# ============================================================
+# SECRET TEMPLATE — Replace placeholders before applying!
+# NEVER commit this file with real values.
+# ============================================================
+#
+# Required secrets:
+#   GITHUB_PAT: GitHub Personal Access Token (repo + workflow scopes)
+#   ANTHROPIC_API_KEY: For LangChain orchestrator (optional)
+#
+# Usage:
+#   1. Copy this file: cp secrets.yml secrets.local.yml
+#   2. Edit secrets.local.yml with real values
+#   3. Apply: kubectl apply -f secrets.local.yml
+#   4. DO NOT commit secrets.local.yml
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: autopilot-secrets
+  namespace: autopilot-ws-default
+  labels:
+    app: autopilot
+type: Opaque
+stringData:
+  # Replace <YOUR_GITHUB_PAT> with a real token
+  GITHUB_PAT: "<YOUR_GITHUB_PAT>"
+  GITHUB_REPO: "lucassfreiree/autopilot"
+  # Optional: only needed for LangChain orchestrator
+  ANTHROPIC_API_KEY: "<YOUR_ANTHROPIC_API_KEY>"

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -1,0 +1,30 @@
+# LangChain Integration — Autopilot
+
+> Zero-cost: runs inside GitHub Actions with `pip install langchain-anthropic`
+
+## What it does
+Replaces rigid shell-script decision-making with intelligent LangChain agents that:
+- Analyze CI failures semantically (not just regex)
+- Decide next actions based on context
+- Maintain memory of past decisions via state branch
+- Coordinate multi-agent handoffs intelligently
+
+## Files
+| File | Purpose |
+|------|---------|
+| `orchestrator.py` | Main LangChain agent with tools for Autopilot operations |
+| `tools.py` | Custom LangChain tools (read state, trigger workflows, create handoffs) |
+| `memory.py` | RAG memory backed by autopilot-state branch |
+| `requirements.txt` | Python dependencies (all free/open-source) |
+| `../../.github/workflows/langchain-orchestrator.yml` | Workflow to run the agent |
+
+## Usage
+Triggered via workflow_dispatch or by other workflows that need intelligent decision-making.
+
+```bash
+gh api repos/lucassfreiree/autopilot/actions/workflows/langchain-orchestrator.yml/dispatches \
+  --method POST -f ref=main \
+  -f "inputs[workspace_id]=ws-default" \
+  -f "inputs[task]=analyze-ci-failure" \
+  -f "inputs[context]=Build failed on agent repo - npm test exit code 1"
+```

--- a/integrations/langchain/memory.py
+++ b/integrations/langchain/memory.py
@@ -1,0 +1,120 @@
+"""
+RAG memory backed by autopilot-state branch.
+Provides context from past releases, audit entries, and improvement reports.
+Zero cost — reads directly from GitHub API.
+"""
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from typing import Optional
+
+REPO = "lucassfreiree/autopilot"
+STATE_BRANCH = "autopilot-state"
+
+
+def _gh_list(path: str) -> list[str]:
+    """List files in a state directory."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{REPO}/contents/{path}?ref={STATE_BRANCH}",
+         "--jq", ".[].name"],
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
+
+
+def _gh_read(path: str) -> Optional[dict]:
+    """Read a JSON file from state branch."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{REPO}/contents/{path}?ref={STATE_BRANCH}",
+         "--jq", ".content"],
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return None
+    import base64
+    try:
+        decoded = base64.b64decode(result.stdout.strip()).decode("utf-8")
+        return json.loads(decoded)
+    except Exception:
+        return None
+
+
+def get_recent_audit_entries(workspace_id: str = "ws-default", limit: int = 10) -> list[dict]:
+    """Fetch the most recent audit entries (sorted by timestamp desc)."""
+    path = f"state/workspaces/{workspace_id}/audit"
+    files = _gh_list(path)
+    # Audit files are named like: operation-TIMESTAMP.json, sort desc
+    files.sort(reverse=True)
+    entries = []
+    for f in files[:limit]:
+        entry = _gh_read(f"{path}/{f}")
+        if entry:
+            entries.append(entry)
+    return entries
+
+
+def get_release_history(workspace_id: str = "ws-default") -> dict:
+    """Get current release state for both components."""
+    agent = _gh_read(f"state/workspaces/{workspace_id}/agent-release-state.json")
+    controller = _gh_read(f"state/workspaces/{workspace_id}/controller-release-state.json")
+    return {"agent": agent, "controller": controller}
+
+
+def get_improvement_trend(workspace_id: str = "ws-default") -> Optional[dict]:
+    """Get the latest improvement report with trend data."""
+    return _gh_read(f"state/workspaces/{workspace_id}/improvements/latest-report.json")
+
+
+def get_active_handoffs(workspace_id: str = "ws-default") -> list[dict]:
+    """Get pending handoffs that need attention."""
+    path = f"state/workspaces/{workspace_id}/handoffs"
+    files = _gh_list(path)
+    handoffs = []
+    for f in files:
+        h = _gh_read(f"{path}/{f}")
+        if h and h.get("status") in ("pending", "in-progress"):
+            handoffs.append(h)
+    return handoffs
+
+
+def build_context_summary(workspace_id: str = "ws-default") -> str:
+    """Build a text summary of current project state for the LLM context."""
+    lines = [f"=== Autopilot Context for {workspace_id} ===", ""]
+
+    # Release state
+    releases = get_release_history(workspace_id)
+    for comp in ("agent", "controller"):
+        r = releases.get(comp)
+        if r:
+            lines.append(f"[{comp}] version={r.get('lastVersion', '?')} "
+                         f"status={r.get('status', '?')} "
+                         f"sha={r.get('lastReleasedSha', '?')[:8]} "
+                         f"updated={r.get('updatedAt', '?')}")
+
+    # Improvement
+    report = get_improvement_trend(workspace_id)
+    if report:
+        lines.append(f"\n[Health] score={report.get('healthScore', '?')}/100 "
+                     f"trend={report.get('trend', {}).get('direction', '?')} "
+                     f"issues={report.get('totalIssues', '?')}")
+
+    # Pending handoffs
+    handoffs = get_active_handoffs(workspace_id)
+    if handoffs:
+        lines.append(f"\n[Handoffs] {len(handoffs)} pending:")
+        for h in handoffs[:3]:
+            lines.append(f"  - from={h.get('fromAgent')} to={h.get('toAgent')} "
+                         f"priority={h.get('priority')} summary={h.get('context', {}).get('summary', '?')[:60]}")
+
+    # Recent audit
+    audits = get_recent_audit_entries(workspace_id, limit=5)
+    if audits:
+        lines.append(f"\n[Recent operations]:")
+        for a in audits:
+            lines.append(f"  - {a.get('operation', '?')} status={a.get('status', '?')} "
+                         f"at={a.get('timestamp', '?')}")
+
+    return "\n".join(lines)

--- a/integrations/langchain/orchestrator.py
+++ b/integrations/langchain/orchestrator.py
@@ -1,0 +1,184 @@
+"""
+Autopilot LangChain Orchestrator
+================================
+Intelligent agent that replaces rigid shell-script decision trees
+with context-aware AI reasoning.
+
+Zero cost: uses Claude API (via ANTHROPIC_API_KEY) inside GitHub Actions.
+
+Usage:
+    python orchestrator.py --task "analyze-ci-failure" \
+        --workspace "ws-default" \
+        --context "npm test failed with exit code 1 in agent repo"
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from memory import build_context_summary
+from tools import ALL_TOOLS
+
+
+SYSTEM_PROMPT = """You are the Autopilot Orchestrator — an AI agent managing CI/CD releases
+for corporate repositories via GitHub Actions.
+
+## YOUR CAPABILITIES
+You have tools to:
+- Read workspace config, release state, health, session locks, improvement reports
+- Trigger workflows: source changes, CI fixes, health checks, backups, improvement scans
+- Create handoffs to other agents (Claude Code, Codex, ChatGPT)
+
+## RULES (non-negotiable)
+1. ALWAYS check session lock before any state-changing operation
+2. If another agent holds the lock, create a handoff — NEVER force
+3. Never expose secrets, tokens, or internal URLs in your output
+4. Use workspace_id from context — never hardcode
+5. Prefer the simplest action that solves the problem
+6. When uncertain, create a handoff to Claude Code for complex decisions
+
+## TASK TYPES
+
+### analyze-ci-failure
+1. Read release state → check last CI result
+2. Read health → check for pre-existing issues
+3. Decide: is this a new failure or pre-existing?
+4. If new: trigger fix-ci workflow
+5. If pre-existing: log and skip
+
+### smart-release
+1. Check session lock
+2. Read release state for the component
+3. Read health — abort if critical
+4. Check improvement report — abort if score < 50
+5. Trigger the release if safe
+
+### triage-handoff
+1. Read pending handoffs
+2. Analyze each one's priority and context
+3. Decide which agent is best suited
+4. Create new handoffs if needed
+
+### health-response
+1. Read health check results
+2. Identify failed checks
+3. For each failure, decide the remediation action
+4. Execute fixes or create handoffs
+
+## OUTPUT
+Always respond with a JSON object:
+{
+  "task": "<task name>",
+  "decision": "<what you decided to do and why>",
+  "actions_taken": ["<list of actions executed>"],
+  "next_steps": ["<recommendations for follow-up>"],
+  "status": "success|partial|blocked"
+}
+"""
+
+
+def run_orchestrator(task: str, workspace_id: str, context: str) -> dict:
+    """Run the LangChain orchestrator agent."""
+    # Build memory context from state branch
+    state_context = build_context_summary(workspace_id)
+
+    # Initialize Claude model
+    model = ChatAnthropic(
+        model="claude-sonnet-4-20250514",
+        max_tokens=4096,
+        temperature=0,
+    )
+
+    # Bind tools
+    model_with_tools = model.bind_tools(ALL_TOOLS)
+
+    # Build the prompt
+    messages = [
+        SystemMessage(content=SYSTEM_PROMPT),
+        HumanMessage(content=f"""## Current State
+{state_context}
+
+## Task
+Type: {task}
+Workspace: {workspace_id}
+Context: {context}
+
+Execute this task using your tools. Check the session lock first if needed.
+Respond with the JSON output format specified in your instructions."""),
+    ]
+
+    # Agent loop — execute tool calls until done
+    max_iterations = 10
+    for i in range(max_iterations):
+        response = model_with_tools.invoke(messages)
+        messages.append(response)
+
+        # If no tool calls, we're done
+        if not response.tool_calls:
+            break
+
+        # Execute each tool call
+        from langchain_core.messages import ToolMessage
+        for tool_call in response.tool_calls:
+            # Find the matching tool
+            tool_fn = None
+            for t in ALL_TOOLS:
+                if t.name == tool_call["name"]:
+                    tool_fn = t
+                    break
+
+            if tool_fn is None:
+                tool_result = json.dumps({"error": f"Unknown tool: {tool_call['name']}"})
+            else:
+                try:
+                    result = tool_fn.invoke(tool_call["args"])
+                    tool_result = json.dumps(result) if isinstance(result, dict) else str(result)
+                except Exception as e:
+                    tool_result = json.dumps({"error": str(e)})
+
+            messages.append(ToolMessage(
+                content=tool_result,
+                tool_call_id=tool_call["id"],
+            ))
+
+    # Extract final response
+    final_text = response.content
+    if isinstance(final_text, list):
+        final_text = " ".join(
+            block.get("text", "") for block in final_text
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+
+    try:
+        return json.loads(final_text)
+    except (json.JSONDecodeError, TypeError):
+        return {
+            "task": task,
+            "decision": final_text,
+            "actions_taken": [],
+            "next_steps": [],
+            "status": "partial",
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Autopilot LangChain Orchestrator")
+    parser.add_argument("--task", required=True, help="Task type to execute")
+    parser.add_argument("--workspace", default="ws-default", help="Workspace ID")
+    parser.add_argument("--context", default="", help="Additional context for the task")
+    args = parser.parse_args()
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("ERROR: ANTHROPIC_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+
+    result = run_orchestrator(args.task, args.workspace, args.context)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/langchain/requirements.txt
+++ b/integrations/langchain/requirements.txt
@@ -1,0 +1,4 @@
+langchain>=0.3.0
+langchain-anthropic>=0.3.0
+langchain-core>=0.3.0
+pydantic>=2.0

--- a/integrations/langchain/tools.py
+++ b/integrations/langchain/tools.py
@@ -1,0 +1,183 @@
+"""
+Custom LangChain tools for Autopilot operations.
+All tools use GitHub CLI (gh) — zero infrastructure cost.
+"""
+
+import json
+import subprocess
+from typing import Optional
+
+from langchain_core.tools import tool
+
+REPO = "lucassfreiree/autopilot"
+STATE_BRANCH = "autopilot-state"
+
+
+def _gh_api(endpoint: str) -> dict:
+    """Call GitHub API via gh CLI."""
+    result = subprocess.run(
+        ["gh", "api", endpoint, "--jq", ".content"],
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return {"error": result.stderr.strip()}
+    import base64
+    try:
+        decoded = base64.b64decode(result.stdout.strip()).decode("utf-8")
+        return json.loads(decoded)
+    except Exception as e:
+        return {"error": str(e), "raw": result.stdout[:200]}
+
+
+def _dispatch_workflow(workflow: str, inputs: dict) -> str:
+    """Dispatch a GitHub Actions workflow."""
+    cmd = [
+        "gh", "api",
+        f"repos/{REPO}/actions/workflows/{workflow}/dispatches",
+        "--method", "POST",
+        "-f", "ref=main",
+    ]
+    for key, value in inputs.items():
+        cmd.extend(["-f", f"inputs[{key}]={value}"])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        return f"ERROR: {result.stderr.strip()}"
+    return "OK: workflow dispatched"
+
+
+@tool
+def read_workspace_config(workspace_id: str = "ws-default") -> dict:
+    """Read workspace configuration from autopilot-state branch.
+    Returns repo names, branches, paths, and settings for the workspace."""
+    return _gh_api(
+        f"repos/{REPO}/contents/state/workspaces/{workspace_id}/workspace.json?ref={STATE_BRANCH}"
+    )
+
+
+@tool
+def read_release_state(workspace_id: str = "ws-default", component: str = "agent") -> dict:
+    """Read current release state for a component (agent or controller).
+    Returns last SHA, tag, version, status, and promotion history."""
+    return _gh_api(
+        f"repos/{REPO}/contents/state/workspaces/{workspace_id}/{component}-release-state.json?ref={STATE_BRANCH}"
+    )
+
+
+@tool
+def read_health(workspace_id: str = "ws-default") -> dict:
+    """Read health check results for a workspace.
+    Returns overall status and individual check results."""
+    return _gh_api(
+        f"repos/{REPO}/contents/state/workspaces/{workspace_id}/health.json?ref={STATE_BRANCH}"
+    )
+
+
+@tool
+def read_session_lock(workspace_id: str = "ws-default") -> dict:
+    """Read the current session lock to check if another agent is active.
+    ALWAYS check this before any state-changing operation."""
+    return _gh_api(
+        f"repos/{REPO}/contents/state/workspaces/{workspace_id}/locks/session-lock.json?ref={STATE_BRANCH}"
+    )
+
+
+@tool
+def read_improvement_report(workspace_id: str = "ws-default") -> dict:
+    """Read the latest continuous improvement report.
+    Returns health score, issues found, trend direction."""
+    return _gh_api(
+        f"repos/{REPO}/contents/state/workspaces/{workspace_id}/improvements/latest-report.json?ref={STATE_BRANCH}"
+    )
+
+
+@tool
+def trigger_source_change(
+    workspace_id: str,
+    component: str,
+    change_type: str,
+    target_path: str,
+    file_content: str,
+    commit_message: str,
+    promote: bool = True,
+) -> str:
+    """Trigger the apply-source-change pipeline to modify corporate repo code.
+    This is the primary way to make code changes."""
+    return _dispatch_workflow("apply-source-change.yml", {
+        "workspace_id": workspace_id,
+        "component": component,
+        "change_type": change_type,
+        "target_path": target_path,
+        "file_content": file_content,
+        "commit_message": commit_message,
+        "promote": str(promote).lower(),
+    })
+
+
+@tool
+def trigger_health_check(workspace_id: str = "ws-default") -> str:
+    """Run a health check on the workspace."""
+    return _dispatch_workflow("health-check.yml", {
+        "workspace_id": workspace_id,
+    })
+
+
+@tool
+def trigger_fix_ci(workspace_id: str = "ws-default") -> str:
+    """Trigger the CI fix workflow to auto-fix lint errors."""
+    return _dispatch_workflow("fix-corporate-ci.yml", {
+        "workspace_id": workspace_id,
+    })
+
+
+@tool
+def create_agent_handoff(
+    from_agent: str,
+    to_agent: str,
+    summary: str,
+    component: str = "agent",
+    priority: str = "normal",
+    workspace_id: str = "ws-default",
+) -> str:
+    """Create a handoff from one agent to another.
+    Use when the current agent can't complete a task and needs delegation."""
+    return _dispatch_workflow("enqueue-agent-handoff.yml", {
+        "workspace_id": workspace_id,
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "component": component,
+        "summary": summary,
+        "priority": priority,
+    })
+
+
+@tool
+def trigger_backup(workspace_id: str = "ws-default") -> str:
+    """Create a backup snapshot of the current state."""
+    return _dispatch_workflow("backup-state.yml", {
+        "workspace_id": workspace_id,
+    })
+
+
+@tool
+def trigger_improvement_scan(workspace_id: str = "ws-default", auto_fix: str = "true") -> str:
+    """Run the continuous improvement pipeline to scan for issues and auto-fix."""
+    return _dispatch_workflow("continuous-improvement.yml", {
+        "workspace_id": workspace_id,
+        "auto_fix": auto_fix,
+    })
+
+
+# All tools exported for the orchestrator
+ALL_TOOLS = [
+    read_workspace_config,
+    read_release_state,
+    read_health,
+    read_session_lock,
+    read_improvement_report,
+    trigger_source_change,
+    trigger_health_check,
+    trigger_fix_ci,
+    create_agent_handoff,
+    trigger_backup,
+    trigger_improvement_scan,
+]

--- a/integrations/n8n/.gitignore
+++ b/integrations/n8n/.gitignore
@@ -1,0 +1,2 @@
+# n8n runtime data (created by docker compose)
+n8n-data/

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -1,0 +1,34 @@
+# n8n Integration — Autopilot
+
+> Zero cost: n8n is 100% open-source. Self-host with Docker or K8s.
+
+## What it provides
+Visual automation workflows that connect Autopilot to external systems:
+- **Slack/Discord alerts** on CI failures, releases, and health issues
+- **Webhook receivers** for GitHub events
+- **Human-in-the-loop** approval flows with interactive messages
+- **Dashboard** — visual pipeline status in n8n UI
+
+## Files
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | Run n8n locally with zero cost |
+| `workflows/ci-failure-alert.json` | Alert on CI failure → Slack + auto-triage |
+| `workflows/release-notify.json` | Notify on successful release |
+| `workflows/health-monitor.json` | Periodic health check + alert if degraded |
+| `workflows/approval-gate.json` | Interactive approval via Slack/webhook |
+
+## Quick Start
+```bash
+# 1. Start n8n locally (free, self-hosted)
+cd integrations/n8n
+docker compose up -d
+
+# 2. Open http://localhost:5678
+# 3. Import workflows from workflows/ directory
+# 4. Configure credentials (GitHub PAT, Slack webhook)
+```
+
+## n8n Cloud (optional, paid)
+If you prefer managed hosting, n8n offers a cloud plan.
+But self-hosted is 100% free and works identically.

--- a/integrations/n8n/docker-compose.yml
+++ b/integrations/n8n/docker-compose.yml
@@ -1,0 +1,24 @@
+# n8n self-hosted — 100% free, open-source
+# Runs locally or on any VPS/VM with Docker
+#
+# Usage:
+#   docker compose up -d
+#   Open http://localhost:5678
+#
+# Data persists in ./n8n-data/ (gitignored)
+services:
+  n8n:
+    image: n8nio/n8n:latest
+    container_name: autopilot-n8n
+    restart: unless-stopped
+    ports:
+      - "5678:5678"
+    environment:
+      - N8N_BASIC_AUTH_ACTIVE=true
+      - N8N_BASIC_AUTH_USER=autopilot
+      - N8N_BASIC_AUTH_PASSWORD=changeme
+      - WEBHOOK_URL=http://localhost:5678/
+      - GENERIC_TIMEZONE=America/Sao_Paulo
+      - N8N_LOG_LEVEL=info
+    volumes:
+      - ./n8n-data:/home/node/.n8n

--- a/integrations/n8n/workflows/approval-gate.json
+++ b/integrations/n8n/workflows/approval-gate.json
@@ -1,0 +1,139 @@
+{
+  "name": "Autopilot — Approval Gate",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "autopilot/approval-request",
+        "responseMode": "onReceived"
+      },
+      "id": "webhook-trigger",
+      "name": "Approval Request",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "autopilot-approval"
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.SLACK_WEBHOOK_URL }}",
+        "method": "POST",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"blocks\": [\n    {\n      \"type\": \"header\",\n      \"text\": {\n        \"type\": \"plain_text\",\n        \"text\": \"🔐 Release Approval Required\"\n      }\n    },\n    {\n      \"type\": \"section\",\n      \"text\": {\n        \"type\": \"mrkdwn\",\n        \"text\": \"*Component:* {{ $json.body.component }}\\n*Version:* {{ $json.body.version }}\\n*Workspace:* {{ $json.body.workspace_id }}\\n*Requested by:* {{ $json.body.agent }}\"\n      }\n    },\n    {\n      \"type\": \"actions\",\n      \"elements\": [\n        {\n          \"type\": \"button\",\n          \"text\": { \"type\": \"plain_text\", \"text\": \"✅ Approve\" },\n          \"style\": \"primary\",\n          \"url\": \"{{ $env.WEBHOOK_URL }}webhook/autopilot/approval-response?action=approve&id={{ $json.body.approval_id }}\"\n        },\n        {\n          \"type\": \"button\",\n          \"text\": { \"type\": \"plain_text\", \"text\": \"❌ Reject\" },\n          \"style\": \"danger\",\n          \"url\": \"{{ $env.WEBHOOK_URL }}webhook/autopilot/approval-response?action=reject&id={{ $json.body.approval_id }}\"\n        }\n      ]\n    }\n  ]\n}",
+        "options": {}
+      },
+      "id": "slack-approval",
+      "name": "Send Approval Request",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "autopilot/approval-response",
+        "responseMode": "onReceived"
+      },
+      "id": "approval-response",
+      "name": "Approval Response",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 520],
+      "webhookId": "autopilot-approval-response"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "conditions": [
+            {
+              "id": "check-approved",
+              "leftValue": "={{ $json.query.action }}",
+              "rightValue": "approve",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ]
+        },
+        "outputPinData": true
+      },
+      "id": "is-approved",
+      "name": "Approved?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [460, 520]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/lucassfreiree/autopilot/actions/workflows/release-agent.yml/dispatches",
+        "method": "POST",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\"ref\": \"main\", \"inputs\": {\"workspace_id\": \"ws-default\"}}",
+        "options": {}
+      },
+      "id": "trigger-release",
+      "name": "Trigger Release",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [680, 440],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-pat",
+          "name": "GitHub PAT"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.SLACK_WEBHOOK_URL }}",
+        "method": "POST",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "text",
+              "value": "=❌ Release *rejected* for approval {{ $json.query.id }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "notify-rejected",
+      "name": "Notify Rejected",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [680, 600]
+    }
+  ],
+  "connections": {
+    "Approval Request": {
+      "main": [
+        [{"node": "Send Approval Request", "type": "main", "index": 0}]
+      ]
+    },
+    "Approval Response": {
+      "main": [
+        [{"node": "Approved?", "type": "main", "index": 0}]
+      ]
+    },
+    "Approved?": {
+      "main": [
+        [{"node": "Trigger Release", "type": "main", "index": 0}],
+        [{"node": "Notify Rejected", "type": "main", "index": 0}]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {"name": "autopilot"},
+    {"name": "approval"},
+    {"name": "human-in-the-loop"}
+  ]
+}

--- a/integrations/n8n/workflows/ci-failure-alert.json
+++ b/integrations/n8n/workflows/ci-failure-alert.json
@@ -1,0 +1,180 @@
+{
+  "name": "Autopilot — CI Failure Alert",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "autopilot/ci-failure",
+        "responseMode": "onReceived",
+        "responseData": "allEntries"
+      },
+      "id": "webhook-trigger",
+      "name": "GitHub Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "autopilot-ci-failure"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true
+          },
+          "conditions": [
+            {
+              "id": "check-conclusion",
+              "leftValue": "={{ $json.body.conclusion }}",
+              "rightValue": "failure",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "filter-failure",
+      "name": "Is Failure?",
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.github.com/repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/health.json?ref=autopilot-state",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "read-health",
+      "name": "Read Health State",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [680, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-pat",
+          "name": "GitHub PAT"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "build-message",
+              "name": "message",
+              "value": "=🚨 *CI Failure Detected*\n\n*Repo:* {{ $('GitHub Webhook').item.json.body.repository.full_name }}\n*Workflow:* {{ $('GitHub Webhook').item.json.body.workflow.name }}\n*Branch:* {{ $('GitHub Webhook').item.json.body.workflow_run.head_branch }}\n*Conclusion:* {{ $('GitHub Webhook').item.json.body.conclusion }}\n*Run:* {{ $('GitHub Webhook').item.json.body.workflow_run.html_url }}\n\n*Health:* {{ $json.overall || 'unknown' }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "build-alert",
+      "name": "Build Alert Message",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.SLACK_WEBHOOK_URL }}",
+        "method": "POST",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "text",
+              "value": "={{ $json.message }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "slack-notify",
+      "name": "Send Slack Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [1120, 200]
+    },
+    {
+      "parameters": {
+        "url": "https://api.github.com/repos/lucassfreiree/autopilot/actions/workflows/fix-corporate-ci.yml/dispatches",
+        "method": "POST",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "ref",
+              "value": "main"
+            },
+            {
+              "name": "inputs",
+              "value": "={\"workspace_id\": \"ws-default\"}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "auto-fix",
+      "name": "Trigger Auto-Fix",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [1120, 400],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-pat",
+          "name": "GitHub PAT"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "GitHub Webhook": {
+      "main": [
+        [{"node": "Is Failure?", "type": "main", "index": 0}]
+      ]
+    },
+    "Is Failure?": {
+      "main": [
+        [{"node": "Read Health State", "type": "main", "index": 0}]
+      ]
+    },
+    "Read Health State": {
+      "main": [
+        [{"node": "Build Alert Message", "type": "main", "index": 0}]
+      ]
+    },
+    "Build Alert Message": {
+      "main": [
+        [
+          {"node": "Send Slack Alert", "type": "main", "index": 0},
+          {"node": "Trigger Auto-Fix", "type": "main", "index": 0}
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {"name": "autopilot"},
+    {"name": "ci"},
+    {"name": "alerts"}
+  ]
+}

--- a/integrations/n8n/workflows/health-monitor.json
+++ b/integrations/n8n/workflows/health-monitor.json
@@ -1,0 +1,158 @@
+{
+  "name": "Autopilot — Health Monitor",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "hours",
+              "hoursInterval": 4
+            }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Every 4 Hours",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "url": "https://api.github.com/repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/health.json?ref=autopilot-state",
+        "method": "GET",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "read-health",
+      "name": "Read Health",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [460, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-pat",
+          "name": "GitHub PAT"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Decode base64 content from GitHub API\nconst content = $input.first().json.content;\nconst decoded = Buffer.from(content, 'base64').toString('utf8');\nconst health = JSON.parse(decoded);\n\n// Check if any critical issues\nconst checks = health.checks || {};\nconst failed = Object.entries(checks)\n  .filter(([_, v]) => v.status === 'fail')\n  .map(([k, v]) => `${k}: ${v.message}`);\n\nconst warned = Object.entries(checks)\n  .filter(([_, v]) => v.status === 'warn')\n  .map(([k, v]) => `${k}: ${v.message}`);\n\nreturn [{\n  json: {\n    overall: health.overall,\n    failedChecks: failed,\n    warnedChecks: warned,\n    needsAlert: health.overall === 'critical' || health.overall === 'degraded',\n    checkedAt: health.checkedAt || new Date().toISOString()\n  }\n}];"
+      },
+      "id": "parse-health",
+      "name": "Parse Health",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "conditions": [
+            {
+              "id": "check-alert",
+              "leftValue": "={{ $json.needsAlert }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ]
+        }
+      },
+      "id": "needs-alert",
+      "name": "Needs Alert?",
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "alert-msg",
+              "name": "message",
+              "value": "=⚠️ *Autopilot Health Alert*\n\n*Status:* {{ $json.overall }}\n*Checked at:* {{ $json.checkedAt }}\n\n*Failed checks:*\n{{ $json.failedChecks.join('\\n') || 'None' }}\n\n*Warnings:*\n{{ $json.warnedChecks.join('\\n') || 'None' }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "build-alert",
+      "name": "Build Alert",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.SLACK_WEBHOOK_URL }}",
+        "method": "POST",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "text",
+              "value": "={{ $json.message }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "slack-alert",
+      "name": "Send Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [1340, 300]
+    }
+  ],
+  "connections": {
+    "Every 4 Hours": {
+      "main": [
+        [{"node": "Read Health", "type": "main", "index": 0}]
+      ]
+    },
+    "Read Health": {
+      "main": [
+        [{"node": "Parse Health", "type": "main", "index": 0}]
+      ]
+    },
+    "Parse Health": {
+      "main": [
+        [{"node": "Needs Alert?", "type": "main", "index": 0}]
+      ]
+    },
+    "Needs Alert?": {
+      "main": [
+        [{"node": "Build Alert", "type": "main", "index": 0}]
+      ]
+    },
+    "Build Alert": {
+      "main": [
+        [{"node": "Send Alert", "type": "main", "index": 0}]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {"name": "autopilot"},
+    {"name": "health"},
+    {"name": "monitoring"}
+  ]
+}

--- a/integrations/n8n/workflows/release-notify.json
+++ b/integrations/n8n/workflows/release-notify.json
@@ -1,0 +1,78 @@
+{
+  "name": "Autopilot — Release Notification",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "autopilot/release-complete",
+        "responseMode": "onReceived"
+      },
+      "id": "webhook-trigger",
+      "name": "Release Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "autopilot-release"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "format-msg",
+              "name": "message",
+              "value": "=✅ *Release Complete*\n\n*Component:* {{ $json.body.component }}\n*Version:* {{ $json.body.version }}\n*SHA:* `{{ $json.body.sha }}`\n*Promoted to:* {{ $json.body.promoted_to || 'N/A' }}\n*Workspace:* {{ $json.body.workspace_id }}\n*Run:* {{ $json.body.run_url }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "format-message",
+      "name": "Format Message",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.SLACK_WEBHOOK_URL }}",
+        "method": "POST",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "text",
+              "value": "={{ $json.message }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "slack-notify",
+      "name": "Send to Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [680, 300]
+    }
+  ],
+  "connections": {
+    "Release Webhook": {
+      "main": [
+        [{"node": "Format Message", "type": "main", "index": 0}]
+      ]
+    },
+    "Format Message": {
+      "main": [
+        [{"node": "Send to Slack", "type": "main", "index": 0}]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {"name": "autopilot"},
+    {"name": "release"},
+    {"name": "notifications"}
+  ]
+}


### PR DESCRIPTION
## Summary\n\nTrês integrações zero-cost (todas open-source) para expandir o Autopilot além do GitHub Actions:\n\n### LangChain — Orquestração inteligente de agentes\n- `orchestrator.py` com loop de tool-calling usando Claude via LangChain\n- 11 custom tools: read state, trigger workflows, create handoffs, backup, etc.\n- RAG memory que puxa contexto do autopilot-state branch\n- Workflow `langchain-orchestrator.yml` para rodar no GitHub Actions\n- Tasks: `analyze-ci-failure`, `smart-release`, `triage-handoff`, `health-response`\n\n### Kubernetes — Infraestrutura self-hosted\n- Namespace por workspace com resource quotas\n- Self-hosted GitHub Actions runner (substitui runners pagos)\n- 4 CronJobs: health check (4h), improvement scan (semanal), backup (diário), lock GC (15min)\n- Kustomize overlay: `kubectl apply -k integrations/kubernetes/`\n- Secrets template (nunca commita valores reais)\n\n### n8n — Automação visual + integrações externas\n- Docker Compose para self-hosted (100% gratuito)\n- 4 workflows importáveis:\n  - CI failure alert → Slack + auto-fix\n  - Release notification → Slack\n  - Health monitor → check periódico + alerta\n  - Approval gate → botões interativos no Slack\n\n## Custo\n- **LangChain**: gratuito (lib Python open-source, roda no GitHub Actions)\n- **Kubernetes**: gratuito para criar; deploy em qualquer cluster free-tier\n- **n8n**: 100% gratuito self-hosted via Docker\n\n## Arquitetura\n```\n┌─────────────────────────────────────────┐\n│                 n8n                      │\n│   (Slack, alerts, approval gates)        │\n├─────────────────────────────────────────┤\n│              LangChain                   │\n│   (intelligent agent orchestration)      │\n├──────────────┬──────────────┬───────────┤\n│   Claude     │    Codex     │  Copilot  │\n├──────────────┴──────────────┴───────────┤\n│            GitHub Actions                │\n├─────────────────────────────────────────┤\n│            Kubernetes                    │\n│   (self-hosted runners, cronjobs)        │\n└─────────────────────────────────────────┘\n```\n\n## Test plan\n- [ ] Validar YAML dos workflows (feito localmente)\n- [ ] Validar JSON dos n8n workflows (feito localmente)\n- [ ] Validar K8s manifests (feito localmente)\n- [ ] Testar LangChain orchestrator com ANTHROPIC_API_KEY\n- [ ] Testar n8n docker compose up\n- [ ] Testar kubectl apply -k integrations/kubernetes/