### PR TITLE
fix: ALL test assertions for generic 401 (3.5.8 run 41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ This control plane manages **multiple companies** from a single point. Each comp
 ## Controller CAP (GitLab — not yet migrated to GitHub)
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.5.7`
+- **Current deployed tag**: `3.5.8`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -372,8 +372,8 @@
   },
 
   "versioningRules": {
-    "currentVersion": "3.5.7",
-    "previousVersion": "3.5.6",
+    "currentVersion": "3.5.8",
+    "previousVersion": "3.5.7",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versionFiles": [
       { "file": "package.json", "line": 3, "field": "version" },
@@ -412,10 +412,10 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 40,
+    "lastTriggerRun": 41,
     "lastSuccessfulRun": 38,
     "lastDeployPR": 104,
-    "pipelineStatus": "PENDING — run #40 (3.5.7) fix: test assertion 'Missing Bearer token' → 'Unauthorized'. Run #39 falhou porque teste esperava mensagem antiga.",
+    "pipelineStatus": "PENDING — run #41 (3.5.8) fix: ALL test assertions for generic 401. Runs 39-40 falharam porque 3 arquivos de teste esperavam mensagens antigas (agentsRouter.test.ts, jwt.middleware.test.ts, oas-sre-controller.route.test.ts).",
     "lastSuccessfulRun": 38,
     "multiFilePayload": {
       "change_type": "multi-file",
@@ -785,7 +785,9 @@
       "ts2769_jwt_sign": "expiresIn string nao aceito por @types/jsonwebtoken@9.0.6. Usar parseExpiresIn() com cast as jwt.SignOptions['expiresIn']. Copiar pattern do auth.controller.ts",
       "eslint_no_use_before_define": "ESLint rejeita funcoes chamadas antes da definicao. SEMPRE ordenar: funcoes auxiliares PRIMEIRO, funcoes que as usam DEPOIS. Verificar com: grep -n 'function ' file | sort -t: -k2 -n",
       "ci_logs_vs_ci_diagnosis": "ci-diagnosis-controller.json roda tsc/jest LOCAL sem npm install — erros TS2688/jest-not-found sao esperados e NAO refletem a esteira real. Para erros REAIS da esteira corporativa: ler ci-logs-controller-*.txt (ultimo arquivo = ultimo run)",
-      "esteira_corporativa_falhou": "Usar ci-diagnose workflow para baixar logs. Ler ci-diagnosis-controller.json no autopilot-state. Campo buildLog tem o erro exato. Corrigir patch, bump run, re-deploy automaticamente"
+      "esteira_corporativa_falhou": "Usar ci-diagnose workflow para baixar logs. Ler ci-logs-controller-*.txt no autopilot-state (ultimo arquivo = ultimo run). Corrigir patch, bump run, re-deploy automaticamente",
+      "error_message_change_breaks_tests": "CRITICO: Ao mudar qualquer mensagem de erro (ex: 401 response body), buscar TODOS os testes que verificam essa mensagem. Usar: grep -rn 'mensagem_antiga' src/__tests__/ para encontrar TODOS. Arquivos de teste afetados por mudanca no jwt.ts: agentsRouter.test.ts, jwt.middleware.test.ts, oas-sre-controller.route.test.ts",
+      "ci_gate_preexisting_bug": "CI Gate 'smart pre-existing detection' compara com commit anterior. Se 2 commits consecutivos falharem pelo MESMO motivo (ex: run 39 sem fix teste + run 40 com fix parcial), CI Gate classifica como pre-existing e PASSA. Resultado: autopilot mostra SUCCESS mas esteira corporativa FAILED. NAO confiar 100% no CI Gate — SEMPRE verificar ci-logs apos deploy."
     }
   },
 

--- a/patches/agentsRouter.test.ts
+++ b/patches/agentsRouter.test.ts
@@ -1,0 +1,263 @@
+import express, {
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+
+jest.setTimeout(15000);
+
+jest.mock("../../controllers/execute.controller", () => ({
+  executeAgent: jest.fn(
+    async (req: Request, res: Response, next: NextFunction) => {
+      const modeRaw = typeof req.query.mode === "string" ? req.query.mode : "";
+      const mode = String(modeRaw || "")
+        .trim()
+        .toLowerCase();
+
+      res.locals = {
+        ...(res.locals || {}),
+        execId: "exec-123",
+        startedAt: Date.now(),
+      };
+
+      if (mode === "sync") {
+        next();
+        return;
+      }
+
+      res.status(202).json({
+        ok: true,
+        execId: "exec-123",
+        mode: "async",
+        status: "RUNNING",
+      });
+    },
+  ),
+}));
+
+jest.mock("../../controllers/agents-execute-logs.controller", () => ({
+  pushAgentExecutionLogs: jest.fn(async (_req: Request, res: Response) => {
+    res.status(200).json({ ok: true });
+  }),
+  getAgentExecutionStatus: jest.fn(async (_req: Request, res: Response) => {
+    res.status(200).json({ status: "DONE" });
+  }),
+  waitForFinalExecution: jest.fn(async () => ({
+    timedOut: false,
+    snapshot: {
+      ok: true,
+      execId: "exec-123",
+      status: "DONE",
+      statusLabel: "Done",
+      finished: true,
+      lastUpdate: new Date().toISOString(),
+      count: 1,
+      entries: [{ ts: new Date().toISOString(), status: "DONE" }],
+    },
+  })),
+}));
+
+jest.mock("../../controllers/list.controller", () => ({
+  listAgents: jest.fn((_req: Request, res: Response) => {
+    res.status(200).json({ ok: true, data: [] });
+  }),
+}));
+
+jest.mock("../../controllers/info.controller", () => ({
+  getInfo: jest.fn((_req: Request, res: Response) => {
+    res.status(200).json({ ok: true });
+  }),
+}));
+
+jest.mock("../../controllers/register.controller", () => ({
+  registerAgent: jest.fn((_req: Request, res: Response) => {
+    res.status(201).json({ ok: true });
+  }),
+}));
+
+jest.mock("../../controllers/agent-errors.controller", () => ({
+  getAgentErrors: jest.fn((_req: Request, res: Response) => {
+    res.status(200).json({ ok: true, data: [] });
+  }),
+}));
+
+describe("agentsRouter auth + scopes enforcement", () => {
+  const JWT_SECRET = process.env.JWT_SECRET || "router-test-secret";
+
+  const TEST_SCOPE_EXECUTE =
+    process.env.SCOPE_EXECUTE_AUTOMATION || "scope:test:execute";
+  const TEST_SCOPE_SEND = process.env.SCOPE_SEND_LOGS || "scope:test:send";
+  const TEST_SCOPE_READ = process.env.SCOPE_READ_STATUS || "scope:test:read";
+  const TEST_SCOPE_REGISTER =
+    process.env.SCOPE_REGISTER_AGENT || "scope:test:register";
+
+  async function makeApp() {
+    const { default: agentsRouter } = await import("../../routes/agentsRouter");
+    const app = express();
+    app.use(express.json());
+    app.use(agentsRouter);
+    return app;
+  }
+
+  function bearer(scopes: string[] = []) {
+    const token = jwt.sign({ sub: "tester", scope: scopes }, JWT_SECRET, {
+      algorithm: "HS256",
+      expiresIn: "10m",
+    });
+    return `Bearer ${token}`;
+  }
+
+  function callbackBearer(
+    params: { execId?: string; agentId?: string; scopes?: string[] } = {},
+  ) {
+    const token = jwt.sign(
+      {
+        typ: "agent-callback",
+        execId: params.execId ?? "exec-123",
+        agentId: params.agentId ?? "agent-01",
+        scope: params.scopes ?? [],
+      },
+      JWT_SECRET,
+      {
+        algorithm: "HS256",
+        expiresIn: "5m",
+        issuer: process.env.JWT_CALLBACK_ISSUER,
+        audience: process.env.JWT_CALLBACK_AUDIENCE,
+      },
+    );
+    return `Bearer ${token}`;
+  }
+
+  test("POST /agent/execute rejects when missing Bearer token", async () => {
+    const app = await makeApp();
+    const res = await request(app).post("/agent/execute").send({});
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  test("POST /agent/execute rejects when token lacks required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/execute")
+      .set("Authorization", bearer([TEST_SCOPE_READ]))
+      .send({ any: "payload" });
+
+    expect(res.status).toBe(403);
+  });
+
+  test("POST /agent/execute accepts when Bearer token has required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/execute")
+      .set("Authorization", bearer([TEST_SCOPE_EXECUTE]))
+      .send({ any: "payload" });
+
+    expect([200, 202]).toContain(res.status);
+  });
+
+  test("GET /agent/execute rejects when missing Bearer token", async () => {
+    const app = await makeApp();
+    const res = await request(app).get("/agent/execute?uuid=exec-123");
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  test("GET /agent/execute rejects when token lacks required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get("/agent/execute?uuid=exec-123")
+      .set("Authorization", bearer([TEST_SCOPE_EXECUTE]));
+
+    expect(res.status).toBe(403);
+  });
+
+  test("GET /agent/execute accepts when Bearer token has required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get("/agent/execute?uuid=exec-123")
+      .set("Authorization", bearer([TEST_SCOPE_READ]));
+
+    expect(res.status).toBe(200);
+  });
+
+  test("POST /agent/execute/logs rejects when missing Bearer token", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/execute/logs")
+      .send({ execId: "exec-123", entries: [] });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  test("POST /agent/execute/logs rejects when callback token lacks required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/execute/logs")
+      .set(
+        "Authorization",
+        callbackBearer({ execId: "exec-123", scopes: [TEST_SCOPE_READ] }),
+      )
+      .send({ execId: "exec-123", entries: [] });
+
+    expect(res.status).toBe(403);
+  });
+
+  test("POST /agent/execute/logs accepts when callback token has required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/execute/logs")
+      .set(
+        "Authorization",
+        callbackBearer({ execId: "exec-123", scopes: [TEST_SCOPE_SEND] }),
+      )
+      .send({ execId: "exec-123", entries: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  test("POST /agent/register rejects when missing Bearer token", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/register")
+      .send({ any: "payload" });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  test("POST /agent/register rejects when callback token lacks required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/register")
+      .set(
+        "Authorization",
+        callbackBearer({ execId: "exec-123", scopes: [TEST_SCOPE_SEND] }),
+      )
+      .send({ any: "payload" });
+
+    expect(res.status).toBe(403);
+  });
+
+  test("GET /agent/info is reachable", async () => {
+    const app = await makeApp();
+    const res = await request(app).get("/agent/info");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  test("POST /agent/register accepts when callback token has required scope", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/agent/register")
+      .set(
+        "Authorization",
+        callbackBearer({ execId: "exec-123", scopes: [TEST_SCOPE_REGISTER] }),
+      )
+      .send({ any: "payload" });
+
+    expect([200, 201]).toContain(res.status);
+  });
+});

--- a/patches/jwt.middleware.test.ts
+++ b/patches/jwt.middleware.test.ts
@@ -1,0 +1,107 @@
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import crypto from "node:crypto";
+
+type ReqWithJwt = Request & { jwt?: jwt.JwtPayload | string };
+
+describe("JWT middleware", () => {
+  const originalEnv = process.env;
+  let jwtSecret = "";
+
+  beforeEach(() => {
+    jest.resetModules();
+    jwtSecret = crypto.randomBytes(24).toString("hex");
+    process.env = { ...originalEnv };
+    process.env.JWT_SECRET = jwtSecret;
+    delete process.env.JWT_PUBLIC_KEY;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+    delete process.env.JWT_ALGORITHMS;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  function makeReq(auth?: string): Request {
+    return {
+      headers: auth ? { authorization: auth } : {},
+    } as unknown as Request;
+  }
+
+  function makeRes() {
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+    return res as Response & { status: jest.Mock; json: jest.Mock };
+  }
+
+  test("rejects when Authorization header is missing", async () => {
+    const { requireJwt } = await import("../../middleware/jwt");
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    requireJwt(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("rejects when token is invalid", async () => {
+    const { requireJwt } = await import("../../middleware/jwt");
+
+    const req = makeReq("Bearer invalid.token.here");
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    requireJwt(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("accepts when token is valid and attaches decoded payload", async () => {
+    const { requireJwt } = await import("../../middleware/jwt");
+
+    const token = jwt.sign(
+      { sub: "user-123", scope: "agent:execute" },
+      jwtSecret,
+      {
+        algorithm: "HS256",
+        expiresIn: "10m",
+      },
+    );
+
+    const req = makeReq(`Bearer ${token}`);
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    requireJwt(req, res, next);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((req as ReqWithJwt).jwt).toBeTruthy();
+    const decoded = (req as ReqWithJwt).jwt as jwt.JwtPayload;
+    expect(decoded.sub).toBe("user-123");
+  });
+
+  test("getIncomingAuthorization returns header value when present", async () => {
+    const { getIncomingAuthorization } = await import("../../middleware/jwt");
+
+    const req = makeReq("Bearer abc");
+    expect(getIncomingAuthorization(req)).toBe("Bearer abc");
+  });
+
+  test("getIncomingAuthorization returns undefined when missing", async () => {
+    const { getIncomingAuthorization } = await import("../../middleware/jwt");
+
+    const req = makeReq();
+    expect(getIncomingAuthorization(req)).toBeUndefined();
+  });
+});

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -114,7 +114,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.7
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.8
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -15,26 +15,36 @@
       "content_ref": "patches/oas-sre-controller.route.test.ts"
     },
     {
+      "target_path": "src/__tests__/unit/agentsRouter.test.ts",
+      "action": "replace-file",
+      "content_ref": "patches/agentsRouter.test.ts"
+    },
+    {
+      "target_path": "src/__tests__/unit/jwt.middleware.test.ts",
+      "action": "replace-file",
+      "content_ref": "patches/jwt.middleware.test.ts"
+    },
+    {
       "target_path": "package.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.6\"",
-      "replace": "\"version\": \"3.5.7\""
+      "search": "\"version\": \"3.5.7\"",
+      "replace": "\"version\": \"3.5.8\""
     },
     {
       "target_path": "package-lock.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.6\"",
-      "replace": "\"version\": \"3.5.7\""
+      "search": "\"version\": \"3.5.7\"",
+      "replace": "\"version\": \"3.5.8\""
     },
     {
       "target_path": "src/swagger/swagger.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.6\"",
-      "replace": "\"version\": \"3.5.7\""
+      "search": "\"version\": \"3.5.7\"",
+      "replace": "\"version\": \"3.5.8\""
     }
   ],
-  "commit_message": "fix: generic 401 error messages + update test assertions (3.5.7)",
+  "commit_message": "fix: update all test assertions for generic 401 messages (3.5.8)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 40
+  "run": 41
 }


### PR DESCRIPTION
## Summary\n- Runs 39-40 failed: tests expected old error messages\n- Fixed ALL 3 test files: agentsRouter.test.ts (4), jwt.middleware.test.ts (2), oas-sre-controller.route.test.ts (1)\n- Version bump 3.5.7 → 3.5.8 (3.5.7 tag already exists in registry)\n\n## Root cause\nChanging jwt.ts error messages without updating ALL test files that assert on them.\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK