### PR TITLE
feat: codex-apply workflow — Codex can commit code via PR

### DIFF
--- a/.github/workflows/codex-apply.yml
+++ b/.github/workflows/codex-apply.yml
@@ -1,0 +1,510 @@
+name: "[Agent] Codex Apply: Task → Code → PR"
+run-name: "Codex Apply • run=${{ github.event.inputs.run || 'push' }}"
+
+on:
+  push:
+    branches: [main]
+    paths: ['trigger/codex-commit.json']
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task for Codex to implement"
+        required: true
+        type: string
+      target_files:
+        description: "Comma-separated file paths to modify (e.g., src/index.ts,README.md)"
+        required: false
+        type: string
+      model:
+        description: "OpenAI model to use"
+        required: false
+        default: "o3"
+      auto_merge:
+        description: "Auto-merge PR after creation"
+        required: false
+        type: boolean
+        default: false
+      run:
+        description: "Run number (for tracking)"
+        required: false
+        default: "manual"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-apply
+  cancel-in-progress: true
+
+env:
+  REPO: lucassfreiree/autopilot
+
+jobs:
+  codex-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Load config
+        id: cfg
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ] && [ -f trigger/codex-commit.json ]; then
+            TASK=$(jq -r '.task // ""' trigger/codex-commit.json)
+            MODEL=$(jq -r '.model // "o3"' trigger/codex-commit.json)
+            TARGET_FILES=$(jq -r '.target_files // ""' trigger/codex-commit.json)
+            AUTO_MERGE=$(jq -r '.auto_merge // false' trigger/codex-commit.json)
+            RUN=$(jq -r '.run // 0' trigger/codex-commit.json)
+            BRANCH_SUFFIX=$(jq -r '.branch_suffix // ""' trigger/codex-commit.json)
+          else
+            TASK="${{ github.event.inputs.task }}"
+            MODEL="${{ github.event.inputs.model || 'o3' }}"
+            TARGET_FILES="${{ github.event.inputs.target_files }}"
+            AUTO_MERGE="${{ github.event.inputs.auto_merge || 'false' }}"
+            RUN="${{ github.event.inputs.run || 'manual' }}"
+            BRANCH_SUFFIX=""
+          fi
+
+          if [ -z "$BRANCH_SUFFIX" ]; then
+            BRANCH_SUFFIX="task-$(date +%Y%m%d-%H%M%S)"
+          fi
+
+          echo "task<<TASKEOF" >> $GITHUB_OUTPUT
+          echo "$TASK" >> $GITHUB_OUTPUT
+          echo "TASKEOF" >> $GITHUB_OUTPUT
+          echo "model=$MODEL" >> $GITHUB_OUTPUT
+          echo "target_files=$TARGET_FILES" >> $GITHUB_OUTPUT
+          echo "auto_merge=$AUTO_MERGE" >> $GITHUB_OUTPUT
+          echo "run=$RUN" >> $GITHUB_OUTPUT
+          echo "branch_suffix=$BRANCH_SUFFIX" >> $GITHUB_OUTPUT
+
+      - name: Resolve model
+        id: model
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          REQUESTED_MODEL: ${{ steps.cfg.outputs.model }}
+        run: |
+          set -euo pipefail
+          CANDIDATES=("o3" "o3-mini" "o1" "gpt-4o" "gpt-4.1" "gpt-4-turbo" "gpt-3.5-turbo")
+          MODELS_JSON=$(curl -sS https://api.openai.com/v1/models \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -H "Content-Type: application/json" 2>/dev/null || echo '{}')
+
+          if ! echo "$MODELS_JSON" | jq -e '.data' >/dev/null 2>&1; then
+            echo "selected=$REQUESTED_MODEL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          AVAILABLE=$(echo "$MODELS_JSON" | jq -r '.data[].id')
+          SELECTED=""
+          if echo "$AVAILABLE" | grep -Fxq "$REQUESTED_MODEL"; then
+            SELECTED="$REQUESTED_MODEL"
+          else
+            for m in "${CANDIDATES[@]}"; do
+              if echo "$AVAILABLE" | grep -Fxq "$m"; then
+                SELECTED="$m"
+                break
+              fi
+            done
+          fi
+          echo "selected=${SELECTED:-$REQUESTED_MODEL}" >> "$GITHUB_OUTPUT"
+
+      - name: Read target files content
+        id: context
+        run: |
+          set -euo pipefail
+          TARGET_FILES="${{ steps.cfg.outputs.target_files }}"
+          FILE_CONTEXT=""
+
+          if [ -n "$TARGET_FILES" ]; then
+            IFS=',' read -ra FILES <<< "$TARGET_FILES"
+            for f in "${FILES[@]}"; do
+              f=$(echo "$f" | xargs)  # trim whitespace
+              if [ -f "$f" ]; then
+                CONTENT=$(cat "$f")
+                FILE_CONTEXT="${FILE_CONTEXT}
+--- FILE: ${f} ---
+${CONTENT}
+--- END FILE: ${f} ---
+"
+              else
+                FILE_CONTEXT="${FILE_CONTEXT}
+--- FILE: ${f} (NEW FILE — does not exist yet) ---
+--- END FILE: ${f} ---
+"
+              fi
+            done
+          fi
+
+          # Save to temp file to avoid shell escaping issues
+          echo "$FILE_CONTEXT" > /tmp/file-context.txt
+          echo "has_context=$([ -n "$TARGET_FILES" ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+
+      - name: Call OpenAI for code changes
+        id: codex
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MODEL: ${{ steps.model.outputs.selected }}
+          TASK: ${{ steps.cfg.outputs.task }}
+        run: |
+          set -euo pipefail
+
+          FILE_CONTEXT=$(cat /tmp/file-context.txt 2>/dev/null || echo "")
+
+          SYSTEM_PROMPT='You are Codex, an expert software engineer. You receive tasks and return ONLY valid JSON with file changes.
+
+RESPONSE FORMAT (strict JSON, no markdown, no explanation outside JSON):
+{
+  "branch_name": "codex/short-descriptive-name",
+  "commit_message": "type: short description",
+  "pr_title": "Short PR title (under 70 chars)",
+  "pr_body": "## Summary\n- bullet points of changes",
+  "changes": [
+    {
+      "action": "create|modify|delete",
+      "path": "relative/path/to/file",
+      "content": "full file content here (for create/modify)"
+    }
+  ]
+}
+
+RULES:
+- action "create": new file, provide full content
+- action "modify": existing file, provide FULL new content (not a diff)
+- action "delete": remove file, no content needed
+- branch_name MUST start with "codex/"
+- commit_message follows conventional commits (feat:, fix:, chore:, docs:, refactor:)
+- Return ONLY the JSON object, nothing else
+- Content must be valid for the file type
+- Never include secrets, tokens, or credentials in content'
+
+          USER_PROMPT="TASK: ${TASK}"
+          if [ -n "$FILE_CONTEXT" ]; then
+            USER_PROMPT="${USER_PROMPT}
+
+CURRENT FILE CONTENTS:
+${FILE_CONTEXT}"
+          fi
+
+          # Build request JSON safely using jq
+          REQ=$(jq -n \
+            --arg model "$MODEL" \
+            --arg system "$SYSTEM_PROMPT" \
+            --arg user "$USER_PROMPT" \
+            '{
+              model: $model,
+              input: [
+                {role: "system", content: $system},
+                {role: "user", content: $user}
+              ],
+              text: {format: {type: "text"}}
+            }')
+
+          HTTP_CODE=$(curl -sS -o /tmp/codex-response.json -w "%{http_code}" \
+            https://api.openai.com/v1/responses \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$REQ")
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error ::OpenAI API returned HTTP $HTTP_CODE"
+            cat /tmp/codex-response.json
+            echo "status=failed" >> $GITHUB_OUTPUT
+            echo "error=OpenAI API returned HTTP $HTTP_CODE" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Extract text content from response
+          RESPONSE_TEXT=$(jq -r '.output[]? | select(.type=="message") | .content[]? | select(.type=="output_text") | .text // empty' /tmp/codex-response.json 2>/dev/null || echo "")
+
+          if [ -z "$RESPONSE_TEXT" ]; then
+            # Fallback: try choices format
+            RESPONSE_TEXT=$(jq -r '.choices[0].message.content // empty' /tmp/codex-response.json 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$RESPONSE_TEXT" ]; then
+            echo "::error ::Could not extract response text from OpenAI"
+            jq '.' /tmp/codex-response.json
+            echo "status=failed" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Clean markdown code fences if present
+          CLEAN_JSON=$(echo "$RESPONSE_TEXT" | sed 's/^```json//;s/^```//;s/```$//' | sed '/^$/d')
+          echo "$CLEAN_JSON" > /tmp/codex-changes.json
+
+          # Validate JSON structure
+          if ! jq -e '.changes' /tmp/codex-changes.json >/dev/null 2>&1; then
+            echo "::error ::Codex response is not valid JSON with changes array"
+            echo "$CLEAN_JSON" | head -50
+            echo "status=failed" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          BRANCH=$(jq -r '.branch_name // "codex/auto-task"' /tmp/codex-changes.json)
+          COMMIT_MSG=$(jq -r '.commit_message // "chore: codex auto-commit"' /tmp/codex-changes.json)
+          PR_TITLE=$(jq -r '.pr_title // "Codex: auto-generated changes"' /tmp/codex-changes.json)
+          PR_BODY=$(jq -r '.pr_body // "Auto-generated by Codex agent"' /tmp/codex-changes.json)
+          NUM_CHANGES=$(jq '.changes | length' /tmp/codex-changes.json)
+
+          # Ensure branch starts with codex/
+          if [[ ! "$BRANCH" =~ ^codex/ ]]; then
+            BRANCH="codex/$BRANCH"
+          fi
+
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "commit_msg=$COMMIT_MSG" >> $GITHUB_OUTPUT
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+          echo "num_changes=$NUM_CHANGES" >> $GITHUB_OUTPUT
+          echo "status=success" >> $GITHUB_OUTPUT
+
+          # Save PR body to file (multiline)
+          echo "$PR_BODY" > /tmp/pr-body.txt
+
+          echo "::notice ::Codex generated $NUM_CHANGES file change(s) for branch $BRANCH"
+
+      - name: Apply changes and create branch
+        if: steps.codex.outputs.status == 'success'
+        id: apply
+        run: |
+          set -euo pipefail
+
+          BRANCH="${{ steps.codex.outputs.branch }}"
+          COMMIT_MSG="${{ steps.codex.outputs.commit_msg }}"
+
+          # Create branch
+          git checkout -B "$BRANCH"
+
+          # Apply each change
+          NUM_CHANGES=$(jq '.changes | length' /tmp/codex-changes.json)
+          APPLIED=0
+
+          for i in $(seq 0 $((NUM_CHANGES - 1))); do
+            ACTION=$(jq -r ".changes[$i].action" /tmp/codex-changes.json)
+            FILE_PATH=$(jq -r ".changes[$i].path" /tmp/codex-changes.json)
+
+            # Security: reject paths with .. or absolute paths
+            if [[ "$FILE_PATH" == /* ]] || [[ "$FILE_PATH" == *..* ]]; then
+              echo "::warning ::Skipping suspicious path: $FILE_PATH"
+              continue
+            fi
+
+            case "$ACTION" in
+              create|modify)
+                mkdir -p "$(dirname "$FILE_PATH")"
+                jq -r ".changes[$i].content // \"\"" /tmp/codex-changes.json > "$FILE_PATH"
+                git add "$FILE_PATH"
+                echo "✅ $ACTION: $FILE_PATH"
+                APPLIED=$((APPLIED + 1))
+                ;;
+              delete)
+                if [ -f "$FILE_PATH" ]; then
+                  git rm "$FILE_PATH"
+                  echo "🗑️ delete: $FILE_PATH"
+                  APPLIED=$((APPLIED + 1))
+                else
+                  echo "::warning ::File not found for deletion: $FILE_PATH"
+                fi
+                ;;
+              *)
+                echo "::warning ::Unknown action '$ACTION' for $FILE_PATH"
+                ;;
+            esac
+          done
+
+          if [ "$APPLIED" -eq 0 ]; then
+            echo "::error ::No changes were applied"
+            echo "applied=0" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Commit
+          git config user.name "codex-agent"
+          git config user.email "codex-agent@github.com"
+          git commit -m "$COMMIT_MSG
+
+Co-authored-by: codex-agent <codex-agent@github.com>
+Triggered-by: codex-apply workflow run ${{ steps.cfg.outputs.run }}"
+
+          # Push
+          git push -u origin "$BRANCH" --force
+
+          echo "applied=$APPLIED" >> $GITHUB_OUTPUT
+          echo "::notice ::Applied $APPLIED change(s) and pushed to $BRANCH"
+
+      - name: Create Pull Request
+        if: steps.codex.outputs.status == 'success' && steps.apply.outputs.applied != '0'
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = '${{ steps.codex.outputs.branch }}';
+            const title = '${{ steps.codex.outputs.pr_title }}';
+            const prBodyFile = fs.readFileSync('/tmp/pr-body.txt', 'utf8');
+
+            const body = `${prBodyFile}
+
+            ---
+            🤖 **Auto-generated by Codex Agent**
+            - Model: \`${{ steps.model.outputs.selected }}\`
+            - Run: \`${{ steps.cfg.outputs.run }}\`
+            - Task: ${{ steps.cfg.outputs.task }}
+            - Changes applied: ${{ steps.apply.outputs.applied }}`;
+
+            // Check for existing PR
+            const { data: pulls } = await github.rest.pulls.list({
+              owner, repo, state: 'open', head: `${owner}:${branch}`, base: 'main', per_page: 1
+            });
+
+            let pr;
+            if (pulls.length > 0) {
+              pr = pulls[0];
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, title, body });
+              core.notice(`Updated existing PR #${pr.number}`);
+            } else {
+              const created = await github.rest.pulls.create({
+                owner, repo, title, head: branch, base: 'main', body
+              });
+              pr = created.data;
+              core.notice(`Created PR #${pr.number}`);
+            }
+
+            // Add labels
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: ['codex', 'auto-pr']
+              });
+            } catch (e) {
+              core.warning(`Labeling failed: ${e.message}`);
+            }
+
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('pr_url', pr.html_url);
+            core.setOutput('pr_node_id', pr.node_id);
+
+      - name: Auto-merge PR
+        if: steps.cfg.outputs.auto_merge == 'true' && steps.pr.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = parseInt('${{ steps.pr.outputs.pr_number }}');
+
+            try {
+              // Squash merge directly
+              await github.rest.pulls.merge({
+                owner, repo, pull_number: prNumber, merge_method: 'squash'
+              });
+              core.notice(`PR #${prNumber} merged successfully`);
+            } catch (e) {
+              core.warning(`Auto-merge failed (may need manual merge): ${e.message}`);
+              // Fallback: try enable auto-merge
+              try {
+                const prNodeId = '${{ steps.pr.outputs.pr_node_id }}';
+                await github.graphql(`
+                  mutation($pullRequestId: ID!) {
+                    enablePullRequestAutoMerge(input: {
+                      pullRequestId: $pullRequestId,
+                      mergeMethod: SQUASH
+                    }) { pullRequest { number } }
+                  }
+                `, { pullRequestId: prNodeId });
+                core.notice(`Auto-merge enabled for PR #${prNumber}`);
+              } catch (e2) {
+                core.warning(`Enable auto-merge also failed: ${e2.message}`);
+              }
+            }
+
+      - name: Save result to autopilot-state
+        if: always()
+        run: |
+          set -euo pipefail
+
+          STATUS="${{ steps.codex.outputs.status || 'failed' }}"
+          PR_URL="${{ steps.pr.outputs.pr_url || 'none' }}"
+          PR_NUMBER="${{ steps.pr.outputs.pr_number || '0' }}"
+          APPLIED="${{ steps.apply.outputs.applied || '0' }}"
+
+          RESULT=$(jq -n \
+            --arg status "$STATUS" \
+            --arg model "${{ steps.model.outputs.selected }}" \
+            --arg run "${{ steps.cfg.outputs.run }}" \
+            --arg task "${{ steps.cfg.outputs.task }}" \
+            --arg branch "${{ steps.codex.outputs.branch || 'none' }}" \
+            --arg pr_url "$PR_URL" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg changes_applied "$APPLIED" \
+            --arg auto_merge "${{ steps.cfg.outputs.auto_merge }}" \
+            '{
+              status: $status,
+              model: $model,
+              run: $run,
+              task: $task,
+              branch: $branch,
+              pr_url: $pr_url,
+              pr_number: ($pr_number | tonumber),
+              changes_applied: ($changes_applied | tonumber),
+              auto_merge: ($auto_merge == "true"),
+              updatedAt: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+            }')
+
+          echo "$RESULT" > /tmp/codex-apply-result.json
+
+      - name: Checkout state branch
+        if: always()
+        uses: actions/checkout@v4
+        with:
+          ref: autopilot-state
+          path: state_branch
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Save to autopilot-state
+        if: always()
+        run: |
+          mkdir -p state_branch/state/bridges
+          cp /tmp/codex-apply-result.json state_branch/state/bridges/codex-apply-latest.json 2>/dev/null || true
+          cp /tmp/codex-changes.json state_branch/state/bridges/codex-apply-changes.json 2>/dev/null || true
+          cd state_branch
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          sed -i '/^state\//d' .gitignore 2>/dev/null || true
+          git add .gitignore 2>/dev/null || true
+          git add state/bridges/ 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No state changes"
+          else
+            git commit -m "chore: update codex-apply result (run ${{ steps.cfg.outputs.run }})"
+            git push origin autopilot-state
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Codex Apply Results"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Run | \`${{ steps.cfg.outputs.run }}\` |"
+            echo "| Model | \`${{ steps.model.outputs.selected }}\` |"
+            echo "| Status | \`${{ steps.codex.outputs.status || 'failed' }}\` |"
+            echo "| Branch | \`${{ steps.codex.outputs.branch || 'n/a' }}\` |"
+            echo "| Changes Applied | \`${{ steps.apply.outputs.applied || '0' }}\` |"
+            echo "| PR | ${{ steps.pr.outputs.pr_url || 'none' }} |"
+            echo "| Auto-merge | \`${{ steps.cfg.outputs.auto_merge }}\` |"
+            echo ""
+            echo "### Task"
+            echo "${{ steps.cfg.outputs.task }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -12,7 +12,8 @@
     "ci-monitoring",
     "handoff-consumption",
     "pre-deploy-validation",
-    "security-patching"
+    "security-patching",
+    "direct-commits-via-codex-apply"
   ],
   "tools": {
     "primary": "codex-web",
@@ -60,9 +61,38 @@
         "gh pr merge {pr_number} --squash"
       ],
       "rules": [
-        "Branch DEVE comecar com claude/ (protecao de branch)",
+        "Branch DEVE comecar com claude/ ou codex/ (protecao de branch)",
         "SEMPRE squash merge",
         "NUNCA push direto para main (403)"
+      ]
+    },
+    "codexApplyWorkflow": {
+      "description": "Workflow que permite Codex fazer commits automaticamente via OpenAI API. Codex recebe a task, gera codigo, cria branch codex/*, commita, abre PR e opcionalmente faz auto-merge.",
+      "workflow": "codex-apply.yml",
+      "triggerFile": "trigger/codex-commit.json",
+      "triggerFormat": {
+        "task": "Descricao da tarefa para o Codex implementar",
+        "target_files": "Arquivos alvo separados por virgula (opcional — Codex ve o conteudo atual)",
+        "model": "Modelo OpenAI (default: o3)",
+        "branch_suffix": "Sufixo do branch codex/ (opcional)",
+        "auto_merge": "true para merge automatico, false para apenas criar PR",
+        "run": "Incrementar para disparar"
+      },
+      "flow": [
+        "1. Trigger file alterado em main (ou workflow_dispatch)",
+        "2. Workflow le task + arquivos alvo",
+        "3. Chama OpenAI com prompt estruturado pedindo JSON com changes",
+        "4. Codex retorna: branch_name, commit_message, pr_title, pr_body, changes[]",
+        "5. Workflow aplica changes (create/modify/delete files)",
+        "6. Cria branch codex/*, commita, push",
+        "7. Cria PR com labels [codex, auto-pr]",
+        "8. Se auto_merge=true: faz squash merge automatico",
+        "9. Resultado salvo em autopilot-state (state/bridges/codex-apply-latest.json)"
+      ],
+      "securityRules": [
+        "Paths com .. ou absolutos sao rejeitados",
+        "Commit identifica codex-agent como autor",
+        "Resultado auditado no autopilot-state"
       ]
     },
     "dispatchWorkflow": {

--- a/trigger/codex-commit.json
+++ b/trigger/codex-commit.json
@@ -1,0 +1,10 @@
+{
+  "_context": "SHARED | all workspaces | Codex agent commit automation",
+  "workspace_id": "ws-default",
+  "task": "Create a simple health-check script at ops/scripts/utils/health-ping.sh that checks if the GitHub API is reachable and returns OK/FAIL status",
+  "target_files": "",
+  "model": "o3",
+  "branch_suffix": "health-ping-script",
+  "auto_merge": false,
+  "run": 1
+}


### PR DESCRIPTION
## Summary
- New workflow `codex-apply.yml` that enables Codex to commit code via automated PR
- Codex receives a task, generates code changes via OpenAI API, creates `codex/*` branch, commits, and opens PR
- Supports auto-merge for fully autonomous operation
- Includes trigger file `trigger/codex-commit.json` for dispatch
- Updated `codex-agent-contract.json` with new capability documentation

## How it works
1. Edit `trigger/codex-commit.json` with task + bump `run`
2. Merge to main triggers `codex-apply.yml`
3. Workflow calls OpenAI with structured prompt requesting JSON changes
4. Applies file changes, creates branch `codex/*`, commits, creates PR
5. If `auto_merge: true`, squash merges automatically

## Test plan
- [ ] Trigger workflow via `trigger/codex-commit.json` (requires OpenAI quota)
- [ ] Verify PR creation with correct branch naming
- [ ] Verify auto-merge flow

https://claude.ai/code/session_012cNnHgdpbkEg8HWMgkyEqC