### PR TITLE
fix: use git clone for autopilot patches in multi-file workflow

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -280,9 +280,10 @@ jobs:
 
       - name: "Checkout autopilot (for patch files)"
         if: needs.setup.outputs.change_type == 'multi-file'
-        uses: actions/checkout@v4
-        with:
-          path: /tmp/autopilot
+        run: |
+          git clone --depth 1 "https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ env.AUTOPILOT_REPO }}.git" /tmp/autopilot
+          echo "Autopilot repo cloned for patch files"
+          ls /tmp/autopilot/patches/ 2>/dev/null || echo "No patches/ directory"
 
       - name: "Apply change"
         working-directory: /tmp/source

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -40,5 +40,5 @@
   "commit_message": "fix: OAS auth from env, execId in errors, fix test timers (3.5.4)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 29
+  "run": 30
 }


### PR DESCRIPTION
## Summary
- Run 29 failed at "Checkout autopilot (for patch files)" — `actions/checkout@v4` doesn't support absolute paths outside `$GITHUB_WORKSPACE`
- Replace with `git clone --depth 1` using `RELEASE_TOKEN` to `/tmp/autopilot`
- Bump trigger run to 30

## Test plan
- [ ] Workflow triggers and clones autopilot repo to /tmp/autopilot
- [ ] Patch files accessible at /tmp/autopilot/patches/
- [ ] All 6 multi-file changes applied to controller

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK