### PR TITLE
fix: agent-bridge use git add -f to bypass .gitignore on state branch…

### DIFF
--- a/.github/workflows/agent-bridge.yml
+++ b/.github/workflows/agent-bridge.yml
@@ -187,7 +187,7 @@ jobs:
           cd state_branch
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add state/bridges/agent-bridge-latest.json
+          git add -f state/bridges/agent-bridge-latest.json
           if git diff --cached --quiet; then
             echo "No state changes"
           else

--- a/trigger/agent-bridge.json
+++ b/trigger/agent-bridge.json
@@ -6,5 +6,5 @@
   "model": "o3",
   "include_session_memory": true,
   "include_patches": true,
-  "run": 5
+  "run": 6
 }


### PR DESCRIPTION
… (run 6)

The autopilot-state branch has state/ in .gitignore of main branch context. Using git add -f forces the add regardless of .gitignore rules.

https://claude.ai/code/session_01WNCzT7nhQbajAjtvmqDgvK