### PR TITLE
feat: body.headers fallback for APB auth (3.5.11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ This control plane manages **multiple companies** from a single point. Each comp
 ## Controller CAP (GitLab — not yet migrated to GitHub)
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.5.10`
+- **Current deployed tag**: `3.5.11`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -372,8 +372,8 @@
   },
 
   "versioningRules": {
-    "currentVersion": "3.5.10",
-    "previousVersion": "3.5.9",
+    "currentVersion": "3.5.11",
+    "previousVersion": "3.5.10",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versionFiles": [
       { "file": "package.json", "line": 3, "field": "version" },
@@ -412,7 +412,7 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 43,
+    "lastTriggerRun": 44,
     "lastSuccessfulRun": 43,
     "lastDeployPR": 104,
     "pipelineStatus": "SUCCESS — run #43 (3.5.10) COMPLETO. Esteira corporativa #208 PASSOU. Imagem Docker 3.5.10 publicada. NOTA: CI Gate reportou ci-failed-preexisting INCORRETAMENTE — esteira real passou.",

--- a/patches/oas-origin-auth.ts
+++ b/patches/oas-origin-auth.ts
@@ -54,6 +54,20 @@ function resolveHeaderCandidates(envName: string): string[] {
   return uniqueValues(fromEnv);
 }
 
+function readBodyHeaders(req: Request): Record<string, string> {
+  const body = req.body as Record<string, unknown> | undefined;
+  if (!body || typeof body !== "object") return {};
+  const raw = body.headers;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof val === "string" && val.trim()) {
+      result[key.toLowerCase()] = val.trim();
+    }
+  }
+  return result;
+}
+
 function firstHeaderValue(
   req: Request,
   candidates: string[],
@@ -65,9 +79,17 @@ function firstHeaderValue(
     }))
     .find((item) => item.value !== "");
 
-  if (!found) return null;
+  if (found) return found;
 
-  return found;
+  const bodyHeaders = readBodyHeaders(req);
+  const fromBody = candidates
+    .map((candidate) => ({
+      value: bodyHeaders[candidate.toLowerCase()] || "",
+      headerName: candidate,
+    }))
+    .find((item) => item.value !== "");
+
+  return fromBody || null;
 }
 
 function normalized(value: string): string {

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -114,7 +114,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.10
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.11
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -2,59 +2,34 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.5.9",
+  "version": "3.5.10",
   "changes": [
     {
-      "target_path": "src/middleware/jwt.ts",
+      "target_path": "src/middleware/oas-origin-auth.ts",
       "action": "replace-file",
-      "content_ref": "patches/jwt.ts"
-    },
-    {
-      "target_path": "src/middleware/jwt-callback.ts",
-      "action": "replace-file",
-      "content_ref": "patches/jwt-callback.ts"
-    },
-    {
-      "target_path": "src/__tests__/unit/oas-sre-controller.route.test.ts",
-      "action": "replace-file",
-      "content_ref": "patches/oas-sre-controller.route.test.ts"
-    },
-    {
-      "target_path": "src/__tests__/unit/agentsRouter.test.ts",
-      "action": "replace-file",
-      "content_ref": "patches/agentsRouter.test.ts"
-    },
-    {
-      "target_path": "src/__tests__/unit/jwt.middleware.test.ts",
-      "action": "replace-file",
-      "content_ref": "patches/jwt.middleware.test.ts"
-    },
-    {
-      "target_path": "src/__tests__/unit/jwt-callback.middleware.test.ts",
-      "action": "replace-file",
-      "content_ref": "patches/jwt-callback.middleware.test.ts"
+      "content_ref": "patches/oas-origin-auth.ts"
     },
     {
       "target_path": "package.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.9\"",
-      "replace": "\"version\": \"3.5.10\""
+      "search": "\"version\": \"3.5.10\"",
+      "replace": "\"version\": \"3.5.11\""
     },
     {
       "target_path": "package-lock.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.9\"",
-      "replace": "\"version\": \"3.5.10\""
+      "search": "\"version\": \"3.5.10\"",
+      "replace": "\"version\": \"3.5.11\""
     },
     {
       "target_path": "src/swagger/swagger.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.9\"",
-      "replace": "\"version\": \"3.5.10\""
+      "search": "\"version\": \"3.5.10\"",
+      "replace": "\"version\": \"3.5.11\""
     }
   ],
-  "commit_message": "fix: generic 401 in all middlewares + all 4 test files (3.5.10)",
+  "commit_message": "feat: read auth headers from body.headers fallback for APB calls (3.5.11)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 43
+  "run": 44
 }


### PR DESCRIPTION
## Summary\n- APB sends auth headers inside JSON body `{\"headers\": {\"x-techbb-namespace\": \"...\"}}`\n- Controller only read HTTP headers, not body headers\n- Added fallback: try HTTP headers first, then `req.body.headers`\n- Fixes 401 Unauthorized when APB calls controller via OAS portal\n\n## How it works\n```\n1. HTTP headers present? → use them (existing behavior)\n2. HTTP headers missing? → check req.body.headers → use if found\n3. Neither? → fall through to JWT auth\n```\n\nhttps://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK