### PR TITLE
fix: cancel-in-progress to unblock stuck workflow run

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -50,7 +50,7 @@ permissions:
 
 concurrency:
   group: source-change
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -40,5 +40,5 @@
   "commit_message": "fix: OAS auth from env, execId in errors, fix test timers (3.5.4)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 31
+  "run": 32
 }


### PR DESCRIPTION
Run 30 lint step hung for 1h+. This enables `cancel-in-progress: true` so run 32 auto-cancels the stuck run. Bump trigger to 32.

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK