### PR TITLE
chore: organize workflow names with category prefixes

### DIFF
--- a/.github/workflows/agent-sync.yml
+++ b/.github/workflows/agent-sync.yml
@@ -1,4 +1,4 @@
-name: "Agent Sync: Claude <-> ChatGPT"
+name: "[Corp] Agent Sync: Claude + ChatGPT"
 
 on:
   push:
@@ -36,7 +36,7 @@ env:
 
 jobs:
   sync:
-    name: "Agent collaboration"
+    name: "Clone + Fix + Push"
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/alert-notify.yml
+++ b/.github/workflows/alert-notify.yml
@@ -1,11 +1,11 @@
-name: "Alert & Notify"
+name: "[Infra] Alert & Notify"
 
 on:
   workflow_run:
     workflows:
-      - "Health Check"
-      - "Test: Full Flow (Controller + Agent)"
-      - "Test: Corporate Flow"
+      - "[Core] Health Check"
+      - "[Corp] Test: Full Flow (Controller + Agent)"
+      - "[Corp] Test: Corporate E2E Flow"
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -1,4 +1,4 @@
-name: "Apply Source Code Change"
+name: "[Corp] Deploy: Apply Source Change"
 
 on:
   push:

--- a/.github/workflows/backup-state.yml
+++ b/.github/workflows/backup-state.yml
@@ -1,4 +1,4 @@
-name: "Backup State"
+name: "[Core] Backup: State Snapshot"
 
 on:
   schedule:
@@ -15,6 +15,7 @@ env:
 
 jobs:
   backup:
+    name: "Snapshot to autopilot-backups"
     runs-on: ubuntu-latest
     steps:
       - name: Snapshot state to backups

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,4 +1,4 @@
-name: "Bootstrap: Full Setup"
+name: "[Core] Bootstrap: Full Setup"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/check-repo-access.yml
+++ b/.github/workflows/check-repo-access.yml
@@ -1,4 +1,4 @@
-name: Check Repo Access
+name: "[Corp] Check: Repo Access"
 
 on:
   workflow_dispatch:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   check-access:
+    name: "Validate Token Access"
     runs-on: ubuntu-latest
     steps:
       - name: Check access to corporate repos

--- a/.github/workflows/ci-diagnose.yml
+++ b/.github/workflows/ci-diagnose.yml
@@ -1,4 +1,4 @@
-name: "CI Diagnose: Fetch Error Logs"
+name: "[Corp] CI: Diagnose Error Logs"
 
 on:
   push:

--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -1,4 +1,4 @@
-name: "CI Failure Analysis"
+name: "[Agent] CI Failure Analysis"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,4 +1,4 @@
-name: "Cleanup: Stale Branches"
+name: "[Infra] Cleanup: Stale Branches"
 
 on:
   schedule:

--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -1,4 +1,4 @@
-name: "Continuous Improvement"
+name: "[Infra] Continuous Improvement"
 
 # Self-improving pipeline that analyzes the project for issues,
 # applies auto-fixes, records learnings, and tracks improvement trends.

--- a/.github/workflows/deploy-panel.yml
+++ b/.github/workflows/deploy-panel.yml
@@ -1,4 +1,4 @@
-name: "Deploy Panel"
+name: "[Infra] Deploy Panel (GitHub Pages)"
 
 on:
   push:
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   deploy:
+    name: "Deploy to GitHub Pages"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/drift-correction.yml
+++ b/.github/workflows/drift-correction.yml
@@ -1,4 +1,4 @@
-name: "Drift Correction"
+name: "[Corp] Drift Correction"
 
 on:
   schedule:
@@ -23,6 +23,7 @@ env:
 
 jobs:
   drift:
+    name: "Detect & Correct Drift"
     runs-on: ubuntu-latest
     steps:
       - name: "Detect and correct drift"

--- a/.github/workflows/enqueue-agent-handoff.yml
+++ b/.github/workflows/enqueue-agent-handoff.yml
@@ -1,4 +1,4 @@
-name: "Enqueue Agent Handoff"
+name: "[Agent] Enqueue Handoff"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/fetch-files.yml
+++ b/.github/workflows/fetch-files.yml
@@ -1,4 +1,4 @@
-name: "Fetch: Corporate Source Files"
+name: "[Corp] Fetch: Source Files"
 on:
   push:
     branches: [main]

--- a/.github/workflows/fix-and-validate.yml
+++ b/.github/workflows/fix-and-validate.yml
@@ -1,4 +1,4 @@
-name: "Fix CI + Validate Full Flow"
+name: "[Corp] Fix: CI + Validate Full Flow"
 
 on:
   push:

--- a/.github/workflows/fix-corporate-ci.yml
+++ b/.github/workflows/fix-corporate-ci.yml
@@ -1,4 +1,4 @@
-name: "Fix: Corporate CI Errors"
+name: "[Corp] Fix: CI Lint Errors"
 
 on:
   push:

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,4 +1,4 @@
-name: "Health Check"
+name: "[Core] Health Check"
 
 on:
   schedule:
@@ -19,6 +19,7 @@ env:
 
 jobs:
   health:
+    name: "Run Health Checks"
     runs-on: ubuntu-latest
     steps:
       - name: Discover workspaces

--- a/.github/workflows/langchain-orchestrator.yml
+++ b/.github/workflows/langchain-orchestrator.yml
@@ -1,4 +1,4 @@
-name: "LangChain Orchestrator"
+name: "[Agent] LangChain Orchestrator"
 
 # Intelligent agent orchestration powered by LangChain + Claude.
 # Replaces rigid shell scripts with context-aware AI decision-making.

--- a/.github/workflows/record-improvement.yml
+++ b/.github/workflows/record-improvement.yml
@@ -1,4 +1,4 @@
-name: "Record Improvement"
+name: "[Agent] Record Improvement"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -4,7 +4,7 @@
 # Required secrets: RELEASE_TOKEN
 # Required vars: AUTOPILOT_WORKSPACE_ID
 # =============================================================================
-name: "Autopilot: Agent Release"
+name: "[Release] Agent"
 
 on:
   workflow_run:

--- a/.github/workflows/release-approval.yml
+++ b/.github/workflows/release-approval.yml
@@ -1,4 +1,4 @@
-name: "Release Approval Gate"
+name: "[Release] Approval Gate"
 
 on:
   workflow_dispatch:
@@ -32,6 +32,7 @@ env:
 
 jobs:
   gate:
+    name: "Approval Gate"
     runs-on: ubuntu-latest
     steps:
       - name: "Check freeze"

--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -4,7 +4,7 @@
 # Required secrets: RELEASE_TOKEN (PAT with repo scope on lucassfreiree/autopilot + deploy repo)
 # Required vars: AUTOPILOT_WORKSPACE_ID
 # =============================================================================
-name: "Autopilot: Controller Release"
+name: "[Release] Controller"
 
 on:
   workflow_run:

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -1,4 +1,4 @@
-name: "Release Freeze"
+name: "[Release] Freeze / Unfreeze"
 
 on:
   workflow_dispatch:
@@ -30,6 +30,7 @@ env:
 
 jobs:
   freeze:
+    name: "Freeze or Unfreeze Releases"
     runs-on: ubuntu-latest
     steps:
       - name: "${{ github.event.inputs.action }} releases"

--- a/.github/workflows/release-metrics.yml
+++ b/.github/workflows/release-metrics.yml
@@ -1,4 +1,4 @@
-name: "Release Metrics"
+name: "[Release] Metrics"
 
 on:
   schedule:
@@ -18,6 +18,7 @@ env:
 
 jobs:
   metrics:
+    name: "Collect Daily Metrics"
     runs-on: ubuntu-latest
     steps:
       - name: "Collect metrics"

--- a/.github/workflows/restore-state.yml
+++ b/.github/workflows/restore-state.yml
@@ -1,4 +1,4 @@
-name: "Restore State (Rollback)"
+name: "[Core] Restore: State Rollback"
 
 on:
   workflow_dispatch:
@@ -24,6 +24,7 @@ env:
 
 jobs:
   restore:
+    name: "Restore from Backup"
     runs-on: ubuntu-latest
     steps:
       - name: "Find snapshot"

--- a/.github/workflows/seed-workspace.yml
+++ b/.github/workflows/seed-workspace.yml
@@ -1,4 +1,4 @@
-name: "Seed Workspace"
+name: "[Core] Seed Workspace"
 
 on:
   workflow_dispatch:
@@ -29,6 +29,7 @@ env:
 
 jobs:
   seed:
+    name: "Create Workspace State"
     runs-on: ubuntu-latest
     steps:
       - name: Validate

--- a/.github/workflows/session-guard.yml
+++ b/.github/workflows/session-guard.yml
@@ -1,4 +1,4 @@
-name: "Session Guard: Prevent Concurrent Agent Conflicts"
+name: "[Core] Session Guard"
 
 # This workflow protects against concurrent modifications from
 # different agents (Claude Code vs Codex) sharing the same account.

--- a/.github/workflows/sync-copilot-prompt.yml
+++ b/.github/workflows/sync-copilot-prompt.yml
@@ -1,4 +1,4 @@
-name: "Sync Copilot Prompt"
+name: "[Infra] Sync Copilot Prompt"
 
 # Auto-regenerates .github/copilot-instructions.md whenever
 # workflows, schemas, contracts, or triggers change.

--- a/.github/workflows/test-corporate-flow.yml
+++ b/.github/workflows/test-corporate-flow.yml
@@ -1,4 +1,4 @@
-name: "Test: Corporate E2E Flow"
+name: "[Corp] Test: Corporate E2E Flow"
 
 on:
   push:

--- a/.github/workflows/test-full-flow.yml
+++ b/.github/workflows/test-full-flow.yml
@@ -1,4 +1,4 @@
-name: "Test: Full Flow (Controller + Agent)"
+name: "[Corp] Test: Full Flow (Controller + Agent)"
 
 on:
   push:

--- a/.github/workflows/workspace-lock-gc.yml
+++ b/.github/workflows/workspace-lock-gc.yml
@@ -1,4 +1,4 @@
-name: "Lock GC"
+name: "[Core] Lock GC"
 
 on:
   schedule:
@@ -14,6 +14,7 @@ env:
 
 jobs:
   gc:
+    name: "Cleanup Expired Locks"
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup expired locks


### PR DESCRIPTION
## Summary
- Reorganized all 31 workflow `name:` fields with category prefixes: `[Agent]`, `[Core]`, `[Corp]`, `[Infra]`, `[Release]`
- Added descriptive job-level `name:` to 12 jobs that had none
- Fixed pre-existing bug in alert-notify.yml: `workflow_run` referenced `"Test: Corporate Flow"` but actual name was `"Test: Corporate E2E Flow"` (alerts were silently not firing)

## What does NOT change
- Zero functional changes — no triggers, paths, secrets, steps, or logic modified
- Only `name:` fields (workflow-level and job-level) and `workflow_run` references updated
- All 31 YAML files validated (syntax OK)
- All `workflow_run` cross-references verified to match actual workflow names

## Expected GitHub Actions UI (alphabetical grouping)
```
[Agent] (4)  — CI Failure Analysis, Enqueue Handoff, LangChain, Record Improvement
[Core]  (7)  — Backup, Bootstrap, Health Check, Lock GC, Restore, Seed, Session Guard
[Corp]  (10) — Apply Source Change, Agent Sync, Check Access, CI Diagnose, Drift, Fetch, Fix CI, Tests
[Infra] (5)  — Alert, Cleanup, Continuous Improvement, Deploy Panel, Sync Copilot
[Release](5) — Agent, Controller, Approval Gate, Freeze, Metrics
```

## Test plan
- [x] YAML syntax validation: 31/31 OK
- [x] workflow_run references: 3/3 match actual names
- [x] No old name references remain in codebase
- [x] git diff confirms only name: lines changed

https://claude.ai/code/session_01WKXBAACShRzwVQmFrBd3p5