### PR TITLE
fix: mint JWT for internal-origin agent calls (3.5.6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Visual automation and external integrations (100% self-hosted, open-source).
 ## Controller CAP (GitLab — not yet migrated to GitHub)
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.5.5`
+- **Current deployed tag**: `3.5.6`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 2,
   "contractId": "claude-session-memory",
   "description": "Memoria cumulativa de TUDO que foi feito, decidido e aprendido. Cada sessao DEVE ler isso e aplicar automaticamente. O objetivo e reduzir tempo de execucao e melhorar qualidade a cada sessao.",
-  "lastUpdated": "2026-03-24T00:15:00-03:00",
-  "lastSessionId": "session_01WNCzT7nhQbajAjtvmqDgvK_deploy355",
+  "lastUpdated": "2026-03-23T20:00:00-03:00",
+  "lastSessionId": "session_01WNCzT7nhQbajAjtvmqDgvK_fix356",
 
   "executionHistory": {
     "description": "Historico completo de tudo que foi executado. Futuras sessoes DEVEM consultar antes de repetir qualquer operacao.",
@@ -253,8 +253,8 @@
   },
 
   "versioningRules": {
-    "currentVersion": "3.5.5",
-    "previousVersion": "3.5.4",
+    "currentVersion": "3.5.6",
+    "previousVersion": "3.5.5",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versionFiles": [
       { "file": "package.json", "line": 3, "field": "version" },
@@ -293,10 +293,10 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 34,
+    "lastTriggerRun": 35,
     "lastSuccessfulRun": 34,
     "lastDeployPR": 93,
-    "pipelineStatus": "SUCCESS — run #34 completou todos os stages. Versao 3.5.5 com swagger completo (18 rotas).",
+    "pipelineStatus": "PENDING — run #35 (3.5.6) fix: mint JWT for internal-origin agent calls.",
     "multiFilePayload": {
       "change_type": "multi-file",
       "changesFormat": [
@@ -509,7 +509,9 @@
       "NAO esperar usuario aprovar — permissoes em .claude/settings.json",
       "NAO criar PR separado para memoria — incluir no mesmo PR",
       "NAO usar reset --hard sem commitar/stash antes",
-      "NAO criar branch que ja existe sem -B flag"
+      "NAO criar branch que ja existe sem -B flag",
+      "NAO perguntar ao usuario sobre codigos — baixar, analisar, corrigir e deployar AUTOMATICAMENTE",
+      "NAO pedir confirmacao para deploy — seguir fluxo completo autonomamente"
     ],
     "speedups": [
       "Deploy: TUDO em 1 commit (patches + trigger + values + CLAUDE.md)",

--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -1,0 +1,608 @@
+import type { Request, Response } from "express";
+import crypto from "node:crypto";
+import jwt from "jsonwebtoken";
+import {
+  initExecution,
+  type ExecutionSnapshot,
+  waitForFinalExecution,
+} from "./agents-execute-logs.controller";
+import type { OasOriginAuthDecision } from "../middleware/oas-origin-auth";
+import { timestampSP } from "../util/time";
+import { resolveTrustedRegisteredAgentExecuteUrlByCluster } from "../util/trusted-agent";
+import { readSyncTimeoutMs } from "../util/sync-timeout";
+
+type JsonRecord = Record<string, unknown>;
+
+type Locals = {
+  requestId?: string;
+  oasAuthDecision?: OasOriginAuthDecision;
+};
+
+type DispatchPlan = {
+  cluster: string;
+};
+
+type ResolvedDispatchPlan = DispatchPlan & {
+  agentUrl: string;
+};
+
+type ValidationResult =
+  | {
+      ok: true;
+      image: string;
+      envs: JsonRecord;
+      clustersNames: string[];
+    }
+  | {
+      ok: false;
+      errors: string[];
+    };
+
+type AgentCallResult = {
+  cluster: string;
+  status: number;
+  ok: boolean;
+};
+
+type SyncResponseContext = {
+  execId: string;
+  image: string;
+  clustersNames: string[];
+  authMode: string;
+  dispatches: AgentCallResult[];
+  snapshot: ExecutionSnapshot;
+};
+
+type AllowedImage = {
+  key: string;
+  aliases: string[];
+  functionName: string;
+};
+
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+const DEFAULT_AGENT_CALL_TIMEOUT_MS = 30_000;
+
+function asRecord(value: unknown): JsonRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as JsonRecord;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function safeLogValue(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[\r\n\t]+/g, " ")
+    .trim()
+    .slice(0, 256);
+}
+
+function readAgentCallTimeoutMs(): number {
+  const raw = Number(process.env.AGENT_CALL_TIMEOUT_MS || "");
+  if (!Number.isFinite(raw) || raw < 1) {
+    return DEFAULT_AGENT_CALL_TIMEOUT_MS;
+  }
+
+  return Math.floor(raw);
+}
+
+function parseSafeIdentifier(value: unknown): string {
+  const normalized = safeString(value);
+  if (!normalized || !SAFE_IDENTIFIER_PATTERN.test(normalized)) return "";
+  return encodeURIComponent(normalized);
+}
+
+function normalizeMode(req: Request): "sync" | "async" {
+  const raw =
+    typeof req.query.mode === "string"
+      ? req.query.mode.trim().toLowerCase()
+      : "";
+  return raw === "sync" ? "sync" : "async";
+}
+
+function normalizeImageKey(imageName: string): string {
+  const withoutDigest = imageName.split("@")[0].trim();
+  const lastPath = withoutDigest.split("/").pop() || withoutDigest;
+  const withoutTag = lastPath.split(":")[0];
+  return withoutTag.trim().toLowerCase();
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(
+    new Set(values.map((item) => item.trim()).filter(Boolean)),
+  );
+}
+
+function allowedImages(): AllowedImage[] {
+  const defaultImageKey = "psc-sre-ns-migration-preflight";
+
+  const configuredImageKey =
+    safeString(process.env.OAS_PREFLIGHT_IMAGE_KEY) || defaultImageKey;
+  const configuredImageAliases = String(
+    process.env.OAS_PREFLIGHT_IMAGE_ALIASES || "",
+  )
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  return [
+    {
+      key: normalizeImageKey(configuredImageKey),
+      aliases: uniqueStrings([configuredImageKey, ...configuredImageAliases]),
+      functionName:
+        safeString(process.env.OAS_PREFLIGHT_FUNCTION) ||
+        safeString(process.env.OAS_PREFLIGHT_FUNCTION_ORIGEM) ||
+        "sre_execute",
+    },
+  ];
+}
+
+function resolveAllowedImage(rawImageName: string): AllowedImage | null {
+  const key = normalizeImageKey(rawImageName);
+  return (
+    allowedImages().find((image) => {
+      if (image.key === key) return true;
+      return image.aliases.some((alias) => normalizeImageKey(alias) === key);
+    }) ?? null
+  );
+}
+
+function parseClustersNames(
+  value: unknown,
+  errors: string[],
+): string[] {
+  let rawValues: unknown[] = [];
+
+  if (Array.isArray(value)) {
+    rawValues = value;
+  } else {
+    const asText = safeString(value);
+    if (!asText) {
+      errors.push(
+        "Field 'CLUSTERS_NAMES' is required and must be an array of cluster names.",
+      );
+      return [];
+    }
+
+    if (asText.startsWith("[")) {
+      try {
+        const parsed = JSON.parse(asText) as unknown;
+        if (Array.isArray(parsed)) {
+          rawValues = parsed;
+        } else {
+          errors.push("Field 'CLUSTERS_NAMES' must be a JSON array.");
+          return [];
+        }
+      } catch {
+        errors.push("Field 'CLUSTERS_NAMES' must be a valid JSON array.");
+        return [];
+      }
+    } else {
+      rawValues = asText.split(",").map((item) => item.trim());
+    }
+  }
+
+  const clusters = rawValues
+    .map((item) => parseSafeIdentifier(item))
+    .filter(Boolean);
+
+  if (clusters.length < 1) {
+    errors.push(
+      "Field 'CLUSTERS_NAMES' must include at least one valid cluster name.",
+    );
+    return [];
+  }
+
+  if (clusters.length !== rawValues.length) {
+    errors.push(
+      "Field 'CLUSTERS_NAMES' contains invalid values. Allowed pattern: A-Z, a-z, 0-9, dot, underscore, hyphen.",
+    );
+    return [];
+  }
+
+  return uniqueStrings(clusters);
+}
+
+function cloneEnvs(value: unknown): JsonRecord | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  try {
+    return JSON.parse(JSON.stringify(record)) as JsonRecord;
+  } catch {
+    return null;
+  }
+}
+
+function validateSreControllerPayload(body: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  const source = asRecord(body);
+  if (!source) {
+    return { ok: false, errors: ["Request body must be a JSON object."] };
+  }
+
+  // image
+  const imageRaw = safeString(source["image"] ?? source["IMAGE"]);
+  if (!imageRaw) {
+    errors.push("Field 'image' is required.");
+    return { ok: false, errors };
+  }
+
+  const allowedImage = resolveAllowedImage(imageRaw);
+  if (!allowedImage) {
+    const allowed = allowedImages().map((img) => img.key);
+    errors.push(
+      `Image '${imageRaw}' is not allowed. Allowed images: ${allowed.join(", ")}.`,
+    );
+    return { ok: false, errors };
+  }
+
+  // envs — required object, passed as-is to the agent
+  const envsRaw =
+    source["envs"] ??
+    source["ENVS"] ??
+    source["variables"] ??
+    source["vars"];
+  const envs = cloneEnvs(envsRaw);
+  if (!envs) {
+    errors.push(
+      "Field 'envs' is required and must be a JSON object with the environment variables for the image.",
+    );
+    return { ok: false, errors };
+  }
+
+  // CLUSTERS_NAMES
+  const clustersNamesRaw =
+    source["CLUSTERS_NAMES"] ??
+    source["clusters_names"] ??
+    source["clustersNames"];
+  const clustersNames = parseClustersNames(clustersNamesRaw, errors);
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    image: imageRaw,
+    envs,
+    clustersNames,
+  };
+}
+
+function getIncomingAuthorization(req: Request): string | undefined {
+  const auth = safeString(req.headers.authorization);
+  return auth || undefined;
+}
+
+function mintInternalOriginJwt(execId: string): string | undefined {
+  const secret = safeString(process.env.JWT_SECRET);
+  if (!secret) return undefined;
+
+  const issuer =
+    safeString(process.env.JWT_ISSUER) || "psc-sre-automacao-controller";
+  const audience =
+    safeString(process.env.JWT_AUDIENCE) || "psc-sre-automacao-agent";
+  const expiresIn = safeString(process.env.JWT_EXPIRES_IN) || "5m";
+  const algorithm = (safeString(process.env.JWT_SIGN_ALG) ||
+    "HS256") as jwt.Algorithm;
+  const subject =
+    safeString(process.env.JWT_DEFAULT_SUBJECT) || "oas-internal-origin";
+  const executeScope =
+    safeString(process.env.SCOPE_EXECUTE_AUTOMATION) || "execute:automation";
+
+  const token = jwt.sign(
+    {
+      execId,
+      scopes: [executeScope],
+      origin: "internal-origin",
+    },
+    secret,
+    {
+      issuer,
+      audience,
+      subject,
+      expiresIn,
+      algorithm,
+    },
+  );
+
+  return `Bearer ${token}`;
+}
+
+function getAgentAuthorization(
+  req: Request,
+  res: Response,
+  execId: string,
+): string | undefined {
+  const incoming = getIncomingAuthorization(req);
+  if (incoming) return incoming;
+
+  const authDecision = readAuthDecision(res);
+  if (authDecision?.trustedInternalOrigin) {
+    const minted = mintInternalOriginJwt(execId);
+    if (minted) {
+      console.info(
+        "[oas-sre-controller] minted JWT for internal-origin request execId=%s",
+        safeLogValue(execId),
+      );
+      return minted;
+    }
+  }
+
+  const fromEnv = safeString(process.env.AGENT_EXECUTE_AUTHORIZATION);
+  return fromEnv || undefined;
+}
+
+async function callAgent(
+  url: string,
+  headers: Record<string, string>,
+  payload: unknown,
+): Promise<{ status: number; ok: boolean }> {
+  const timeoutMs = readAgentCallTimeoutMs();
+  const abort = new AbortController();
+  const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: abort.signal,
+    });
+
+    return {
+      status: resp.status,
+      ok: resp.ok,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function readAuthDecision(res: Response): OasOriginAuthDecision | undefined {
+  const locals = res.locals as Locals;
+  return locals.oasAuthDecision;
+}
+
+function summarizeDispatches(dispatches: AgentCallResult[]) {
+  return dispatches.map((item) => ({
+    cluster: item.cluster,
+    agentStatus: item.status,
+  }));
+}
+
+function buildSyncResponsePayload(context: SyncResponseContext) {
+  return {
+    mode: "sync" as const,
+    execId: context.execId,
+    image: context.image,
+    clustersNames: context.clustersNames,
+    authMode: context.authMode,
+    dispatches: summarizeDispatches(context.dispatches),
+    statusEndpoint: `/agent/execute?uuid=${encodeURIComponent(context.execId)}`,
+    status: context.snapshot.status,
+    statusLabel: context.snapshot.statusLabel,
+    finished: context.snapshot.finished,
+    lastUpdate: context.snapshot.lastUpdate,
+    count: context.snapshot.count,
+    entries: context.snapshot.entries,
+  };
+}
+
+export async function postOasSreController(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const mode = normalizeMode(req);
+  const validation = validateSreControllerPayload(req.body);
+
+  if (!validation.ok) {
+    res.status(400).json({
+      ok: false,
+      error: "Invalid payload for /oas/sre-controller",
+      details: validation.errors,
+    });
+    return;
+  }
+
+  const execId = crypto.randomUUID();
+  initExecution(execId);
+
+  const requestId = safeString(req.header("x-request-id")) || execId;
+  const authDecision = readAuthDecision(res);
+  const outboundAuthorization = getAgentAuthorization(req, res, execId);
+
+  console.info(
+    "[oas-sre-controller] start execId=%s image=%s clusters=%d authMode=%s",
+    safeLogValue(execId),
+    safeLogValue(validation.image),
+    validation.clustersNames.length,
+    safeLogValue(authDecision?.mode || "jwt"),
+  );
+
+  let dispatches: AgentCallResult[] = [];
+
+  try {
+    const resolvedPlans: Array<ResolvedDispatchPlan | null> =
+      validation.clustersNames.map((cluster) => {
+        const agentUrl =
+          resolveTrustedRegisteredAgentExecuteUrlByCluster(cluster);
+        return agentUrl ? { cluster, agentUrl } : null;
+      });
+
+    const missingTargets = validation.clustersNames.filter(
+      (_, i) => resolvedPlans[i] === null,
+    );
+
+    if (missingTargets.length > 0) {
+      res.status(404).json({
+        ok: false,
+        error: "Agent not registered for one or more cluster targets",
+        missingTargets,
+      });
+      return;
+    }
+
+    const plans = resolvedPlans.filter(
+      (p): p is ResolvedDispatchPlan => p !== null,
+    );
+
+    dispatches = await Promise.all(
+      plans.map(async (plan) => {
+        const headers: Record<string, string> = {
+          "content-type": "application/json",
+          "x-request-id": requestId,
+          "x-exec-id": execId,
+        };
+
+        if (outboundAuthorization) {
+          headers.authorization = outboundAuthorization;
+        }
+
+        const forwardBody = {
+          execId,
+          cluster: plan.cluster,
+          image: validation.image,
+          envs: validation.envs,
+        };
+
+        console.info(
+          "[oas-sre-controller] dispatch execId=%s cluster=%s url=%s",
+          safeLogValue(execId),
+          safeLogValue(plan.cluster),
+          safeLogValue(plan.agentUrl),
+        );
+
+        const agentResponse = await callAgent(
+          plan.agentUrl,
+          headers,
+          forwardBody,
+        );
+        return {
+          ...agentResponse,
+          cluster: plan.cluster,
+        };
+      }),
+    );
+
+    const failedDispatch = dispatches.find((dispatch) => !dispatch.ok);
+    if (failedDispatch) {
+      console.error(
+        "[oas-sre-controller] agent-error execId=%s cluster=%s status=%d",
+        safeLogValue(execId),
+        safeLogValue(failedDispatch.cluster),
+        failedDispatch.status,
+      );
+
+      res.status(502).json({
+        ok: false,
+        error: "Failed to call Agent",
+        execId,
+        cluster: failedDispatch.cluster,
+        agentStatus: failedDispatch.status,
+        dispatches: dispatches.map((item) => ({
+          cluster: item.cluster,
+          agentStatus: item.status,
+        })),
+      });
+      return;
+    }
+
+    console.info(
+      "[oas-sre-controller] accepted execId=%s clusters=%d",
+      safeLogValue(execId),
+      dispatches.length,
+    );
+
+    if (mode === "sync") {
+      const timeoutMs = readSyncTimeoutMs(process.env);
+      const { timedOut, snapshot } = await waitForFinalExecution(
+        execId,
+        timeoutMs,
+      );
+      const syncPayload = buildSyncResponsePayload({
+        execId,
+        image: validation.image,
+        clustersNames: validation.clustersNames,
+        authMode: authDecision?.mode || "jwt",
+        dispatches,
+        snapshot,
+      });
+
+      if (timedOut) {
+        res.status(504).json({
+          ok: false,
+          error: "TIMEOUT",
+          message:
+            "Timed out while waiting for execution to reach a final state (DONE or ERROR).",
+          timeoutMs,
+          ...syncPayload,
+        });
+        return;
+      }
+
+      if (snapshot.status === "ERROR") {
+        res.status(502).json({
+          ok: false,
+          error: "EXECUTION_ERROR",
+          message:
+            "Execution finished with ERROR status reported by the Agent callback.",
+          ...syncPayload,
+        });
+        return;
+      }
+
+      res.status(200).json({
+        ok: true,
+        ...syncPayload,
+      });
+      return;
+    }
+
+    res.status(202).json({
+      ok: true,
+      mode: "async",
+      execId,
+      status: "RUNNING",
+      startedAt: timestampSP(),
+      image: validation.image,
+      clustersNames: validation.clustersNames,
+      authMode: authDecision?.mode || "jwt",
+      dispatches: summarizeDispatches(dispatches),
+      statusEndpoint: `/agent/execute?uuid=${encodeURIComponent(execId)}`,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    const isAbort = error instanceof Error && error.name === "AbortError";
+
+    if (isAbort) {
+      const timeoutMs = readAgentCallTimeoutMs();
+      console.error(
+        "[oas-sre-controller] timeout execId=%s timeoutMs=%d",
+        safeLogValue(execId),
+        timeoutMs,
+      );
+
+      res.status(504).json({
+        ok: false,
+        error: "Timed out while waiting for Agent response",
+        detail: `No response from Agent after ${timeoutMs}ms`,
+        execId,
+        dispatches: summarizeDispatches(dispatches),
+      });
+      return;
+    }
+
+    console.error(
+      "[oas-sre-controller] exception execId=%s detail=%s",
+      safeLogValue(execId),
+      safeLogValue(msg),
+    );
+
+    res.status(500).json({
+      ok: false,
+      error: "Internal error while dispatching OAS automation",
+      detail: msg,
+      execId,
+      dispatches,
+    });
+  }
+}

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -114,7 +114,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.5
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.6
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -2,28 +2,28 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "changes": [
     {
       "target_path": "package.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.4\"",
-      "replace": "\"version\": \"3.5.5\""
+      "search": "\"version\": \"3.5.5\"",
+      "replace": "\"version\": \"3.5.6\""
     },
     {
       "target_path": "package-lock.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.4\"",
-      "replace": "\"version\": \"3.5.5\""
+      "search": "\"version\": \"3.5.5\"",
+      "replace": "\"version\": \"3.5.6\""
     },
     {
-      "target_path": "src/swagger/swagger.json",
+      "target_path": "src/controllers/oas-sre-controller.controller.ts",
       "action": "replace-file",
-      "content_ref": "patches/swagger.json"
+      "content_ref": "patches/oas-sre-controller.controller.ts"
     }
   ],
-  "commit_message": "feat: complete swagger with all 18 routes, version bump 3.5.5",
+  "commit_message": "fix: mint JWT for internal-origin requests to agent, version bump 3.5.6",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 34
+  "run": 35
 }


### PR DESCRIPTION
## Summary\n\n- **Fix**: When requests arrive via internal-origin auth (K8s `x-techbb-*` headers), the controller now generates a JWT using `JWT_SECRET` to authenticate with the agent\n- **Root cause**: `getAgentAuthorization()` returned `undefined` for internal-origin requests because there was no `Authorization` header to forward and `AGENT_EXECUTE_AUTHORIZATION` env var was not configured\n- **Result**: Agent returned 401 \"Missing Bearer token\" for all internal-origin calls from playbooks (e.g. `sgh-oaas-playbook-jobs`)\n\n## Changes\n\n- `patches/oas-sre-controller.controller.ts`: Added `mintInternalOriginJwt()` function + modified `getAgentAuthorization()` to use it when `trustedInternalOrigin === true`\n- Version bump 3.5.5 → 3.5.6\n- Trigger run 35\n\n## Test plan\n\n- [ ] Workflow apply-source-change run #35 completes successfully\n- [ ] Test from Insomnia with `x-techbb-*` headers — should no longer return 401 from agent\n- [ ] Test with Bearer token — should continue working as before\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK