### PR TITLE
feat: multi-company workspace model (CIT + Getronics)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,27 +75,50 @@ Visual automation and external integrations (100% self-hosted, open-source).
 - `workflows/approval-gate.json` — Interactive Slack approval for releases
 - `README.md` — Integration guide
 
-## Context Separation (CRITICAL — Two Completely Different Environments)
+## Context Separation (CRITICAL — Multi-Company Isolation)
 
-There are **TWO separate contexts** that must NEVER be mixed:
+This control plane manages **multiple companies** from a single point. Each company is a **completely isolated context**.
 
-| | **Autopilot (Projeto Pessoal)** | **Corporativo (Empresa)** |
+### Company Contexts
+
+| | **Getronics** (ws-default) | **CIT** (ws-cit) |
 |---|---|---|
-| **Repo** | `lucassfreiree/autopilot` | `bbvinet/psc-sre-automacao-controller` (ou agent) |
-| **Commits** | PRs do Claude (branch `claude/*` → PR → squash merge) | Commits do `github-actions` bot via `BBVINET_TOKEN` |
-| **CI** | GitHub Actions do autopilot | Esteira de Build NPM (runner corporativo) |
-| **Monitoramento** | API `/actions/workflows/.../runs` | `ci-diagnose.yml` → `ci-logs-controller-*.txt` no autopilot-state |
-| **Sucesso** | Workflow apply-source-change completa 7 stages | Imagem Docker publicada no registry |
+| **Workspace** | `ws-default` | `ws-cit` |
+| **Machine** | Getronics workstation | CIT workstation |
+| **Stack** | Node/TypeScript (NestJS, Jest) | DevOps (K8s, Docker, Terraform, IaC, CI/CD) |
+| **Repos** | `bbvinet/psc-sre-automacao-*` | To be configured |
+| **Token** | `BBVINET_TOKEN` | `CIT_TOKEN` (when available) |
+| **Data Classification** | Confidential | Internal |
+
+### Autopilot vs Corporate Context (per company)
+
+| | **Autopilot (Control Plane)** | **Corporate (per workspace)** |
+|---|---|---|
+| **Repo** | `lucassfreiree/autopilot` | Configured in workspace.json `repos[]` |
+| **Commits** | PRs do Claude (`claude/*` → PR → squash merge) | Commits via workspace token |
+| **CI** | GitHub Actions do autopilot | CI pipeline da empresa (configurado por workspace) |
 | **SHAs** | SHA do merge no autopilot | SHA do commit no repo corporativo (DIFERENTE!) |
 
-### Separation Rules
-1. **NUNCA** misturar commits do autopilot com commits do corporativo
-2. **Monitorar SEPARADAMENTE**: workflow do autopilot vs esteira corporativa
-3. Quando usuario diz "esteira quebrou" → refere-se à **esteira CORPORATIVA**, não ao workflow do autopilot
-4. **Sucesso do apply-source-change NÃO garante sucesso da Esteira de Build NPM**
-5. CI Gate pode passar com "pre-existing detection" mesmo quando esteira falha
-6. Para diagnosticar esteira corporativa: `ci-diagnose.yml` → ler `ci-logs-controller-*.txt` (NÃO `ci-diagnosis-controller.json` que roda local sem npm install)
-7. Os dois SHAs são DIFERENTES e não devem ser confundidos
+### Isolation Rules
+1. **NUNCA** misturar dados, commits, credenciais ou estado entre empresas
+2. **Cada workspace** usa exclusivamente seu proprio token (secret name em `credentials.tokenSecretName`)
+3. **Monitorar SEPARADAMENTE**: workflow do autopilot vs CI de cada empresa
+4. Quando usuario menciona CI/esteira → identificar QUAL empresa antes de agir
+5. **Sucesso do apply-source-change NAO garante sucesso do CI corporativo** (vale para todas as empresas)
+6. **Contexto ativo** deve ser identificado ANTES de qualquer operacao
+7. **Em caso de duvida, o padrao e isolamento** — nunca assumir que contextos podem ser compartilhados
+8. Os SHAs sao DIFERENTES entre autopilot e cada repo corporativo
+
+### Getronics-Specific Rules
+1. Esteira de Build NPM (runner corporativo) — monitorar via `ci-diagnose.yml`
+2. Logs reais: `ci-logs-controller-*.txt` no autopilot-state (NAO `ci-diagnosis-controller.json`)
+3. CI Gate pode passar com "pre-existing detection" mesmo quando esteira falha
+4. Controller CAP no GitLab — auto-promote NAO funciona ate migracao
+
+### CIT-Specific Rules
+1. Stack DevOps — foco em infraestrutura, automacao, containers, IaC
+2. Repos e pipelines serao configurados conforme demanda
+3. Operacoes iniciais nao requerem deploy pipeline — foco em organizacao e tooling
 
 ## Rules
 1. Never store corporate code, secrets, or internal URLs in this repo
@@ -121,10 +144,11 @@ There are **TWO separate contexts** that must NEVER be mixed:
 ## Workspaces
 
 ### Active Workspaces
-| Workspace ID | Status | Description |
-|-------------|--------|-------------|
-| `ws-default` | Active | Primary workspace (bbvinet corporate repos) |
-| `ws-corp-1` | Empty/Template | Reserved for additional corporate workspace |
+| Workspace ID | Company | Status | Stack | Description |
+|-------------|---------|--------|-------|-------------|
+| `ws-default` | Getronics | Active | Node/TypeScript | Primary workspace (bbvinet corporate repos) |
+| `ws-cit` | CIT | Active | DevOps | DevOps workspace (K8s, Docker, Terraform, CI/CD) |
+| `ws-corp-1` | — | Empty/Template | — | Reserved for additional corporate workspace |
 
 ### State Location
 ```
@@ -398,11 +422,12 @@ Every new Claude Code session MUST:
 | `workflow_dispatch` or push to `main` (self-path) | `BBVINET_TOKEN` | `bbvinet/psc-sre-automacao-agent`, `bbvinet/psc-sre-automacao-controller`, `bbvinet/psc_releases_cap_sre-aut-agent` |
 
 ### Repository Secrets Available
-| Secret | Purpose |
-|--------|---------|
-| `BBVINET_TOKEN` | PAT with access to corporate repos (bbvinet org) |
-| `RELEASE_TOKEN` | Token for release operations |
-| `OPENAI_API_KEY` | OpenAI API key for LangChain orchestrator |
+| Secret | Company | Purpose |
+|--------|---------|---------|
+| `BBVINET_TOKEN` | Getronics | PAT with access to corporate repos (bbvinet org) |
+| `RELEASE_TOKEN` | Shared | Token for release operations and autopilot checkout |
+| `OPENAI_API_KEY` | Shared | OpenAI API key for LangChain orchestrator |
+| `CIT_TOKEN` | CIT | PAT for CIT corporate repos (to be configured) |
 
 ### Auto-Mapping for Future Sessions (MANDATORY — No user intervention required)
 Claude Code MUST automatically and proactively keep this file (CLAUDE.md) up to date. This is NOT optional and does NOT require the user to ask.

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -2,44 +2,131 @@
   "schemaVersion": 2,
   "contractId": "claude-session-memory",
   "description": "Memoria cumulativa de TUDO que foi feito, decidido e aprendido. Cada sessao DEVE ler isso e aplicar automaticamente. O objetivo e reduzir tempo de execucao e melhorar qualidade a cada sessao.",
-  "lastUpdated": "2026-03-23T23:55:00-03:00",
-  "lastSessionId": "session_01WNCzT7nhQbajAjtvmqDgvK_eslint_fix",
+  "lastUpdated": "2026-03-24T12:00:00-03:00",
+  "lastSessionId": "session_setup_cit_multicompany",
+
+  "multiCompanyModel": {
+    "description": "Control plane centralizado gerenciando multiplas empresas. Cada empresa e um contexto COMPLETAMENTE ISOLADO.",
+    "companies": {
+      "getronics": {
+        "workspaceId": "ws-default",
+        "machine": "getronics-workstation",
+        "stack": "Node/TypeScript (NestJS, Jest, ESLint)",
+        "tokenSecret": "BBVINET_TOKEN",
+        "repos": ["bbvinet/psc-sre-automacao-controller", "bbvinet/psc-sre-automacao-agent", "bbvinet/psc_releases_cap_sre-aut-agent"],
+        "status": "active",
+        "lastDeploy": "3.5.6 (run #38)",
+        "notes": "Pipeline completo e funcional. Controller no GitLab (sem auto-promote). Esteira de Build NPM."
+      },
+      "cit": {
+        "workspaceId": "ws-cit",
+        "machine": "cit-workstation",
+        "stack": "DevOps (K8s, Docker, Terraform, Ansible, Helm, ArgoCD, CI/CD)",
+        "tokenSecret": "CIT_TOKEN",
+        "repos": [],
+        "status": "setup",
+        "lastDeploy": null,
+        "notes": "Nova empresa. Stack DevOps. Repos e pipelines a serem configurados conforme demanda."
+      }
+    },
+    "goldenRules": [
+      "NUNCA misturar dados, credenciais, commits ou estado entre empresas",
+      "Identificar contexto ativo ANTES de qualquer operacao",
+      "Cada empresa usa exclusivamente seu proprio token",
+      "Em caso de duvida, o padrao e isolamento",
+      "Monitorar CI de cada empresa SEPARADAMENTE",
+      "Workspace config e a fonte de verdade para cada empresa"
+    ]
+  },
 
   "contextSeparation": {
-    "description": "REGRA CRITICA: Existem DOIS contextos COMPLETAMENTE SEPARADOS. NUNCA misturar commits, monitoramento, ou status entre eles.",
+    "description": "REGRA CRITICA: Contexto do autopilot (control plane) e separado do contexto corporativo de CADA empresa. NUNCA misturar.",
     "autopilot": {
       "repo": "lucassfreiree/autopilot",
-      "what": "Projeto pessoal do usuario. Onde ficam patches, triggers, workflows, docs, memoria.",
+      "what": "Projeto pessoal do usuario. Control plane centralizado para todas as empresas.",
       "commits": "PRs que o Claude faz (branch claude/* → PR → squash merge em main)",
       "ci": "GitHub Actions do autopilot (apply-source-change.yml, ci-diagnose.yml, etc.)",
       "monitoring": "https://api.github.com/repos/lucassfreiree/autopilot/actions/workflows/...",
       "successCriteria": "Workflow apply-source-change completar todos os stages (Setup → Audit)",
-      "note": "Sucesso do workflow autopilot NAO significa sucesso do deploy corporativo!"
+      "note": "Sucesso do workflow autopilot NAO significa sucesso do deploy corporativo de NENHUMA empresa!"
     },
-    "corporate": {
+    "getronics": {
       "repo": "bbvinet/psc-sre-automacao-controller (ou agent)",
-      "what": "Repo da EMPRESA. Codigo de producao real. Push feito pelo workflow apply-source-change.",
-      "commits": "Commits feitos pelo github-actions bot via BBVINET_TOKEN — NAO confundir com commits do autopilot",
-      "ci": "Esteira de Build NPM — runner corporativo (NÃO é GitHub Actions do autopilot)",
-      "monitoring": "ci-diagnose.yml busca logs → salva em autopilot-state (ci-logs-controller-*.txt, ci-diagnosis-controller.json)",
-      "successCriteria": "Imagem Docker publicada no registry corporativo (docker.binarios.intranet.bb.com.br)",
-      "note": "CI Gate no autopilot verifica a esteira corporativa via API, mas a esteira pode continuar falhando apos CI Gate passar (smart pre-existing detection)"
+      "what": "Repo da GETRONICS. Codigo de producao real. Push feito pelo workflow apply-source-change.",
+      "commits": "Commits feitos pelo github-actions bot via BBVINET_TOKEN",
+      "ci": "Esteira de Build NPM — runner corporativo",
+      "monitoring": "ci-diagnose.yml busca logs → salva em autopilot-state (ci-logs-controller-*.txt)",
+      "successCriteria": "Imagem Docker publicada no registry corporativo",
+      "note": "CI Gate no autopilot verifica a esteira corporativa via API, mas a esteira pode continuar falhando apos CI Gate passar"
+    },
+    "cit": {
+      "workspace": "ws-cit",
+      "what": "Contexto DevOps da CIT. Repos e pipelines serao configurados conforme demanda.",
+      "stack": "DevOps — K8s, Docker, Terraform, Ansible, Helm, ArgoCD, monitoring",
+      "status": "setup — aguardando repos e credenciais",
+      "note": "Isolamento total do contexto Getronics. Nenhum dado ou operacao compartilhada."
     },
     "goldenRules": [
-      "NUNCA misturar commits do autopilot com commits do corporativo",
-      "Monitorar SEPARADAMENTE: 1) workflow do autopilot, 2) esteira corporativa",
-      "Quando usuario diz 'esteira quebrou' → refere-se a esteira CORPORATIVA (Esteira de Build NPM), NAO ao workflow do autopilot",
-      "Sucesso do apply-source-change (autopilot) NAO garante sucesso da Esteira de Build NPM (corporativo)",
-      "CI Gate pode passar com pre-existing detection mesmo quando esteira corporativa falha",
-      "Para diagnosticar esteira corporativa: usar ci-diagnose workflow → ler ci-logs-controller-*.txt no autopilot-state",
-      "Logs reais da esteira corporativa estao nos arquivos ci-logs-controller-*.txt — NAO no ci-diagnosis-controller.json (que roda tsc/jest local sem npm install)",
-      "Os dois SHAs sao DIFERENTES: SHA do PR mergeado no autopilot vs SHA do commit pushado no repo corporativo"
+      "NUNCA misturar dados entre Getronics e CIT",
+      "Identificar QUAL empresa antes de qualquer acao",
+      "Monitorar SEPARADAMENTE: autopilot vs CI de cada empresa",
+      "Sucesso do apply-source-change NAO garanta sucesso do CI corporativo (vale para todas as empresas)",
+      "Cada empresa tem seu proprio token, repos, pipeline e estado",
+      "Os SHAs sao DIFERENTES entre autopilot e cada repo corporativo"
     ]
   },
 
   "executionHistory": {
     "description": "Historico completo de tudo que foi executado. Futuras sessoes DEVEM consultar antes de repetir qualquer operacao.",
     "sessions": [
+      {
+        "id": "session_setup_cit_multicompany",
+        "date": "2026-03-24",
+        "summary": "Setup multi-company model: CIT workspace (DevOps) + Getronics isolation + workspace schema v3",
+        "stepsExecuted": [
+          {
+            "step": 1,
+            "action": "Evoluiu workspace schema para v3 com suporte multi-empresa",
+            "how": "Adicionou campos company (id, name, machine, dataClassification), stack (primary, tools, platforms), credentials (tokenSecretName), repos[] (array generico), allowedAgents",
+            "filesChanged": ["schemas/workspace.schema.json"],
+            "lesson": "Schema antigo (v2) mantido como campos legacy (controller, agent) para backward compatibility com ws-default. Novos workspaces usam repos[]."
+          },
+          {
+            "step": 2,
+            "action": "Criou workspace ws-cit para CIT (DevOps)",
+            "how": "state/workspaces/ws-cit/workspace.json com company.id=cit, stack DevOps, CIT_TOKEN",
+            "filesCreated": ["state/workspaces/ws-cit/workspace.json"],
+            "lesson": "Workspace CIT começa sem repos — serão adicionados conforme demanda."
+          },
+          {
+            "step": 3,
+            "action": "Atualizou ws-default com metadados Getronics",
+            "how": "Adicionou company (id=getronics), stack, credentials ao workspace.json existente. Schema v2→v3",
+            "filesChanged": ["state/workspaces/ws-default/workspace.json"],
+            "lesson": "Campos legacy (controller, agent) mantidos intactos. Workflows existentes nao precisam de alteracao."
+          },
+          {
+            "step": 4,
+            "action": "Atualizou CLAUDE.md com modelo multi-empresa",
+            "how": "Reescreveu Context Separation para multi-company. Adicionou CIT na tabela de workspaces. Adicionou CIT_TOKEN na tabela de secrets.",
+            "filesChanged": ["CLAUDE.md"]
+          },
+          {
+            "step": 5,
+            "action": "Atualizou session memory com multiCompanyModel",
+            "how": "Adicionou bloco multiCompanyModel com companies (getronics + cit), goldenRules. Expandiu contextSeparation para incluir CIT.",
+            "filesChanged": ["contracts/claude-session-memory.json"],
+            "lesson": "Memoria agora rastreia estado de cada empresa separadamente."
+          }
+        ],
+        "mistakesMade": [],
+        "keyDecisions": [
+          "Nenhum workflow alterado — esteira Getronics permanece intacta",
+          "Schema v3 backward-compatible: campos legacy mantidos",
+          "CIT começa em modo setup — repos adicionados sob demanda",
+          "Isolamento por design: cada empresa com token, workspace e estado proprios"
+        ]
+      },
       {
         "id": "session_01WNCzT7nhQbajAjtvmqDgvK",
         "date": "2026-03-23",

--- a/schemas/workspace.schema.json
+++ b/schemas/workspace.schema.json
@@ -5,13 +5,72 @@
   "type": "object",
   "required": ["schemaVersion", "workspaceId", "createdAt"],
   "properties": {
-    "schemaVersion": { "const": 2 },
+    "schemaVersion": { "const": 3 },
     "workspaceId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$" },
     "displayName": { "type": "string", "maxLength": 100 },
     "createdAt": { "type": "string", "format": "date-time" },
     "updatedAt": { "type": "string", "format": "date-time" },
+    "company": {
+      "type": "object",
+      "description": "Company context isolation — each workspace belongs to exactly one company",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9-]+$", "description": "Unique company identifier (lowercase, no spaces)" },
+        "name": { "type": "string", "description": "Company display name" },
+        "machine": { "type": "string", "description": "Machine/environment identifier where this context operates" },
+        "dataClassification": { "type": "string", "enum": ["public", "internal", "confidential", "restricted"], "default": "internal" }
+      }
+    },
+    "stack": {
+      "type": "object",
+      "description": "Technology stack for this workspace context",
+      "properties": {
+        "primary": { "type": "string", "description": "Primary technology (e.g., node, python, devops, java)" },
+        "tools": { "type": "array", "items": { "type": "string" }, "description": "Key tools and platforms" },
+        "platforms": { "type": "array", "items": { "type": "string" }, "description": "Infrastructure platforms (e.g., kubernetes, aws, azure)" }
+      }
+    },
+    "credentials": {
+      "type": "object",
+      "description": "Credential references (secret names, never actual values)",
+      "properties": {
+        "tokenSecretName": { "type": "string", "description": "GitHub secret name for repo access token" },
+        "additionalSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "purpose": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "repos": {
+      "type": "array",
+      "description": "All repositories managed in this workspace",
+      "items": {
+        "type": "object",
+        "required": ["id", "sourceRepo"],
+        "properties": {
+          "id": { "type": "string", "description": "Logical component name (e.g., controller, agent, infra)" },
+          "sourceRepo": { "type": "string", "description": "org/repo format" },
+          "platform": { "type": "string", "enum": ["github", "gitlab", "bitbucket", "azure-devops"], "default": "github" },
+          "deployRepo": { "type": "string" },
+          "deployBranch": { "type": "string", "default": "main" },
+          "deployValuesPath": { "type": "string" },
+          "ciWorkflowName": { "type": "string" },
+          "imagePattern": { "type": "string" },
+          "capRepo": { "type": "string" },
+          "capBranch": { "type": "string" },
+          "capValuesPath": { "type": "string" }
+        }
+      }
+    },
     "controller": {
       "type": "object",
+      "description": "Legacy: controller config (kept for backward compatibility with ws-default)",
       "properties": {
         "sourceRepo": { "type": "string" },
         "deployRepo": { "type": "string" },
@@ -23,6 +82,7 @@
     },
     "agent": {
       "type": "object",
+      "description": "Legacy: agent config (kept for backward compatibility with ws-default)",
       "properties": {
         "sourceRepo": { "type": "string" },
         "deployRepo": { "type": "string" },
@@ -38,10 +98,11 @@
     "settings": {
       "type": "object",
       "properties": {
-        "promotionTarget": { "type": "string", "enum": ["deploy", "cap", "both"], "default": "both" },
+        "promotionTarget": { "type": "string", "enum": ["deploy", "cap", "both", "none"], "default": "both" },
         "autoRelease": { "type": "boolean", "default": true },
         "lockTimeoutMinutes": { "type": "integer", "default": 30 },
-        "healthCheckEnabled": { "type": "boolean", "default": true }
+        "healthCheckEnabled": { "type": "boolean", "default": true },
+        "allowedAgents": { "type": "array", "items": { "type": "string" }, "description": "Agents permitted to operate on this workspace" }
       }
     }
   }

--- a/state/workspaces/ws-cit/workspace.json
+++ b/state/workspaces/ws-cit/workspace.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 3,
+  "workspaceId": "ws-cit",
+  "displayName": "CIT Workspace",
+  "createdAt": "2026-03-24T12:00:00Z",
+  "updatedAt": "2026-03-24T12:00:00Z",
+  "company": {
+    "id": "cit",
+    "name": "CIT",
+    "machine": "cit-workstation",
+    "dataClassification": "internal"
+  },
+  "stack": {
+    "primary": "devops",
+    "tools": [
+      "docker",
+      "kubernetes",
+      "terraform",
+      "ansible",
+      "helm",
+      "argocd",
+      "prometheus",
+      "grafana",
+      "jenkins",
+      "gitlab-ci",
+      "github-actions",
+      "bash",
+      "python"
+    ],
+    "platforms": [
+      "kubernetes",
+      "docker",
+      "linux"
+    ]
+  },
+  "credentials": {
+    "tokenSecretName": "CIT_TOKEN",
+    "additionalSecrets": []
+  },
+  "repos": [],
+  "settings": {
+    "promotionTarget": "none",
+    "autoRelease": false,
+    "lockTimeoutMinutes": 30,
+    "healthCheckEnabled": true,
+    "allowedAgents": ["claude-code"]
+  }
+}

--- a/state/workspaces/ws-default/workspace.json
+++ b/state/workspaces/ws-default/workspace.json
@@ -1,9 +1,26 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "workspaceId": "ws-default",
-  "displayName": "Default Workspace",
+  "displayName": "Getronics Workspace",
   "createdAt": "2026-03-21T21:41:00Z",
-  "updatedAt": "2026-03-21T22:00:00Z",
+  "updatedAt": "2026-03-24T12:00:00Z",
+  "company": {
+    "id": "getronics",
+    "name": "Getronics",
+    "machine": "getronics-workstation",
+    "dataClassification": "confidential"
+  },
+  "stack": {
+    "primary": "node",
+    "tools": ["typescript", "nestjs", "jest", "eslint", "docker", "kubernetes"],
+    "platforms": ["openshift", "kubernetes"]
+  },
+  "credentials": {
+    "tokenSecretName": "BBVINET_TOKEN",
+    "additionalSecrets": [
+      { "name": "RELEASE_TOKEN", "purpose": "Release operations and autopilot checkout" }
+    ]
+  },
   "controller": {
     "sourceRepo": "bbvinet/psc-sre-automacao-controller",
     "deployRepo": "",


### PR DESCRIPTION
## Summary
- Workspace schema v3: adds company metadata, stack definition, credentials reference, generic repos[], allowedAgents
- New workspace `ws-cit` for CIT (DevOps stack: K8s, Docker, Terraform, Ansible, Helm, ArgoCD, CI/CD)
- Updated `ws-default` with Getronics company metadata (backward-compatible, legacy fields untouched)
- CLAUDE.md: multi-company context separation docs, CIT in workspaces table, CIT_TOKEN in secrets table
- Session memory: multiCompanyModel with per-company tracking and isolation rules

## What does NOT change
- Zero workflow modifications — existing Getronics pipeline (apply-source-change, CI gate, etc.) untouched
- Legacy controller/agent fields in ws-default preserved for backward compatibility
- All trigger files, patches, references unchanged

## Test plan
- [ ] Verify ws-default workspace.json still valid (schema v3 backward-compatible)
- [ ] Verify ws-cit workspace.json created correctly
- [ ] Confirm no workflow files were modified

https://claude.ai/code/session_01WKXBAACShRzwVQmFrBd3p5