### PR TITLE
fix: bridge workflow failing due to state/ in .gitignore

### DIFF
--- a/.github/workflows/agent-bridge.yml
+++ b/.github/workflows/agent-bridge.yml
@@ -187,7 +187,10 @@ jobs:
           cd state_branch
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add -f state/bridges/agent-bridge-latest.json
+          # Remove state/ from .gitignore — this branch exists to store state
+          sed -i '/^state\//d' .gitignore 2>/dev/null || true
+          git add .gitignore 2>/dev/null || true
+          git add state/bridges/agent-bridge-latest.json
           if git diff --cached --quiet; then
             echo "No state changes"
           else


### PR DESCRIPTION
## Summary\n- Fix bridge workflow failing at \"Save bridge response to autopilot-state\" step\n- Root cause: `autopilot-state` branch has `state/` in `.gitignore` (inherited from main), but that branch exists to store state\n- Fix: remove `state/` from `.gitignore` before `git add` in the save step\n\n## Test plan\n- [ ] Re-run bridge workflow and verify it completes successfully\n\nhttps://claude.ai/code/session_012cNnHgdpbkEg8HWMgkyEqC