### PR TITLE
chore: disable alert-notify workflow temporarily

### DIFF
--- a/.github/workflows/alert-notify.yml
+++ b/.github/workflows/alert-notify.yml
@@ -33,6 +33,7 @@ env:
 
 jobs:
   notify:
+    if: false  # Temporarily disabled — re-enable by removing this line
     runs-on: ubuntu-latest
     steps:
       - name: "Evaluate trigger"


### PR DESCRIPTION
## Summary
- Desabilita temporariamente o workflow `alert-notify.yml` que cria Issues no GitHub quando builds falham (gerando emails)
- Para reativar: remover a linha `if: false` do job `notify`

https://claude.ai/code/session_01WKXBAACShRzwVQmFrBd3p5