### PR TITLE
Add Autopilot docs, agent operational parity guide, and auto PR/merge script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
-# autopilot-backups
+# Autopilot
 
-State snapshots for rollback. Do not merge into main.
+Control plane web-only para orquestração de CI/CD multi-workspace e multi-agente (Claude, Codex, ChatGPT e Copilot), operando de forma 100% GitHub-native.
+
+## Objetivo
+
+Este repositório centraliza:
+
+- Workflows de automação do controle de releases (`.github/workflows/`)
+- Contratos e regras dos agentes (`contracts/`)
+- Schemas de estado e validação (`schemas/`)
+- Gatilhos declarativos para workflows (`trigger/`)
+- Ambiente operacional de DevOps/SRE (`ops/`)
+- Integrações opcionais (`integrations/`)
+
+## Fonte de verdade
+
+- Branch `main`: código do control plane
+- Branch `autopilot-state`: estado operacional (locks, audit, health, release state)
+- Branch `autopilot-backups`: snapshots para rollback
+
+## Leitura rápida para operação por agentes
+
+1. `AGENTS.md` — regras obrigatórias para o Codex
+2. `CLAUDE.md` — contexto completo deixado pelo Claude
+3. `HANDOFF.md` — guia de handoff e arquitetura detalhada
+4. `ops/docs/agent-operational-parity.md` — checklist prático para operar com o mesmo fluxo do Claude
+
+## Segurança e isolamento
+
+- Nunca misturar contextos entre workspaces.
+- Sempre usar `workspace_id` explícito nas operações.
+- Antes de qualquer alteração de estado, verificar lock de sessão em `state/workspaces/<ws_id>/locks/session-lock.json`.

--- a/ops/docs/agent-operational-parity.md
+++ b/ops/docs/agent-operational-parity.md
@@ -1,0 +1,73 @@
+# Agent Operational Parity (Claude ↔ Codex)
+
+Este documento consolida um fluxo seguro para o Codex operar no Autopilot com a mesma disciplina operacional que o Claude, **sem alterar comportamento de pipelines existentes**.
+
+## 1) Checklist de pré-operação (obrigatório)
+
+1. Identificar o workspace pelo contexto da solicitação:
+   - Getronics / bbvinet / NestJS / controller / agent → `ws-default`
+   - CIT / Terraform / K8s / cloud / monitoring → `ws-cit`
+2. Ler contratos:
+   - `contracts/codex-agent-contract.json`
+   - `contracts/shared-agent-contract.json`
+3. Verificar lock de sessão **antes de qualquer mudança de estado**:
+   - `state/workspaces/<ws_id>/locks/session-lock.json` (branch `autopilot-state`)
+4. Se lock ativo por outro agente (`agentId != "none"` e `expiresAt > now`), **não forçar**:
+   - criar handoff para Claude via `enqueue-agent-handoff.yml`
+
+## 2) Princípios para não quebrar o funcionamento
+
+- Não modificar schemas sem necessidade explícita.
+- Não alterar nomes/inputs de workflows sem migração planejada.
+- Não hardcodar organização/tenant em scripts; usar sempre `workspace_id`.
+- Não assumir workspace padrão.
+- Não persistir segredos, URLs internas ou código corporativo neste repositório.
+
+## 3) Mapa rápido de execução (o que o Claude já fazia)
+
+### A. Trigger file (preferido)
+
+- Alterar arquivo em `trigger/*.json`
+- Conferir `_context`
+- Incrementar campo `run`
+
+Exemplos:
+- `trigger/source-change.json` → deploy de alteração no repo corporativo
+- `trigger/fix-ci.json` → correção de lint no repo corporativo
+- `trigger/full-test.json` → teste full flow
+
+### B. workflow_dispatch (quando necessário)
+
+- Disparar workflow com `workspace_id` explícito.
+- Nunca omitir `workspace_id`.
+
+### C. Handoff entre agentes
+
+- Usar `enqueue-agent-handoff.yml` quando houver bloqueio, ambiguidade de contexto, ou necessidade de revisão arquitetural especializada.
+
+## 4) Critérios de pronto operacional para Codex
+
+O ambiente está em paridade operacional quando:
+
+- Codex consegue identificar workspace corretamente.
+- Codex respeita lock/session guard antes de mudança de estado.
+- Codex usa triggers/workflows sem hardcode de tenant.
+- Codex registra alterações via PR no repositório de control plane.
+- Codex aciona handoff ao Claude quando aplicável.
+
+## 5) Fluxo de melhoria contínua sem risco
+
+1. Priorizar melhorias em documentação, runbooks e checklists.
+2. Validar JSON/YAML alterados antes de commit.
+3. Executar checagens locais de sintaxe e consistência.
+4. Abrir PR com escopo pequeno e auditável.
+5. Não mesclar mudanças de refatoração ampla sem validação incremental.
+
+## 6) Referências canônicas
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `HANDOFF.md`
+- `ops/docs/workspace-separation.md`
+- `contracts/*.json`
+- `schemas/*.json`

--- a/ops/docs/github-ops.md
+++ b/ops/docs/github-ops.md
@@ -82,3 +82,20 @@ See CLAUDE.md for full workflow listing.
     workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
     service_account: ${{ secrets.GCP_SA_EMAIL }}
 ```
+
+## Automatic PR + Merge (Codex-safe)
+
+Para evitar idas e vindas manuais, use o script:
+
+```bash
+./ops/scripts/git/auto-pr-merge.sh "<commit_message>" "<pr_title>" "<pr_body>"
+```
+
+Ele executa, em sequência:
+1. `git diff --check` (sanidade)
+2. Commit automático (se houver mudanças)
+3. Push da branch atual
+4. Criação de PR (se ainda não existir)
+5. `gh pr merge --auto --squash --delete-branch`
+
+> Observação: o merge ocorre automaticamente quando os checks obrigatórios da branch protegida terminarem com sucesso.

--- a/ops/scripts/git/auto-pr-merge.sh
+++ b/ops/scripts/git/auto-pr-merge.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Automates: checks -> commit (if needed) -> push -> PR create/update -> auto-merge enable.
+# Usage:
+#   ./ops/scripts/git/auto-pr-merge.sh "feat: message" "PR title" "PR body"
+
+COMMIT_MSG="${1:-}"
+PR_TITLE="${2:-}"
+PR_BODY="${3:-}"
+
+if [[ -z "$COMMIT_MSG" || -z "$PR_TITLE" || -z "$PR_BODY" ]]; then
+  echo "Usage: $0 \"<commit_message>\" \"<pr_title>\" \"<pr_body>\""
+  exit 1
+fi
+
+BRANCH="$(git branch --show-current)"
+if [[ "$BRANCH" == "main" ]]; then
+  echo "Refusing to run on main. Create/use a feature branch first."
+  exit 1
+fi
+
+# Safety check: whitespace/conflict markers
+if ! git diff --check >/dev/null; then
+  echo "git diff --check failed. Resolve issues before continuing."
+  exit 1
+fi
+
+# Commit only when there are staged/unstaged changes
+if [[ -n "$(git status --porcelain)" ]]; then
+  git add -A
+  git commit -m "$COMMIT_MSG"
+fi
+
+git push -u origin "$BRANCH"
+
+# Create PR if missing; otherwise continue with existing PR
+if ! gh pr view --json number >/dev/null 2>&1; then
+  gh pr create --title "$PR_TITLE" --body "$PR_BODY"
+fi
+
+# Enable auto-merge (squash). If branch protections block it, gh returns non-zero.
+gh pr merge --auto --squash --delete-branch
+
+echo "Done: PR is configured for auto-merge when required checks pass."


### PR DESCRIPTION
### Motivation

- Centralize control-plane documentation and operational artifacts for the Autopilot project in a single, GitHub-native repo. 
- Provide a safe, prescriptive operational parity flow so `Codex` can operate with the same discipline as `Claude` without changing existing pipelines. 
- Reduce manual PR/merge overhead for small, auditable changes by offering an automated safe path to create and enable auto-merge for PRs.

### Description

- Replace and expand `README.md` with a project overview, branch roles, workspace guidance, and operation pointers, including references to agent runbooks and lock checks. 
- Add `ops/docs/agent-operational-parity.md` containing a mandatory pre-operation checklist, principles to avoid breaking pipelines, trigger/workflow guidance, and handoff criteria. 
- Add `ops/scripts/git/auto-pr-merge.sh`, a safety-first automation script that runs `git diff --check`, commits changes, pushes the branch, creates a PR with `gh`, and invokes `gh pr merge --auto --squash --delete-branch`. 
- Update `ops/docs/github-ops.md` to document the `auto-pr-merge.sh` usage and its expected behavior.

### Testing

- No automated tests or CI jobs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c41c64b950832da0e8dd48d859dc56)