### PR TITLE
feat: enable controller CAP auto-promote (version tag mapping)

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -82,6 +82,10 @@ jobs:
       cap_branch: ${{ steps.cfg.outputs.cap_branch }}
       cap_values: ${{ steps.cfg.outputs.cap_values }}
       image_pattern: ${{ steps.cfg.outputs.image_pattern }}
+      controller_cap_repo: ${{ steps.cfg.outputs.controller_cap_repo }}
+      controller_cap_branch: ${{ steps.cfg.outputs.controller_cap_branch }}
+      controller_cap_values: ${{ steps.cfg.outputs.controller_cap_values }}
+      controller_image_pattern: ${{ steps.cfg.outputs.controller_image_pattern }}
     steps:
       - uses: actions/checkout@v4
       - name: "Read workspace config"
@@ -141,6 +145,10 @@ jobs:
           echo "cap_branch=$(echo "$WS_JSON" | jq -r '.agent.capBranch // "main"')" >> "$GITHUB_OUTPUT"
           echo "cap_values=$(echo "$WS_JSON" | jq -r '.agent.capValuesPath')" >> "$GITHUB_OUTPUT"
           echo "image_pattern=$(echo "$WS_JSON" | jq -r '.agent.imagePattern')" >> "$GITHUB_OUTPUT"
+          echo "controller_cap_repo=$(echo "$WS_JSON" | jq -r '.controller.capRepo // ""')" >> "$GITHUB_OUTPUT"
+          echo "controller_cap_branch=$(echo "$WS_JSON" | jq -r '.controller.capBranch // "main"')" >> "$GITHUB_OUTPUT"
+          echo "controller_cap_values=$(echo "$WS_JSON" | jq -r '.controller.capValuesPath // ""')" >> "$GITHUB_OUTPUT"
+          echo "controller_image_pattern=$(echo "$WS_JSON" | jq -r '.controller.imagePattern // ""')" >> "$GITHUB_OUTPUT"
           # Base64 encode file_content to avoid shell quoting issues
           echo "file_content_b64=$(echo "$FILE_CONTENT" | base64 -w0)" >> "$GITHUB_OUTPUT"
 
@@ -679,8 +687,8 @@ jobs:
       matrix:
         component: ${{ fromJson(needs.setup.outputs.components_json) }}
     outputs:
-      promoted: ${{ steps.cap.outputs.promoted }}
-      tag: ${{ steps.cap.outputs.tag }}
+      promoted: ${{ steps.cap.outputs.promoted || steps.cap_controller.outputs.promoted }}
+      tag: ${{ steps.cap.outputs.tag || steps.cap_controller.outputs.tag }}
     steps:
       - name: "Promote"
         id: cap
@@ -730,18 +738,60 @@ jobs:
             echo "promoted=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: "Skip (controller)"
+      - name: "Promote (controller)"
+        id: cap_controller
         if: matrix.component == 'controller'
+        env:
+          GH_TOKEN: ${{ secrets.BBVINET_TOKEN }}
         run: |
-          echo "Controller has no CAP promotion configured"
-          echo "promoted=skipped" >> "$GITHUB_OUTPUT"
+          CAP_REPO="${{ needs.setup.outputs.controller_cap_repo }}"
+          CAP_BRANCH="${{ needs.setup.outputs.controller_cap_branch }}"
+          CAP_VALUES="${{ needs.setup.outputs.controller_cap_values }}"
+          IMAGE_PATTERN="${{ needs.setup.outputs.controller_image_pattern }}"
+          SOURCE_REPO="${{ needs.apply-and-push.outputs.repo }}"
+
+          if [ -z "$CAP_REPO" ] || [ "$CAP_REPO" = "null" ] || [ "$CAP_REPO" = "" ]; then
+            echo "No controller CAP repo configured — skipping"
+            echo "promoted=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get version from source repo
+          VERSION=$(gh api "repos/$SOURCE_REPO/contents/package.json?ref=main" \
+            --jq '.content' | base64 -d | jq -r '.version')
+          TAG="$VERSION"
+          echo "=== Promoting controller $TAG to $CAP_REPO ==="
+
+          # Read current values.yaml
+          VALUES=$(gh api "repos/$CAP_REPO/contents/${CAP_VALUES}?ref=$CAP_BRANCH" --jq '.content' | base64 -d)
+          VSHA=$(gh api "repos/$CAP_REPO/contents/${CAP_VALUES}?ref=$CAP_BRANCH" --jq '.sha')
+          echo "=== Current values.yaml ===" && echo "$VALUES"
+
+          # Update image tag
+          UPDATED=$(echo "$VALUES" | sed "s|\(${IMAGE_PATTERN}\).*|\1${TAG}|")
+          [ "$VALUES" = "$UPDATED" ] && UPDATED=$(echo "$VALUES" | sed "s|^\(\s*tag:\s*\).*|\1\"${TAG}\"|")
+
+          if [ "$VALUES" != "$UPDATED" ]; then
+            echo "=== Updated values.yaml ===" && echo "$UPDATED"
+            gh api "repos/$CAP_REPO/contents/${CAP_VALUES}" --method PUT \
+              -f "branch=$CAP_BRANCH" \
+              -f "message=chore(release): controller -> ${TAG} (source change)" \
+              -f "content=$(echo "$UPDATED" | base64 -w0)" \
+              -f "sha=$VSHA"
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "Promoted controller to $TAG!"
+          else
+            echo "::warning ::Image pattern didn't match in controller values.yaml"
+            echo "promoted=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: "Summary"
         if: always()
         run: |
           echo "## 4. Promote (${{ matrix.component }})" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Promoted: ${{ steps.cap.outputs.promoted || 'skipped' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Tag: \`${{ steps.cap.outputs.tag || 'n/a' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Promoted: ${{ steps.cap.outputs.promoted || steps.cap_controller.outputs.promoted || 'skipped' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag: \`${{ steps.cap.outputs.tag || steps.cap_controller.outputs.tag || 'n/a' }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════════════════════════════════════════════════════
   #  STAGE 5 → Save State: record release state on autopilot-state

--- a/.github/workflows/check-repo-access.yml
+++ b/.github/workflows/check-repo-access.yml
@@ -36,6 +36,7 @@ jobs:
             "bbvinet/psc-sre-automacao-agent"
             "bbvinet/psc-sre-automacao-controller"
             "bbvinet/psc_releases_cap_sre-aut-agent"
+            "bbvinet/psc_releases_cap_sre-aut-controller"
           )
 
           RESULTS=()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Zero local dependencies. 100% GitHub-native.
 - `snapshots/` — Local state snapshots for rollback (e.g., `snapshots/20260321-214500/`)
 - `patches/` — Source code patches applied to corporate repos via apply-source-change pipeline
 - `references/` — Reference files from corporate repos not yet migrated to GitHub
-  - `references/controller-cap/values.yaml` — Controller CAP values.yaml (source: GitLab, image tag updated here)
+  - `references/controller-cap/values.yaml` — Controller CAP values.yaml (source: GitHub `bbvinet/psc_releases_cap_sre-aut-controller`, auto-promoted by Stage 4)
 - `ops/` — Operational environment (scripts, runbooks, templates, checklists)
   - `ops/ops-config.json` — Operational environment master config
   - `ops/scripts/` — Executable operational scripts by domain
@@ -152,7 +152,7 @@ Full separation guide: `ops/docs/workspace-separation.md`
 1. Esteira de Build NPM (runner corporativo) — monitorar via `ci-diagnose.yml`
 2. Logs reais: `ci-logs-controller-*.txt` no autopilot-state (NAO `ci-diagnosis-controller.json`)
 3. CI Gate pode passar com "pre-existing detection" mesmo quando esteira falha
-4. Controller CAP no GitLab — auto-promote NAO funciona ate migracao
+4. Controller CAP now on GitHub (`bbvinet/psc_releases_cap_sre-aut-controller`) — auto-promote ENABLED in Stage 4 after corporate CI passes
 
 ### CIT-Specific Rules
 1. Stack DevOps — foco em infraestrutura, automacao, containers, IaC
@@ -290,14 +290,17 @@ ops/terraform/
 9. Always validate jq output with fallbacks: `jq -r '.field // ""' 2>/dev/null || echo ""`
 10. Use base64 encoding when passing content between workflow jobs (avoids shell quoting issues)
 
-## Controller CAP (GitLab — not yet migrated to GitHub)
+## Controller CAP (GitHub — auto-promote enabled)
+- **CAP repo**: `bbvinet/psc_releases_cap_sre-aut-controller` (GitHub)
+- **CAP values path**: `releases/openshift/hml/deploy/values.yaml`
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
 - **Current deployed tag**: `3.6.3`
+- **Image line**: `image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:<TAG>`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
 - **Trusted caller**: namespace=`sgh-oaas-playbook-jobs`, serviceAccount=`default`, header=`x-techbb-namespace`/`x-techbb-service-account`
-- **Note**: This CAP repo is on GitLab, not GitHub. The autopilot pipeline cannot auto-promote controller releases until migration.
+- **Auto-promote**: Stage 4 of `apply-source-change.yml` updates tag in CAP repo **after corporate CI passes** (Esteira de Build NPM green). Reads `controller.capRepo` from `workspace.json`, uses `BBVINET_TOKEN` to commit via GitHub API.
 
 ## Workspaces
 
@@ -533,7 +536,7 @@ The corporate "Esteira de Build NPM" runs INDEPENDENTLY after code is pushed.
 1.5  Session Guard  → Acquire lock (blocks if another agent active)
 2.   Apply & Push   → Clone → Apply change → Fix lint → Push
 3.   CI Gate        → Wait CI + Smart comparison (pre-existing detection)
-4.   Promote        → Update CAP values.yaml
+4.   Promote        → Update CAP values.yaml (agent + controller — both auto-promote via GitHub API)
 5.   Save State     → Record on autopilot-state
 6.   Audit          → Audit trail + Release lock
 ```
@@ -601,7 +604,7 @@ Every new Claude Code session MUST:
 ### Workflow: check-repo-access.yml
 | Trigger | Secret Used | Repos Checked |
 |---------|-------------|---------------|
-| `workflow_dispatch` or push to `main` (self-path) | `BBVINET_TOKEN` | `bbvinet/psc-sre-automacao-agent`, `bbvinet/psc-sre-automacao-controller`, `bbvinet/psc_releases_cap_sre-aut-agent` |
+| `workflow_dispatch` or push to `main` (self-path) | `BBVINET_TOKEN` | `bbvinet/psc-sre-automacao-agent`, `bbvinet/psc-sre-automacao-controller`, `bbvinet/psc_releases_cap_sre-aut-agent`, `bbvinet/psc_releases_cap_sre-aut-controller` |
 
 ### Repository Secrets Available
 | Secret | Company | Purpose |

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -15,11 +15,12 @@
         "repos": [
           "bbvinet/psc-sre-automacao-controller",
           "bbvinet/psc-sre-automacao-agent",
-          "bbvinet/psc_releases_cap_sre-aut-agent"
+          "bbvinet/psc_releases_cap_sre-aut-agent",
+          "bbvinet/psc_releases_cap_sre-aut-controller"
         ],
         "status": "active",
         "lastDeploy": "3.6.3 (current deployed — security fixes)",
-        "notes": "Pipeline completo e funcional. Controller no GitLab (sem auto-promote). Esteira de Build NPM. Controller v3.6.3 operacional no cluster k8shmlbb111b (HML). Security fixes: XSS sanitizeForOutput, DoS MAX_RESULTS=1000, error detail hardening. Pre-deploy validation workflow criado."
+        "notes": "Pipeline completo e funcional. Controller CAP agora no GitHub (bbvinet/psc_releases_cap_sre-aut-controller) com auto-promote HABILITADO no Stage 4 do apply-source-change. Esteira de Build NPM. Controller v3.6.3 operacional no cluster k8shmlbb111b (HML). Security fixes: XSS sanitizeForOutput, DoS MAX_RESULTS=1000, error detail hardening. Pre-deploy validation workflow criado."
       },
       "cit": {
         "workspaceId": "ws-cit",
@@ -1094,7 +1095,7 @@
       ]
     },
     "lessons": [
-      "Controller esta no GitLab. Auto-promote NAO funciona.",
+      "Controller CAP agora no GitHub (bbvinet/psc_releases_cap_sre-aut-controller). Auto-promote HABILITADO no Stage 4 apos esteira corporativa passar.",
       "trigger/source-change.json e editado por VARIOS workflows. Conflitos COMUNS.",
       "Ao resolver conflito: run = max(HEAD, main) + 1.",
       "SEMPRE fetch origin/main antes de criar branch.",
@@ -1442,6 +1443,11 @@
   },
   "capValuesYaml": {
     "referenceFile": "references/controller-cap/values.yaml",
+    "capRepo": "bbvinet/psc_releases_cap_sre-aut-controller",
+    "capBranch": "main",
+    "capValuesPath": "releases/openshift/hml/deploy/values.yaml",
+    "autoPromote": true,
+    "autoPromoteCondition": "Stage 4 of apply-source-change.yml — runs ONLY after CI Gate passes (corporate Esteira de Build NPM green)",
     "imageLinePattern": "image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:<TAG>",
     "envStructure": {
       "plainValues": [
@@ -1698,7 +1704,8 @@
         "steps": [
           "1. Atualizar references/controller-cap/values.yaml com nova image tag (se promote=true)",
           "2. Atualizar CLAUDE.md secao 'Controller CAP' com nova versao deployed",
-          "3. Atualizar contracts/claude-session-memory.json com nova versao em versioningRules"
+          "3. Atualizar contracts/claude-session-memory.json com nova versao em versioningRules",
+          "4. NOTA: A tag no CAP repo (bbvinet/psc_releases_cap_sre-aut-controller) sera atualizada AUTOMATICAMENTE pelo Stage 4 do workflow apos CI passar — NAO fazer manualmente"
         ],
         "output": "Todas as referencias apontam para nova versao"
       },
@@ -1794,7 +1801,7 @@
         },
         {
           "stage": "4. Promote",
-          "does": "Atualiza image tag no CAP values.yaml (se promote=true). NAO funciona automaticamente — controller esta no GitLab."
+          "does": "Atualiza image tag no CAP values.yaml (se promote=true). Funciona para AGENT (bbvinet/psc_releases_cap_sre-aut-agent) E CONTROLLER (bbvinet/psc_releases_cap_sre-aut-controller). Executa SOMENTE apos CI Gate passar (esteira corporativa verde)."
         },
         {
           "stage": "5. Save State",

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -113,7 +113,8 @@
       "6. Commit tudo em 1 commit, push branch claude/*, PR, squash merge",
       "7. Monitorar workflow apply-source-change (polling 30-60s)",
       "8. Monitorar esteira corporativa ate imagem Docker ser publicada",
-      "9. Se falhar: ler logs, diagnosticar, corrigir, re-deploy AUTOMATICAMENTE"
+      "9. Stage 4 (Promote) atualiza tag AUTOMATICAMENTE no CAP repo apos CI passar — agent (bbvinet/psc_releases_cap_sre-aut-agent) E controller (bbvinet/psc_releases_cap_sre-aut-controller)",
+      "10. Se falhar: ler logs, diagnosticar, corrigir, re-deploy AUTOMATICAMENTE"
     ],
     "preDeployValidation": {
       "workflow": "validate-patches.yml",

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -1,10 +1,12 @@
 # ============================================================
-# Controller CAP Values - GitLab (not yet migrated to GitHub)
-# Source: GitLab CAP repo (psc_releases_cap_sre-aut-controller)
+# Controller CAP Values - GitHub (auto-promote enabled)
+# Source: bbvinet/psc_releases_cap_sre-aut-controller (GitHub)
 # Path: releases/openshift/hml/deploy/values.yaml
 # Image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller
-# Current tag: 3.5.5
+# Current tag: 3.6.3
 # Secret: psc-sre-automacao-controller-runtime
+# Auto-promote: Stage 4 of apply-source-change.yml updates tag
+#   after corporate CI passes (Esteira de Build NPM green)
 # ============================================================
 global:
   clusterSolucao: ''

--- a/state/workspaces/ws-default/workspace.json
+++ b/state/workspaces/ws-default/workspace.json
@@ -26,9 +26,12 @@
     "deployRepo": "",
     "deployBranch": "main",
     "deployValuesPath": "",
-    "ciWorkflowName": "",
-    "imagePattern": "",
-    "note": "Controller CI is via internal GitLab. Promotion manual for now."
+    "capRepo": "bbvinet/psc_releases_cap_sre-aut-controller",
+    "capBranch": "main",
+    "capValuesPath": "releases/openshift/hml/deploy/values.yaml",
+    "ciWorkflowName": "Esteira de Build NPM",
+    "imagePattern": "image: .*psc-sre-automacao-controller:",
+    "note": "Controller CAP now on GitHub. Auto-promote enabled after corporate CI passes."
   },
   "agent": {
     "sourceRepo": "bbvinet/psc-sre-automacao-agent",


### PR DESCRIPTION
## Summary
- **Controller CAP repo** (`bbvinet/psc_releases_cap_sre-aut-controller`) agora no GitHub com auto-promote habilitado
- **Stage 4 (Promote)** do `apply-source-change.yml` atualiza a tag da imagem no `values.yaml` do CAP automaticamente **após a esteira corporativa (Esteira de Build NPM) passar com sucesso**
- Anteriormente o controller era skipped no promote por estar no GitLab — agora funciona igual ao agent

## Arquivos alterados
| Arquivo | Mudança |
|---------|---------|
| `workspace.json` | Adicionado `controller.capRepo`, `capBranch`, `capValuesPath`, `imagePattern` |
| `apply-source-change.yml` | Novo step "Promote (controller)" no Stage 4 + outputs controller CAP no setup |
| `check-repo-access.yml` | Adicionado controller CAP repo na lista de verificação |
| `CLAUDE.md` | Seção Controller CAP: GitLab → GitHub, auto-promote enabled |
| `claude-session-memory.json` | Notes, repos, lessons, capValuesYaml, pipeline stages atualizados |
| `codex-agent-contract.json` | Deploy flow step 9: auto-promote para agent E controller |
| `references/controller-cap/values.yaml` | Header atualizado |

## Fluxo
```
Código fonte → Esteira de Build NPM → PASSA (verde) → CI Gate OK → Stage 4 Promote
→ Atualiza tag em bbvinet/psc_releases_cap_sre-aut-controller values.yaml via GitHub API
```

## Test plan
- [ ] Verificar que workflow `apply-source-change.yml` lê corretamente `controller.capRepo` do `workspace.json`
- [ ] Verificar que Stage 4 executa promote para controller quando `promote=true` e CI Gate passa
- [ ] Verificar que `check-repo-access.yml` valida acesso ao novo repo CAP

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb