### PR TITLE
feat: agent-bridge workflow Claude ↔ Codex

### DIFF
--- a/.github/workflows/agent-bridge.yml
+++ b/.github/workflows/agent-bridge.yml
@@ -1,0 +1,331 @@
+name: "[Agent] Bridge: Claude ↔ Codex"
+
+# Ponte entre agentes via OpenAI API.
+# Claude envia tarefas para Codex e recebe respostas.
+# Respostas salvas no autopilot-state para leitura posterior.
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Tarefa para o Codex executar"
+        required: true
+        type: string
+      context:
+        description: "Contexto adicional (JSON ou texto)"
+        required: false
+        default: ""
+      workspace_id:
+        description: "Workspace ID"
+        required: false
+        default: "ws-default"
+      model:
+        description: "Modelo OpenAI"
+        required: false
+        default: "o3"
+        type: choice
+        options:
+          - o3
+          - o4-mini
+          - gpt-4.1
+          - codex-mini
+      include_session_memory:
+        description: "Incluir session memory no contexto"
+        required: false
+        default: true
+        type: boolean
+      include_patches:
+        description: "Incluir patches/ no contexto"
+        required: false
+        default: false
+        type: boolean
+  push:
+    branches: [main]
+    paths: ['trigger/agent-bridge.json']
+
+permissions:
+  contents: write
+
+env:
+  AUTOPILOT_REPO: lucassfreiree/autopilot
+  STATE_BRANCH: autopilot-state
+
+jobs:
+  bridge:
+    name: "Send task to Codex"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Resolve inputs"
+        id: cfg
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "push" ] && [ -f trigger/agent-bridge.json ]; then
+            TRIG=$(cat trigger/agent-bridge.json)
+            TASK=$(echo "$TRIG" | jq -r '.task // ""')
+            CONTEXT=$(echo "$TRIG" | jq -r '.context // ""')
+            WS_ID=$(echo "$TRIG" | jq -r '.workspace_id // "ws-default"')
+            MODEL=$(echo "$TRIG" | jq -r '.model // "o3"')
+            INCLUDE_MEMORY=$(echo "$TRIG" | jq -r '.include_session_memory // true')
+            INCLUDE_PATCHES=$(echo "$TRIG" | jq -r '.include_patches // false')
+          else
+            TASK="${{ inputs.task }}"
+            CONTEXT="${{ inputs.context }}"
+            WS_ID="${{ inputs.workspace_id }}"
+            MODEL="${{ inputs.model }}"
+            INCLUDE_MEMORY="${{ inputs.include_session_memory }}"
+            INCLUDE_PATCHES="${{ inputs.include_patches }}"
+          fi
+
+          echo "task<<TASK_EOF" >> "$GITHUB_OUTPUT"
+          echo "$TASK" >> "$GITHUB_OUTPUT"
+          echo "TASK_EOF" >> "$GITHUB_OUTPUT"
+
+          echo "context<<CTX_EOF" >> "$GITHUB_OUTPUT"
+          echo "$CONTEXT" >> "$GITHUB_OUTPUT"
+          echo "CTX_EOF" >> "$GITHUB_OUTPUT"
+
+          echo "ws_id=$WS_ID" >> "$GITHUB_OUTPUT"
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+          echo "include_memory=$INCLUDE_MEMORY" >> "$GITHUB_OUTPUT"
+          echo "include_patches=$INCLUDE_PATCHES" >> "$GITHUB_OUTPUT"
+
+          echo "::notice ::Task: $TASK | Model: $MODEL | WS: $WS_ID"
+
+      - name: "Build system prompt"
+        id: prompt
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          SYSTEM_PROMPT="You are Codex, an AI coding agent operating inside the Autopilot control plane (lucassfreiree/autopilot).
+
+          ## YOUR ROLE
+          - Code implementation, refactoring, security patching, CI monitoring
+          - You collaborate with Claude Code (another AI agent on the same repo)
+          - Your responses are saved to autopilot-state branch for Claude to read
+
+          ## CURRENT STATE
+          - Workspace: ${{ steps.cfg.outputs.ws_id }}
+          - Controller version: $(jq -r '.versioningRules.currentVersion // "unknown"' contracts/claude-session-memory.json 2>/dev/null || echo 'unknown')
+          - Last deploy status: $(jq -r '.deployFlow.pipelineStatus // "unknown"' contracts/claude-session-memory.json 2>/dev/null | head -c 200 || echo 'unknown')
+          "
+
+          # Include session memory if requested
+          if [ "${{ steps.cfg.outputs.include_memory }}" = "true" ]; then
+            MEMORY=$(cat contracts/claude-session-memory.json 2>/dev/null | jq -c '.' || echo '{}')
+            SYSTEM_PROMPT="$SYSTEM_PROMPT
+
+          ## SESSION MEMORY (shared with Claude)
+          $MEMORY"
+          fi
+
+          # Include patches if requested
+          if [ "${{ steps.cfg.outputs.include_patches }}" = "true" ]; then
+            PATCHES_LIST=$(ls patches/*.ts 2>/dev/null | head -10 || echo "none")
+            SYSTEM_PROMPT="$SYSTEM_PROMPT
+
+          ## PATCHES IN REPO
+          $PATCHES_LIST"
+
+            for f in patches/*.ts; do
+              if [ -f "$f" ] && [ "$(wc -c < "$f")" -lt 50000 ]; then
+                SYSTEM_PROMPT="$SYSTEM_PROMPT
+
+          ### $(basename $f)
+          $(cat "$f")"
+              fi
+            done
+          fi
+
+          # Include Codex contract
+          if [ -f contracts/codex-agent-contract.json ]; then
+            SYSTEM_PROMPT="$SYSTEM_PROMPT
+
+          ## YOUR CONTRACT
+          $(cat contracts/codex-agent-contract.json)"
+          fi
+
+          # Save to file (avoid shell quoting issues)
+          echo "$SYSTEM_PROMPT" > /tmp/system-prompt.txt
+          echo "Prompt size: $(wc -c < /tmp/system-prompt.txt) bytes"
+
+      - name: "Call OpenAI API"
+        id: call
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          MODEL="${{ steps.cfg.outputs.model }}"
+          TASK="${{ steps.cfg.outputs.task }}"
+          CONTEXT="${{ steps.cfg.outputs.context }}"
+
+          SYSTEM=$(cat /tmp/system-prompt.txt)
+
+          USER_MSG="## TASK
+          $TASK"
+
+          if [ -n "$CONTEXT" ]; then
+            USER_MSG="$USER_MSG
+
+          ## ADDITIONAL CONTEXT
+          $CONTEXT"
+          fi
+
+          # Build JSON payload
+          PAYLOAD=$(jq -n \
+            --arg model "$MODEL" \
+            --arg system "$SYSTEM" \
+            --arg user "$USER_MSG" \
+            '{
+              model: $model,
+              input: [
+                { role: "system", content: $system },
+                { role: "user", content: $user }
+              ],
+              max_output_tokens: 16000
+            }')
+
+          echo "Calling OpenAI API (model: $MODEL)..."
+          echo "Task: $TASK"
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            "https://api.openai.com/v1/responses" \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            --max-time 120)
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          echo "HTTP Status: $HTTP_CODE"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error ::OpenAI API returned $HTTP_CODE"
+            echo "$BODY" | jq '.' 2>/dev/null || echo "$BODY"
+
+            # Fallback to chat completions API
+            echo "Trying fallback to chat completions API..."
+            PAYLOAD_FALLBACK=$(jq -n \
+              --arg model "$MODEL" \
+              --arg system "$SYSTEM" \
+              --arg user "$USER_MSG" \
+              '{
+                model: $model,
+                messages: [
+                  { role: "system", content: $system },
+                  { role: "user", content: $user }
+                ],
+                max_tokens: 16000
+              }')
+
+            RESPONSE=$(curl -s -w "\n%{http_code}" \
+              "https://api.openai.com/v1/chat/completions" \
+              -H "Authorization: Bearer $OPENAI_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD_FALLBACK" \
+              --max-time 120)
+
+            HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+            BODY=$(echo "$RESPONSE" | sed '$d')
+            echo "Fallback HTTP Status: $HTTP_CODE"
+
+            if [ "$HTTP_CODE" != "200" ]; then
+              echo "::error ::Both APIs failed"
+              echo "$BODY" > /tmp/codex-response.json
+              exit 1
+            fi
+
+            # Extract from chat completions format
+            CONTENT=$(echo "$BODY" | jq -r '.choices[0].message.content // "No response"')
+            echo "$CONTENT" > /tmp/codex-response.txt
+            echo "$BODY" > /tmp/codex-response.json
+          else
+            # Extract from responses API format
+            CONTENT=$(echo "$BODY" | jq -r '.output[0].content[0].text // .output // "No response"' 2>/dev/null || echo "$BODY")
+            echo "$CONTENT" > /tmp/codex-response.txt
+            echo "$BODY" > /tmp/codex-response.json
+          fi
+
+          echo ""
+          echo "=== CODEX RESPONSE (first 500 chars) ==="
+          head -c 500 /tmp/codex-response.txt
+          echo ""
+
+      - name: "Save response to autopilot-state"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          WS_ID="${{ steps.cfg.outputs.ws_id }}"
+          TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
+
+          # Prepare response file
+          RESPONSE_FILE="state/workspaces/$WS_ID/agent-bridge-response-$TIMESTAMP.json"
+
+          jq -n \
+            --arg task "${{ steps.cfg.outputs.task }}" \
+            --arg model "${{ steps.cfg.outputs.model }}" \
+            --arg ws_id "$WS_ID" \
+            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg run_id "${{ github.run_id }}" \
+            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --rawfile response /tmp/codex-response.txt \
+            --rawfile raw_json /tmp/codex-response.json \
+            '{
+              type: "agent-bridge-response",
+              from: "codex",
+              to: "claude",
+              task: $task,
+              model: $model,
+              workspaceId: $ws_id,
+              timestamp: $timestamp,
+              runId: $run_id,
+              runUrl: $run_url,
+              response: $response,
+              rawApiResponse: ($raw_json | fromjson? // $raw_json)
+            }' > /tmp/response-payload.json
+
+          # Clone state branch and save
+          git clone --depth 1 --branch "${{ env.STATE_BRANCH }}" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ env.AUTOPILOT_REPO }}.git" \
+            /tmp/state-repo
+
+          mkdir -p "/tmp/state-repo/state/workspaces/$WS_ID"
+          cp /tmp/response-payload.json "/tmp/state-repo/$RESPONSE_FILE"
+
+          # Also save as "latest" for easy access
+          cp /tmp/response-payload.json "/tmp/state-repo/state/workspaces/$WS_ID/agent-bridge-latest.json"
+
+          cd /tmp/state-repo
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add .
+          git commit -m "agent-bridge: codex response for '${{ steps.cfg.outputs.task }}' [$TIMESTAMP]" || echo "No changes"
+          git push || echo "Push failed — will retry"
+
+      - name: "Summary"
+        if: always()
+        run: |
+          echo "## Agent Bridge: Claude ↔ Codex" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Task:** ${{ steps.cfg.outputs.task }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Model:** ${{ steps.cfg.outputs.model }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Workspace:** ${{ steps.cfg.outputs.ws_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f /tmp/codex-response.txt ]; then
+            echo "### Codex Response" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            head -c 2000 /tmp/codex-response.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Response saved to \`autopilot-state\` branch as \`agent-bridge-latest.json\`" >> $GITHUB_STEP_SUMMARY

--- a/trigger/agent-bridge.json
+++ b/trigger/agent-bridge.json
@@ -1,0 +1,10 @@
+{
+  "_context": "SHARED | all workspaces",
+  "workspace_id": "ws-default",
+  "task": "Review current patches in patches/ directory and suggest improvements for security and code quality",
+  "context": "",
+  "model": "o3",
+  "include_session_memory": true,
+  "include_patches": false,
+  "run": 1
+}


### PR DESCRIPTION
## Summary
- New workflow `agent-bridge.yml` — ponte Claude ↔ Codex via OpenAI API
- Trigger file `trigger/agent-bridge.json`
- Uses `OPENAI_API_KEY` secret (already configured)
- Supports Responses API (o3, o4-mini) with Chat Completions fallback
- Response saved to `autopilot-state` as `agent-bridge-latest.json`

## Flow
```
Claude creates task → edits trigger/agent-bridge.json → merge to main
→ workflow calls OpenAI API with context (session memory + patches)
→ Codex response saved to autopilot-state
→ Claude reads response via git fetch autopilot-state
```

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK