### PR TITLE
fix: jwt-callback test + all 401 fixes (3.5.10 run 43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ This control plane manages **multiple companies** from a single point. Each comp
 ## Controller CAP (GitLab — not yet migrated to GitHub)
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.5.9`
+- **Current deployed tag**: `3.5.10`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`

--- a/patches/jwt-callback.middleware.test.ts
+++ b/patches/jwt-callback.middleware.test.ts
@@ -1,0 +1,146 @@
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import crypto from "node:crypto";
+
+type ReqWithCallback = Request & { agentCallbackJwt?: jwt.JwtPayload | string };
+
+describe("JWT callback middleware (Agent → Controller)", () => {
+  const originalEnv = process.env;
+  let jwtSecret = "";
+
+  const makeReq = (
+    auth?: string,
+    body?: unknown,
+    extraHeaders: Record<string, string | undefined> = {},
+  ): ReqWithCallback => {
+    const headers: Record<string, string> = {};
+
+    if (auth) headers.authorization = auth;
+
+    Object.entries(extraHeaders).forEach(([k, v]) => {
+      if (v !== undefined) headers[k.toLowerCase()] = v;
+    });
+
+    const readHeader = (name: string): string | undefined => {
+      const key = name.toLowerCase();
+      return headers[key];
+    };
+
+    return {
+      headers,
+      body,
+      header: (name: string) => readHeader(name),
+      get: (name: string) => readHeader(name),
+    } as unknown as ReqWithCallback;
+  };
+
+  const makeRes = () => {
+    const res = {} as Partial<Response>;
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res as Response;
+  };
+
+  const makeNext = () => jest.fn() as unknown as NextFunction;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jwtSecret = crypto.randomBytes(24).toString("hex");
+    process.env = { ...originalEnv };
+    process.env.JWT_SECRET = jwtSecret;
+    delete process.env.JWT_PUBLIC_KEY;
+    process.env.JWT_CALLBACK_ISSUER = "psc-sre-automacao-agent";
+    process.env.JWT_CALLBACK_AUDIENCE = "psc-sre-automacao-controller";
+    process.env.JWT_ALGORITHMS = "HS256";
+    process.env.JWT_CALLBACK_MAX_TTL_SECONDS = "300";
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test("rejects when missing Bearer token", async () => {
+    const { requireAgentCallbackJwt } = await import(
+      "../../middleware/jwt-callback"
+    );
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    requireAgentCallbackJwt(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("rejects when token is invalid", async () => {
+    const { requireAgentCallbackJwt } = await import(
+      "../../middleware/jwt-callback"
+    );
+
+    const req = makeReq("Bearer invalid.token.value");
+    const res = makeRes();
+    const next = makeNext();
+
+    requireAgentCallbackJwt(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("rejects when issuer/audience do not match callback expectations", async () => {
+    const { requireAgentCallbackJwt } = await import(
+      "../../middleware/jwt-callback"
+    );
+
+    const bad = jwt.sign(
+      { typ: "agent-callback", execId: "exec-1" },
+      jwtSecret,
+      {
+        algorithm: "HS256",
+        expiresIn: "5m",
+        issuer: "psc-sre-automacao-controller",
+        audience: "psc-sre-automacao-agent",
+      },
+    );
+
+    const req = makeReq(`Bearer ${bad}`);
+    const res = makeRes();
+    const next = makeNext();
+
+    requireAgentCallbackJwt(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("accepts when token is valid and stores decoded claims on req", async () => {
+    const { requireAgentCallbackJwt } = await import(
+      "../../middleware/jwt-callback"
+    );
+
+    const good = jwt.sign(
+      { typ: "agent-callback", execId: "exec-1" },
+      jwtSecret,
+      {
+        algorithm: "HS256",
+        expiresIn: "5m",
+        issuer: "psc-sre-automacao-agent",
+        audience: "psc-sre-automacao-controller",
+      },
+    );
+
+    const req = makeReq(`Bearer ${good}`);
+    const res = makeRes();
+    const next = makeNext();
+
+    requireAgentCallbackJwt(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.agentCallbackJwt).toBeDefined();
+  });
+});

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -114,7 +114,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.9
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.10
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -2,7 +2,7 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "changes": [
     {
       "target_path": "src/middleware/jwt.ts",
@@ -30,26 +30,31 @@
       "content_ref": "patches/jwt.middleware.test.ts"
     },
     {
+      "target_path": "src/__tests__/unit/jwt-callback.middleware.test.ts",
+      "action": "replace-file",
+      "content_ref": "patches/jwt-callback.middleware.test.ts"
+    },
+    {
       "target_path": "package.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.8\"",
-      "replace": "\"version\": \"3.5.9\""
+      "search": "\"version\": \"3.5.9\"",
+      "replace": "\"version\": \"3.5.10\""
     },
     {
       "target_path": "package-lock.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.8\"",
-      "replace": "\"version\": \"3.5.9\""
+      "search": "\"version\": \"3.5.9\"",
+      "replace": "\"version\": \"3.5.10\""
     },
     {
       "target_path": "src/swagger/swagger.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.8\"",
-      "replace": "\"version\": \"3.5.9\""
+      "search": "\"version\": \"3.5.9\"",
+      "replace": "\"version\": \"3.5.10\""
     }
   ],
-  "commit_message": "fix: generic 401 in jwt.ts AND jwt-callback.ts + all test assertions (3.5.9)",
+  "commit_message": "fix: generic 401 in all middlewares + all 4 test files (3.5.10)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 42
+  "run": 43
 }


### PR DESCRIPTION
## Summary\n- Esteira #207 failed: jwt-callback.middleware.test.ts had 3 old assertions\n- Now ALL 4 test files + 2 middleware files are patched\n- Total: 2 source files (16 messages) + 4 test files (10 assertions)\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK