### PR TITLE
Add safe auto-merge workflow and document autonomous execution policies

### DIFF
--- a/.github/workflows/auto-merge-to-main.yml
+++ b/.github/workflows/auto-merge-to-main.yml
@@ -1,0 +1,86 @@
+name: "[Core] Auto-Merge PR to main"
+run-name: "${{ github.workflow }} • PR #${{ github.event.pull_request.number }} • ${{ github.event.pull_request.head.ref }} → main"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - ready_for_review
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-main-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-auto-merge:
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate policy for auto-merge
+        id: policy
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map(l => l.name);
+            const hasAutomergeLabel = labels.includes('automerge') || labels.includes('auto-merge');
+            const sameRepository = pr.head.repo.full_name === pr.base.repo.full_name;
+            const trustedAuthor = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(pr.author_association);
+
+            if (!sameRepository) {
+              core.notice(`PR #${pr.number} is from fork (${pr.head.repo.full_name}); skipping for safety.`);
+              core.setOutput('allow', 'false');
+              return;
+            }
+
+            if (!trustedAuthor) {
+              core.notice(`PR #${pr.number} author association ${pr.author_association} is not trusted; skipping.`);
+              core.setOutput('allow', 'false');
+              return;
+            }
+
+            if (pr.draft) {
+              core.notice(`PR #${pr.number} is draft; skipping.`);
+              core.setOutput('allow', 'false');
+              return;
+            }
+
+            if (!hasAutomergeLabel) {
+              core.notice(`PR #${pr.number} missing automerge label; skipping.`);
+              core.setOutput('allow', 'false');
+              return;
+            }
+
+            core.notice(`PR #${pr.number} eligible for auto-merge after checks pass.`);
+            core.setOutput('allow', 'true');
+            core.setOutput('pr_node_id', pr.node_id);
+
+      - name: Enable auto-merge to main (squash)
+        if: steps.policy.outputs.allow == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNodeId = `${{ steps.policy.outputs.pr_node_id }}`;
+            try {
+              await github.graphql(`
+                mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId,
+                    mergeMethod: SQUASH
+                  }) {
+                    pullRequest { number }
+                  }
+                }
+              `, { pullRequestId: prNodeId });
+              core.notice('Auto-merge enabled successfully.');
+            } catch (error) {
+              core.warning(`Could not enable auto-merge: ${error.message}`);
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,8 @@ Edit `trigger/source-change.json`:
 ```
 
 ### Phase 4: Commit + PR + Merge
+
+**Autonomy rule:** com contexto suficiente, executar `commit -> push -> PR -> merge` sem pedir confirmacao adicional ao usuario.
 ```
 1. git add patches/ trigger/source-change.json references/ CLAUDE.md contracts/
 2. git commit -m "feat: <description> + deploy <version>"

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,6 +5,26 @@
 
 ---
 
+## Segregacao critica de contextos (OBRIGATORIO)
+
+Regra operacional confirmada pelo proprietario da conta (2026-03-26):
+
+- **Contextos do usuario principal (NUNCA misturar entre si):**
+  - `ws-default` (Getronics)
+  - `ws-cit`
+- **Contextos de terceiro (irmao, totalmente separados):**
+  - `ws-corp-1`
+  - `ws-socnew`
+
+### Politica de isolamento
+
+1. Sempre validar `workspace_id` antes de qualquer acao com mudanca de estado.
+2. Nunca reutilizar triggers, handoffs, estado, auditoria ou contexto tecnico entre grupos diferentes.
+3. Se houver ambiguidade na solicitacao, interromper e pedir confirmacao explicita do `workspace_id`.
+4. Qualquer automacao nova deve preservar isolamento por `workspace_id` como chave primaria.
+
+---
+
 ## O que e o Autopilot
 
 Control plane web-only para orquestracao de releases multi-workspace, multi-agent.
@@ -292,6 +312,21 @@ Registro de melhorias: category, description, source, status.
 
 ## Como Operar
 
+### Ciclo operacional automatico do agente (padrao)
+
+1. Clone/fetch e branch a partir de `main` atualizado
+2. Pull/rebase antes de editar
+3. Alteracoes + validacao tecnica
+4. Commit atomico
+5. Push da branch
+6. PR para `main`
+7. Monitoramento de checks/workflows
+8. Correcao automatica de falhas quando possivel
+9. Squash merge apos gates
+10. Monitoramento pos-merge
+
+> O agente so deve interromper esse fluxo quando faltar informacao critica ou houver bloqueio de seguranca/isolamento de workspace.
+
 ### Disparar E2E Release
 Editar `trigger/e2e-test.json` e fazer push em main:
 ```json
@@ -303,6 +338,16 @@ Editar `trigger/fix-ci.json` e fazer push em main:
 ```json
 {"workspace_id": "ws-default", "run": 2}
 ```
+
+### Auto-merge para main (apos checks com sucesso)
+Workflow: `.github/workflows/auto-merge-to-main.yml`
+
+Regras:
+1. PR deve ter base `main`
+2. PR nao pode estar em draft
+3. PR deve ter label `automerge` ou `auto-merge`
+4. PR deve ser interno (sem fork) e autoria confiavel (`OWNER`, `MEMBER` ou `COLLABORATOR`)
+5. Auto-merge (squash) e habilitado e o GitHub conclui merge automaticamente quando todos os checks obrigatorios passarem
 
 ### Criar Workspace
 Usar workflow `seed-workspace.yml` via workflow_dispatch.

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -125,7 +125,11 @@
       "currentVersion": "3.6.3",
       "pattern": "Apos X.Y.9 vai para X.(Y+1).0 — NUNCA X.Y.10",
       "checkRegistry": "SEMPRE verificar se tag ja existe antes de bumpar",
-      "versionFiles": ["package.json", "package-lock.json", "src/swagger/swagger.json"]
+      "versionFiles": [
+        "package.json",
+        "package-lock.json",
+        "src/swagger/swagger.json"
+      ]
     }
   },
   "securityPatterns": {
@@ -162,6 +166,36 @@
     "contracts/claude-session-memory.json",
     "contracts/shared-agent-context.md",
     "contracts/codex-deploy-guide.md",
-    "schemas/*.schema.json"
-  ]
+    "schemas/*.schema.json",
+    "contracts/codex-agent-contract.json",
+    "CLAUDE.md"
+  ],
+  "autonomousExecutionPolicy": {
+    "description": "Fluxo padrao obrigatorio para execucao autonoma do Codex em alteracoes tecnicas",
+    "rule": "Com contexto suficiente, executar sem pedir confirmacao: commit -> push -> PR -> merge (squash)",
+    "guardrails": [
+      "Nunca operar sem workspace_id identificado",
+      "Nunca misturar contextos entre workspaces",
+      "Nunca mergear PR de deploy se validate-patches falhar",
+      "Sempre monitorar workflows e esteira corporativa apos merge"
+    ],
+    "sourceOfTruth": [
+      "contracts/claude-session-memory.json#deployFlowGuide",
+      "contracts/codex-agent-contract.json#deployFlow",
+      "CLAUDE.md#Deploy Flow — Complete Guide"
+    ],
+    "operationalChecklist": [
+      "1. Clone/fetch do repo e checkout de branch a partir de main atualizado",
+      "2. Pull/rebase de main antes de iniciar alteracoes",
+      "3. Implementar alteracoes + validar (linters/testes/checks relevantes)",
+      "4. Commit atomico com mensagem clara",
+      "5. Push da branch de trabalho",
+      "6. Abrir PR para main com contexto tecnico completo",
+      "7. Monitorar checks/workflows ate conclusao",
+      "8. Resolver conflitos/falhas automaticamente quando possivel",
+      "9. Realizar squash merge quando policy gates passarem",
+      "10. Monitorar pos-merge (workflows + esteira corporativa quando aplicavel)"
+    ],
+    "defaultMode": "automatico e continuo; interromper apenas quando faltar informacao critica ou houver bloqueio de seguranca"
+  }
 }


### PR DESCRIPTION
### Motivation
- Add a safe, gated mechanism to enable GitHub auto-merge into `main` for trusted internal PRs that are explicitly labeled for auto-merge. 
- Codify and document autonomous execution guardrails and workspace isolation so agents can perform `commit -> push -> PR -> merge` when context is sufficient. 

### Description
- Add workflow `/.github/workflows/auto-merge-to-main.yml` that validates PRs (base `main`, same-repo, non-draft, trusted author association, label `automerge` or `auto-merge`) and enables GitHub auto-merge with `SQUASH` via GraphQL when checks pass. 
- Update `CLAUDE.md` to include an autonomy rule and reference the new auto-merge behavior and required steps for Phase 4/5. 
- Update `HANDOFF.md` to add critical workspace segregation rules, an operational cycle for the agent, and a short summary of the `auto-merge` workflow and its rules. 
- Update `contracts/codex-agent-contract.json` to reformat `versionFiles`, add additional `contextFiles` entries, and introduce an `autonomousExecutionPolicy` section describing required guardrails, checklist and default automatic mode. 

### Testing
- No automated unit or integration tests were run as part of this change. 
- The new workflow and documentation will be exercised by GitHub when qualifying PR events occur and should be monitored on first runs to confirm behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5214bf8f0832dbf68b5de94e70b06)