### PR TITLE
fix: generic 401 error messages (3.5.7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ This control plane manages **multiple companies** from a single point. Each comp
 ## Controller CAP (GitLab — not yet migrated to GitHub)
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.5.6`
+- **Current deployed tag**: `3.5.7`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -372,8 +372,8 @@
   },
 
   "versioningRules": {
-    "currentVersion": "3.5.6",
-    "previousVersion": "3.5.5",
+    "currentVersion": "3.5.7",
+    "previousVersion": "3.5.6",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versionFiles": [
       { "file": "package.json", "line": 3, "field": "version" },
@@ -412,10 +412,10 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 38,
+    "lastTriggerRun": 39,
     "lastSuccessfulRun": 36,
     "lastDeployPR": 104,
-    "pipelineStatus": "SUCCESS — run #38 (3.5.6) COMPLETO. Autopilot 7/7 stages OK + Esteira corporativa #203 OK. Imagem Docker 3.5.6 publicada.",
+    "pipelineStatus": "PENDING — run #39 (3.5.7) generic 401 error messages. Eliminando vazamento de detalhes de auth.",
     "lastSuccessfulRun": 38,
     "multiFilePayload": {
       "change_type": "multi-file",

--- a/patches/jwt.ts
+++ b/patches/jwt.ts
@@ -1,0 +1,74 @@
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+
+type RequestWithJwt = Request & { jwt?: jwt.JwtPayload | string };
+
+type JwtVerifyOptions = {
+  issuer?: string;
+  audience?: string;
+  algorithms?: jwt.Algorithm[];
+};
+
+function getBearerToken(req: Request): string | null {
+  const auth = String(req.headers.authorization || "");
+  if (!auth.startsWith("Bearer ")) return null;
+  const token = auth.slice(7).trim();
+  return token || null;
+}
+
+function buildVerifyOptions(): JwtVerifyOptions {
+  const issuer = String(process.env.JWT_ISSUER || "").trim() || undefined;
+  const audience = String(process.env.JWT_AUDIENCE || "").trim() || undefined;
+
+  const algRaw = String(process.env.JWT_ALGORITHMS || "HS256").trim();
+  const algorithms = algRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean) as jwt.Algorithm[];
+
+  return {
+    issuer,
+    audience,
+    algorithms: algorithms.length ? algorithms : undefined,
+  };
+}
+
+function getJwtKey(): string {
+  const publicKey = String(process.env.JWT_PUBLIC_KEY || "").trim();
+  if (publicKey) return publicKey;
+  const secret = String(process.env.JWT_SECRET || "").trim();
+  if (!secret) throw new Error("Missing JWT_SECRET or JWT_PUBLIC_KEY");
+  return secret;
+}
+
+function isAgentCallbackToken(decoded: unknown): boolean {
+  if (!decoded || typeof decoded !== "object" || Array.isArray(decoded))
+    return false;
+  const rec = decoded as Record<string, unknown>;
+  return String(rec.typ || "").trim() === "agent-callback";
+}
+
+export function requireJwt(req: Request, res: Response, next: NextFunction) {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ error: "Unauthorized" });
+
+  try {
+    const key = getJwtKey();
+    const options = buildVerifyOptions();
+    const decoded = jwt.verify(token, key, options as jwt.VerifyOptions);
+
+    if (isAgentCallbackToken(decoded)) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    (req as RequestWithJwt).jwt = decoded;
+    return next();
+  } catch (_e) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+}
+
+export function getIncomingAuthorization(req: Request): string | undefined {
+  const auth = String(req.headers.authorization || "").trim();
+  return auth || undefined;
+}

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -114,7 +114,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.6
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.7
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -2,16 +2,34 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "changes": [
     {
-      "target_path": "src/controllers/oas-sre-controller.controller.ts",
+      "target_path": "src/middleware/jwt.ts",
       "action": "replace-file",
-      "content_ref": "patches/oas-sre-controller.controller.ts"
+      "content_ref": "patches/jwt.ts"
+    },
+    {
+      "target_path": "package.json",
+      "action": "search-replace",
+      "search": "\"version\": \"3.5.6\"",
+      "replace": "\"version\": \"3.5.7\""
+    },
+    {
+      "target_path": "package-lock.json",
+      "action": "search-replace",
+      "search": "\"version\": \"3.5.6\"",
+      "replace": "\"version\": \"3.5.7\""
+    },
+    {
+      "target_path": "src/swagger/swagger.json",
+      "action": "search-replace",
+      "search": "\"version\": \"3.5.6\"",
+      "replace": "\"version\": \"3.5.7\""
     }
   ],
-  "commit_message": "fix: move readAuthDecision before usage (ESLint no-use-before-define)",
+  "commit_message": "fix: generic 401 error messages to prevent auth implementation leakage (3.5.7)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 38
+  "run": 39
 }


### PR DESCRIPTION
## Summary\n- Unify all 401 responses in jwt.ts to generic \"Unauthorized\"\n- Prevents auth implementation leakage (\"Missing Bearer token\" revealed mechanism)\n- Version bump 3.5.6 → 3.5.7\n\n## Security fix\nBefore: attacker could distinguish between missing token, invalid token, and wrong token type.\nAfter: all 401s return the same `{\"error\": \"Unauthorized\"}` message.\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK