### PR TITLE
chore: fetch controller route files for 3.4.1 comparison

### DIFF
--- a/trigger/fetch-files.json
+++ b/trigger/fetch-files.json
@@ -1,6 +1,6 @@
 {
   "workspace_id": "ws-default",
   "component": "controller",
-  "files": "package.json,package-lock.json,src/swagger/swagger.json,src/middleware/oas-origin-auth.ts",
-  "run": 9
+  "files": "src/app.ts,src/main.ts,src/routes.ts,src/routes/index.ts,src/controllers/oas-sre-controller.controller.ts,src/controllers/agents-execute-logs.controller.ts,src/controllers/execute.controller.ts,src/controllers/agents.controller.ts,src/controllers/auth.controller.ts,src/controllers/health.controller.ts,src/middleware/jwt.ts,src/middleware/scopes.ts,src/auth/scopes.ts",
+  "run": 10
 }


### PR DESCRIPTION
Fetch controller source files to identify missing routes between 3.4.1 and 3.5.4

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK