### PR TITLE
fix(security): XSS + SSRF + error hardening (3.5.13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ ops/terraform/
 ## Controller CAP (GitLab — not yet migrated to GitHub)
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.5.12`
+- **Current deployed tag**: `3.5.13`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -709,8 +709,8 @@
   },
 
   "versioningRules": {
-    "currentVersion": "3.5.11",
-    "previousVersion": "3.5.10",
+    "currentVersion": "3.5.13",
+    "previousVersion": "3.5.12",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versionFiles": [
       { "file": "package.json", "line": 3, "field": "version" },
@@ -749,7 +749,7 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 44,
+    "lastTriggerRun": 46,
     "lastSuccessfulRun": 43,
     "lastDeployPR": 104,
     "pipelineStatus": "SUCCESS — run #43 (3.5.10) COMPLETO. Esteira corporativa #208 PASSOU. Imagem Docker 3.5.10 publicada. NOTA: CI Gate reportou ci-failed-preexisting INCORRETAMENTE — esteira real passou.",
@@ -1163,6 +1163,10 @@
       "ci_logs_vs_ci_diagnosis": "ci-diagnosis-controller.json roda tsc/jest LOCAL sem npm install — erros TS2688/jest-not-found sao esperados e NAO refletem a esteira real. Para erros REAIS da esteira corporativa: ler ci-logs-controller-*.txt (ultimo arquivo = ultimo run)",
       "esteira_corporativa_falhou": "Usar ci-diagnose workflow para baixar logs. Ler ci-logs-controller-*.txt no autopilot-state (ultimo arquivo = ultimo run). Corrigir patch, bump run, re-deploy automaticamente",
       "error_message_change_breaks_tests": "CRITICO: Ao mudar qualquer mensagem de erro (ex: 401 response body), buscar TODOS os arquivos que retornam essa mensagem (jwt.ts, jwt-callback.ts, e qualquer outro middleware) E TODOS os testes que verificam. Usar: grep -rn 'mensagem_antiga' src/ para encontrar TODOS. Arquivos de CODIGO afetados: jwt.ts (3 mensagens), jwt-callback.ts (13 mensagens). Arquivos de TESTE afetados: agentsRouter.test.ts (4), jwt.middleware.test.ts (2), oas-sre-controller.route.test.ts (1). LESSON: jwt-callback.ts e um middleware SEPARADO do jwt.ts que tem suas PROPRIAS mensagens de erro. Ambos devem ser atualizados.",
+      "security_xss_reflected": "NUNCA refletir input do usuario em responses sem sanitizacao. Usar sanitizeForOutput() que remove <>'\"& e limita a 256 chars. Checkmarx detecta Reflected_XSS quando req.body flui para res.json().",
+      "security_ssrf_url_validation": "TODA URL usada em fetch()/http request DEVE ser validada contra TRUSTED_AGENT_URL_PATTERN (regex de dominio confiavel). Usar validateTrustedUrl() antes de qualquer fetch. Checkmarx detecta SSRF quando body influencia URL de request.",
+      "security_dos_loop_bound": "NUNCA usar req.query/req.body para controlar numero de iteracoes de um loop sem limite maximo (MAX_RESULTS). Checkmarx detecta Server_DoS_by_Loop.",
+      "security_error_detail_leak": "NUNCA retornar error.message direto no response. Usar sanitizeForOutput(msg) para limpar e limitar. Evita information disclosure.",
       "oaas_oferta_401_no_headers": "Oferta migra-microsservicos-openshift retorna 401 ao chamar controller. CAUSA: playbook execute-psc-ns-migration-preflight.yml NAO envia headers x-techbb-namespace e x-techbb-service-account. FIX: adicionar headers no task uri do Ansible. Controller esta correto — problema e no playbook da oferta (repo da plataforma OaaS).",
       "oaas_dns_transiente": "Pod APB pode ter falha DNS transiente para hostnames *.psc.k8shmlbb111b.bb.com.br. Reexecutar resolve. Cluster HML correto: k8shmlbb111b (com BB duplo, NAO b simples).",
       "ci_gate_preexisting_bug": "CRITICO: CI Gate 'smart pre-existing detection' esta QUEBRADO. Reporta ciResult=failure MESMO quando a esteira corporativa PASSA. Aconteceu no run #43: esteira #208 PASSOU com sucesso mas CI Gate reportou ci-failed-preexisting. O CI Gate NAO e confiavel para determinar se a esteira passou ou falhou. Para saber o resultado REAL: 1) Checar ci-logs-controller-*.txt (se novo log apareceu com PASS em todos os testes = sucesso), 2) Perguntar ao usuario se necessario, 3) Tempo de execucao: esteira que FALHA em teste leva ~3.5 min, esteira que PASSA leva ~14 min. Se CI Gate levou 14+ min = provavelmente passou."

--- a/patches/execute.controller.fixed.ts
+++ b/patches/execute.controller.fixed.ts
@@ -23,6 +23,25 @@ type LocalsExec = {
 
 const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const DEFAULT_AGENT_CALL_TIMEOUT_MS = 30_000;
+const TRUSTED_AGENT_URL_PATTERN = /^https:\/\/[A-Za-z0-9._-]+\.bb\.com\.br\//;
+
+function validateTrustedUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    return TRUSTED_AGENT_URL_PATTERN.test(url);
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeForOutput(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[<>"'&]/g, "")
+    .replace(/[\r\n\t]+/g, " ")
+    .trim()
+    .slice(0, 256);
+}
 
 function parseSafeIdentifier(value: unknown): string {
   if (typeof value !== "string") return "";
@@ -76,6 +95,10 @@ async function postJson(
   headers: Record<string, string>,
   body: unknown,
 ): Promise<FetchJsonResult> {
+  if (!validateTrustedUrl(url)) {
+    return { ok: false, status: 403, text: "Blocked: untrusted agent URL" };
+  }
+
   const timeoutMs = readAgentCallTimeoutMs();
   const abort = new AbortController();
   const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
@@ -216,7 +239,7 @@ export async function executeAgent(
     res.status(500).json({
       ok: false,
       error: "Internal error while dispatching execution",
-      detail: msg,
+      detail: sanitizeForOutput(msg),
       execId,
     });
   }

--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -61,6 +61,7 @@ type AllowedImage = {
 
 const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const DEFAULT_AGENT_CALL_TIMEOUT_MS = 30_000;
+const TRUSTED_AGENT_URL_PATTERN = /^https:\/\/[A-Za-z0-9._-]+\.bb\.com\.br\//;
 
 function asRecord(value: unknown): JsonRecord | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -71,11 +72,29 @@ function safeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function sanitizeForOutput(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[<>"'&]/g, "")
+    .replace(/[\r\n\t]+/g, " ")
+    .trim()
+    .slice(0, 256);
+}
+
 function safeLogValue(value: unknown): string {
   return String(value ?? "")
     .replace(/[\r\n\t]+/g, " ")
     .trim()
     .slice(0, 256);
+}
+
+function validateTrustedUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    return TRUSTED_AGENT_URL_PATTERN.test(url);
+  } catch {
+    return false;
+  }
 }
 
 function readAgentCallTimeoutMs(): number {
@@ -233,7 +252,7 @@ function validateSreControllerPayload(body: unknown): ValidationResult {
   if (!allowedImage) {
     const allowed = allowedImages().map((img) => img.key);
     errors.push(
-      `Image '${imageRaw}' is not allowed. Allowed images: ${allowed.join(", ")}.`,
+      `Image '${sanitizeForOutput(imageRaw)}' is not allowed. Allowed images: ${allowed.join(", ")}.`,
     );
     return { ok: false, errors };
   }
@@ -351,6 +370,14 @@ async function callAgent(
   headers: Record<string, string>,
   payload: unknown,
 ): Promise<{ status: number; ok: boolean }> {
+  if (!validateTrustedUrl(url)) {
+    console.error(
+      "[oas-sre-controller] blocked untrusted agent URL: %s",
+      safeLogValue(url),
+    );
+    return { status: 403, ok: false };
+  }
+
   const timeoutMs = readAgentCallTimeoutMs();
   const abort = new AbortController();
   const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
@@ -609,9 +636,9 @@ export async function postOasSreController(
     res.status(500).json({
       ok: false,
       error: "Internal error while dispatching OAS automation",
-      detail: msg,
+      detail: sanitizeForOutput(msg),
       execId,
-      dispatches,
+      dispatches: summarizeDispatches(dispatches),
     });
   }
 }

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -114,7 +114,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.12
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.5.13
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,34 +3,39 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.5.11",
+  "version": "3.5.13",
   "changes": [
     {
-      "target_path": "src/middleware/oas-origin-auth.ts",
+      "target_path": "src/controllers/oas-sre-controller.controller.ts",
       "action": "replace-file",
-      "content_ref": "patches/oas-origin-auth.ts"
+      "content_ref": "patches/oas-sre-controller.controller.ts"
+    },
+    {
+      "target_path": "src/controllers/execute.controller.ts",
+      "action": "replace-file",
+      "content_ref": "patches/execute.controller.fixed.ts"
     },
     {
       "target_path": "package.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.11\"",
-      "replace": "\"version\": \"3.5.12\""
+      "search": "\"version\": \"3.5.12\"",
+      "replace": "\"version\": \"3.5.13\""
     },
     {
       "target_path": "package-lock.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.11\"",
-      "replace": "\"version\": \"3.5.12\""
+      "search": "\"version\": \"3.5.12\"",
+      "replace": "\"version\": \"3.5.13\""
     },
     {
       "target_path": "src/swagger/swagger.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.5.11\"",
-      "replace": "\"version\": \"3.5.12\""
+      "search": "\"version\": \"3.5.12\"",
+      "replace": "\"version\": \"3.5.13\""
     }
   ],
-  "commit_message": "fix: replace for-of with reduce to satisfy ESLint no-restricted-syntax (3.5.12)",
+  "commit_message": "fix(security): XSS sanitization + SSRF URL validation + error output hardening (3.5.13)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 45
+  "run": 46
 }


### PR DESCRIPTION
## Summary
- **HIGH Reflected_XSS**: `sanitizeForOutput()` strips `<>"'&` before reflecting user input in error responses
- **MEDIUM SSRF x3**: `validateTrustedUrl()` validates URLs against trusted BB domain pattern (`*.bb.com.br`) before any `fetch()`
- **Error hardening**: `detail` fields sanitized, raw `dispatches` replaced with `summarizeDispatches()`
- Security patterns documented in session memory to prevent recurrence
- Deploy 3.5.13 via apply-source-change (run 46)

## Files changed
- `patches/oas-sre-controller.controller.ts` — XSS + SSRF fixes
- `patches/execute.controller.fixed.ts` — SSRF fix

## Test plan
- [ ] apply-source-change workflow completes successfully
- [ ] Corporate CI (Esteira NPM) passes
- [ ] Re-run Checkmarx scan to confirm findings resolved

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK