### PR TITLE
fix: skip per-file lint for multi-file, add timeout

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -368,36 +368,29 @@ jobs:
 
       - name: "Lint check (our files)"
         working-directory: /tmp/source
+        timeout-minutes: 10
         env:
           CHANGES_B64: ${{ needs.setup.outputs.changes_b64 }}
         run: |
           CHANGE="${{ needs.setup.outputs.change_type }}"
 
-          # Collect files to lint
-          LINT_FILES=()
+          # For multi-file changes, skip per-file lint — the next step
+          # "Fix pre-existing lint errors" handles full src/ lint
           if [ "$CHANGE" = "multi-file" ]; then
-            CHANGES=$(echo "$CHANGES_B64" | base64 -d)
-            for TPATH in $(echo "$CHANGES" | jq -r '.[].target_path'); do
-              EXT="${TPATH##*.}"
-              [[ "$EXT" =~ ^(js|ts|jsx|tsx)$ ]] && LINT_FILES+=("$TPATH")
-            done
-          else
-            TARGET="${{ needs.setup.outputs.target_path }}"
-            EXT="${TARGET##*.}"
-            [[ "$EXT" =~ ^(js|ts|jsx|tsx)$ ]] && LINT_FILES+=("$TARGET")
-          fi
-
-          if [ ${#LINT_FILES[@]} -eq 0 ]; then
-            echo "No JS/TS files to lint, skipping"
+            echo "Multi-file change: deferring lint to pre-existing lint fix step"
             exit 0
           fi
 
-          echo "=== Running lint on ${#LINT_FILES[@]} file(s) ==="
+          TARGET="${{ needs.setup.outputs.target_path }}"
+          EXT="${TARGET##*.}"
+          if [[ ! "$EXT" =~ ^(js|ts|jsx|tsx)$ ]]; then
+            echo "Not a JS/TS file, skipping lint"
+            exit 0
+          fi
+
+          echo "=== Running lint on $TARGET ==="
           npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts 2>/dev/null || true
-          for F in "${LINT_FILES[@]}"; do
-            echo "  Linting: $F"
-            npx eslint "$F" --fix 2>/dev/null || echo "::warning ::Lint issues on $F"
-          done
+          npx eslint "$TARGET" --fix 2>/dev/null || echo "::warning ::Lint issues on $TARGET"
 
       - name: "Fix pre-existing lint errors"
         working-directory: /tmp/source

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -40,5 +40,5 @@
   "commit_message": "fix: OAS auth from env, execId in errors, fix test timers (3.5.4)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 30
+  "run": 31
 }


### PR DESCRIPTION
## Summary
- Run 30 lint step hanging 30+ min due to `npm ci` with native deps (sqlite3, better-sqlite3)
- For `multi-file` changes, skip per-file lint — defer to existing "Fix pre-existing lint errors" step
- Add `timeout-minutes: 10` as safety net
- Bump trigger run to 31

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK