### PR TITLE
fix: jwt-callback.ts generic 401 (3.5.9 run 42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ This control plane manages **multiple companies** from a single point. Each comp
 ## Controller CAP (GitLab — not yet migrated to GitHub)
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.5.8`
+- **Current deployed tag**: `3.5.9`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -372,8 +372,8 @@
   },
 
   "versioningRules": {
-    "currentVersion": "3.5.8",
-    "previousVersion": "3.5.7",
+    "currentVersion": "3.5.9",
+    "previousVersion": "3.5.8",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versionFiles": [
       { "file": "package.json", "line": 3, "field": "version" },
@@ -412,7 +412,7 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 41,
+    "lastTriggerRun": 42,
     "lastSuccessfulRun": 38,
     "lastDeployPR": 104,
     "pipelineStatus": "PENDING — run #41 (3.5.8) fix: ALL test assertions for generic 401. Runs 39-40 falharam porque 3 arquivos de teste esperavam mensagens antigas (agentsRouter.test.ts, jwt.middleware.test.ts, oas-sre-controller.route.test.ts).",
@@ -786,7 +786,7 @@
       "eslint_no_use_before_define": "ESLint rejeita funcoes chamadas antes da definicao. SEMPRE ordenar: funcoes auxiliares PRIMEIRO, funcoes que as usam DEPOIS. Verificar com: grep -n 'function ' file | sort -t: -k2 -n",
       "ci_logs_vs_ci_diagnosis": "ci-diagnosis-controller.json roda tsc/jest LOCAL sem npm install — erros TS2688/jest-not-found sao esperados e NAO refletem a esteira real. Para erros REAIS da esteira corporativa: ler ci-logs-controller-*.txt (ultimo arquivo = ultimo run)",
       "esteira_corporativa_falhou": "Usar ci-diagnose workflow para baixar logs. Ler ci-logs-controller-*.txt no autopilot-state (ultimo arquivo = ultimo run). Corrigir patch, bump run, re-deploy automaticamente",
-      "error_message_change_breaks_tests": "CRITICO: Ao mudar qualquer mensagem de erro (ex: 401 response body), buscar TODOS os testes que verificam essa mensagem. Usar: grep -rn 'mensagem_antiga' src/__tests__/ para encontrar TODOS. Arquivos de teste afetados por mudanca no jwt.ts: agentsRouter.test.ts, jwt.middleware.test.ts, oas-sre-controller.route.test.ts",
+      "error_message_change_breaks_tests": "CRITICO: Ao mudar qualquer mensagem de erro (ex: 401 response body), buscar TODOS os arquivos que retornam essa mensagem (jwt.ts, jwt-callback.ts, e qualquer outro middleware) E TODOS os testes que verificam. Usar: grep -rn 'mensagem_antiga' src/ para encontrar TODOS. Arquivos de CODIGO afetados: jwt.ts (3 mensagens), jwt-callback.ts (13 mensagens). Arquivos de TESTE afetados: agentsRouter.test.ts (4), jwt.middleware.test.ts (2), oas-sre-controller.route.test.ts (1). LESSON: jwt-callback.ts e um middleware SEPARADO do jwt.ts que tem suas PROPRIAS mensagens de erro. Ambos devem ser atualizados.",
       "ci_gate_preexisting_bug": "CI Gate 'smart pre-existing detection' compara com commit anterior. Se 2 commits consecutivos falharem pelo MESMO motivo (ex: run 39 sem fix teste + run 40 com fix parcial), CI Gate classifica como pre-existing e PASSA. Resultado: autopilot mostra SUCCESS mas esteira corporativa FAILED. NAO confiar 100% no CI Gate — SEMPRE verificar ci-logs apos deploy."
     }
   },

--- a/patches/jwt-callback.ts
+++ b/patches/jwt-callback.ts
@@ -1,0 +1,185 @@
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+
+type RequestWithAgentCallbackJwt = Request & {
+  agentCallbackJwt?: jwt.JwtPayload | string;
+};
+
+type JwtVerifyOptions = {
+  issuer?: string;
+  audience?: string;
+  algorithms?: jwt.Algorithm[];
+};
+
+function getBearerToken(req: Request): string | null {
+  const auth = String(req.headers.authorization || "");
+  if (!auth.startsWith("Bearer ")) return null;
+  const token = auth.slice(7).trim();
+  return token || null;
+}
+
+function buildVerifyOptions(): JwtVerifyOptions {
+  const issuer =
+    String(process.env.JWT_CALLBACK_ISSUER || "").trim() ||
+    "psc-sre-automacao-agent";
+  const audience =
+    String(process.env.JWT_CALLBACK_AUDIENCE || "").trim() ||
+    "psc-sre-automacao-controller";
+
+  const algRaw = String(process.env.JWT_ALGORITHMS || "HS256").trim();
+  const algorithms = algRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean) as jwt.Algorithm[];
+
+  return {
+    issuer,
+    audience,
+    algorithms,
+  };
+}
+
+function getJwtKey(): string {
+  const publicKey = String(process.env.JWT_PUBLIC_KEY || "").trim();
+  if (publicKey) return publicKey;
+  const secret = String(process.env.JWT_SECRET || "").trim();
+  if (!secret) throw new Error("Missing JWT_SECRET or JWT_PUBLIC_KEY");
+  return secret;
+}
+
+function isObjectPayload(decoded: unknown): decoded is jwt.JwtPayload {
+  return (
+    typeof decoded === "object" && decoded !== null && !Array.isArray(decoded)
+  );
+}
+
+function getMaxCallbackTtlSeconds(): number {
+  const raw = String(process.env.JWT_CALLBACK_MAX_TTL_SECONDS || "300").trim();
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 300;
+}
+
+function readBodyExecId(req: Request): string {
+  const body = req.body as unknown;
+  if (!body || typeof body !== "object" || Array.isArray(body)) return "";
+  const rec = body as Record<string, unknown>;
+  return String(rec.execId || "").trim();
+}
+
+function readBodyAgentId(req: Request): string {
+  const header = String(req.header("x-agent-id") || "").trim();
+  if (header) return header;
+
+  const body = req.body as unknown;
+  if (!body || typeof body !== "object" || Array.isArray(body)) return "";
+  const rec = body as Record<string, unknown>;
+  return String(rec.agentId || "").trim();
+}
+
+export function requireAgentCallbackJwt(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ error: "Unauthorized" });
+
+  try {
+    const key = getJwtKey();
+    const options = buildVerifyOptions();
+    const decoded = jwt.verify(token, key, options as jwt.VerifyOptions);
+
+    if (!isObjectPayload(decoded)) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const typ = String(decoded.typ || "").trim();
+    if (typ !== "agent-callback") {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const execId = String(
+      (decoded as Record<string, unknown>).execId || "",
+    ).trim();
+    if (!execId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const iat = typeof decoded.iat === "number" ? decoded.iat : NaN;
+    const exp = typeof decoded.exp === "number" ? decoded.exp : NaN;
+    if (!Number.isFinite(iat) || !Number.isFinite(exp)) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const ttlSeconds = exp - iat;
+    if (ttlSeconds > getMaxCallbackTtlSeconds()) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const bodyExecId = readBodyExecId(req);
+    if (bodyExecId && bodyExecId !== execId) {
+      return res.status(403).json({ error: "Token execId mismatch" });
+    }
+
+    const tokenAgentId = String(
+      (decoded as Record<string, unknown>).agentId || "",
+    ).trim();
+    const bodyAgentId = readBodyAgentId(req);
+    if (tokenAgentId && bodyAgentId && tokenAgentId !== bodyAgentId) {
+      return res.status(403).json({ error: "Token agentId mismatch" });
+    }
+
+    (req as RequestWithAgentCallbackJwt).agentCallbackJwt = decoded;
+    return next();
+  } catch (_e) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+}
+
+export function requireAgentRegisterCallbackJwt(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ error: "Unauthorized" });
+
+  try {
+    const key = getJwtKey();
+    const options = buildVerifyOptions();
+    const decoded = jwt.verify(token, key, options as jwt.VerifyOptions);
+
+    if (!isObjectPayload(decoded)) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const typ = String(decoded.typ || "").trim();
+    if (typ !== "agent-callback") {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const iat = typeof decoded.iat === "number" ? decoded.iat : NaN;
+    const exp = typeof decoded.exp === "number" ? decoded.exp : NaN;
+    if (!Number.isFinite(iat) || !Number.isFinite(exp)) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const ttlSeconds = exp - iat;
+    if (ttlSeconds > getMaxCallbackTtlSeconds()) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const tokenAgentId = String(
+      (decoded as Record<string, unknown>).agentId || "",
+    ).trim();
+    const bodyAgentId = readBodyAgentId(req);
+    if (tokenAgentId && bodyAgentId && tokenAgentId !== bodyAgentId) {
+      return res.status(403).json({ error: "Token agentId mismatch" });
+    }
+
+    (req as RequestWithAgentCallbackJwt).agentCallbackJwt = decoded;
+    return next();
+  } catch (_e) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+}

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -114,7 +114,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.8
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.9
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -2,12 +2,17 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "changes": [
     {
       "target_path": "src/middleware/jwt.ts",
       "action": "replace-file",
       "content_ref": "patches/jwt.ts"
+    },
+    {
+      "target_path": "src/middleware/jwt-callback.ts",
+      "action": "replace-file",
+      "content_ref": "patches/jwt-callback.ts"
     },
     {
       "target_path": "src/__tests__/unit/oas-sre-controller.route.test.ts",
@@ -27,24 +32,24 @@
     {
       "target_path": "package.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.7\"",
-      "replace": "\"version\": \"3.5.8\""
+      "search": "\"version\": \"3.5.8\"",
+      "replace": "\"version\": \"3.5.9\""
     },
     {
       "target_path": "package-lock.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.7\"",
-      "replace": "\"version\": \"3.5.8\""
+      "search": "\"version\": \"3.5.8\"",
+      "replace": "\"version\": \"3.5.9\""
     },
     {
       "target_path": "src/swagger/swagger.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.7\"",
-      "replace": "\"version\": \"3.5.8\""
+      "search": "\"version\": \"3.5.8\"",
+      "replace": "\"version\": \"3.5.9\""
     }
   ],
-  "commit_message": "fix: update all test assertions for generic 401 messages (3.5.8)",
+  "commit_message": "fix: generic 401 in jwt.ts AND jwt-callback.ts + all test assertions (3.5.9)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 41
+  "run": 42
 }


### PR DESCRIPTION
## Summary\n- jwt-callback.ts had 13 instances of old error messages not updated\n- Used by /agent/register and /agent/execute/logs routes\n- Runs 39-41 failed because only jwt.ts was changed, not jwt-callback.ts\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK