### PR TITLE
fix: apply all controller corrections via source-change pipeline

### DIFF
--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -20,10 +20,25 @@
       "target_path": "src/swagger/swagger.json",
       "action": "replace-file",
       "content_ref": "patches/swagger.json"
+    },
+    {
+      "target_path": "src/middleware/oas-origin-auth.ts",
+      "action": "replace-file",
+      "content_ref": "patches/oas-origin-auth.ts"
+    },
+    {
+      "target_path": "src/controllers/execute.controller.ts",
+      "action": "replace-file",
+      "content_ref": "patches/execute.controller.fixed.ts"
+    },
+    {
+      "target_path": "src/__tests__/unit/agents-execute-logs.controller.test.ts",
+      "action": "replace-file",
+      "content_ref": "patches/agents-execute-logs.controller.test.fixed.ts"
     }
   ],
-  "commit_message": "chore: bump to 3.5.4, fix swagger encoding (remove accents)",
+  "commit_message": "fix: OAS auth from env, execId in errors, fix test timers (3.5.4)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 27
+  "run": 28
 }


### PR DESCRIPTION
## Summary

- **Trigger run 27 only applied**: version bump + swagger.json
- **Missing corrections now included** (run 28):
  - `src/middleware/oas-origin-auth.ts` — Remove hardcoded auth values, read from env/K8s secrets
  - `src/controllers/execute.controller.ts` — Add `execId` to 504 timeout and 500 error responses
  - `src/__tests__/unit/agents-execute-logs.controller.test.ts` — Fix jest timer issues (remove fake timers incompatible with async polling)

## What changed

| File | Change |
|------|--------|
| `trigger/source-change.json` | Added 3 missing `replace-file` entries, bumped run to 28 |

## Test plan

- [ ] Merge triggers `apply-source-change` workflow
- [ ] Pipeline applies all 6 changes to controller repo
- [ ] CI passes on controller repo
- [ ] CAP promotion updates image tag to 3.5.4

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK