### PR TITLE
fix: mint JWT with correct scope claim (3.5.6 run 36)

### DIFF
--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -293,10 +293,10 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 35,
+    "lastTriggerRun": 36,
     "lastSuccessfulRun": 34,
     "lastDeployPR": 93,
-    "pipelineStatus": "PENDING — run #35 (3.5.6) fix: mint JWT for internal-origin agent calls.",
+    "pipelineStatus": "PENDING — run #36 (3.5.6) fix: mint JWT for internal-origin agent calls. Run #35 falhou no CI Gate.",
     "multiFilePayload": {
       "change_type": "multi-file",
       "changesFormat": [

--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -292,7 +292,7 @@ function mintInternalOriginJwt(execId: string): string | undefined {
   const token = jwt.sign(
     {
       execId,
-      scopes: [executeScope],
+      scope: [executeScope],
       origin: "internal-origin",
     },
     secret,

--- a/patches/swagger.json
+++ b/patches/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PSC SRE Automacao Controller",
     "description": "API do Controller de automacao SRE. Orquestra a execucao de automacoes nos Agents distribuidos por cluster, gerencia logs de execucao, autenticacao JWT e integracao com o OAS (Orquestrador de Automacao de Servicos).",
-    "version": "3.5.5",
+    "version": "3.5.6",
     "contact": {
       "name": "PSC SRE Automacao"
     }

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -20,10 +20,15 @@
       "target_path": "src/controllers/oas-sre-controller.controller.ts",
       "action": "replace-file",
       "content_ref": "patches/oas-sre-controller.controller.ts"
+    },
+    {
+      "target_path": "src/swagger/swagger.json",
+      "action": "replace-file",
+      "content_ref": "patches/swagger.json"
     }
   ],
   "commit_message": "fix: mint JWT for internal-origin requests to agent, version bump 3.5.6",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 35
+  "run": 36
 }


### PR DESCRIPTION
## Summary\n\n- **Fix run #35 failure**: Changed JWT scope claim from `scopes` (plural) to `scope` (singular) to match agent's `requireScopes` middleware\n- Swagger version bump to 3.5.6\n- Run 36 trigger\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK