### PR TITLE
chore: diagnose corporate CI failure for controller 3.5.6

### DIFF
--- a/trigger/ci-diagnose.json
+++ b/trigger/ci-diagnose.json
@@ -1,7 +1,7 @@
 {
   "workspace_id": "ws-default",
   "component": "controller",
-  "commit_sha": "c7520a439604bff59dab1d76f475b14bb6bac917",
-  "note": "Diagnose after lint fix - check if tests run now",
-  "run": 10
+  "commit_sha": "",
+  "note": "Diagnose corporate CI failure after deploy 3.5.6 (run 36)",
+  "run": 11
 }


### PR DESCRIPTION
Trigger ci-diagnose workflow to fetch error logs from corporate CI\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK