### PR TITLE
[codex-autopilot] feat: add commit traceability marker

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -347,6 +347,8 @@ Regra de produto Autopilot: **nunca** manter apenas local; toda mudanca necessar
 Sincronizacao automatica recomendada:
 - `scripts/codex/sync-autopilot-product.sh`
 - Fluxo: detecta alteracoes locais -> commit automatico -> push -> PR -> merge -> aguarda estado `MERGED`.
+- Rastreabilidade: commits do repo autopilot devem incluir marcador `[codex-autopilot]` para facilitar leitura na esteira.
+- Restricao: **nao** usar esse marcador em commits das esteiras/repositorios empresariais.
 
 ### Disparar E2E Release
 Editar `trigger/e2e-test.json` e fazer push em main:

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -176,6 +176,7 @@
     "description": "Fluxo padrao obrigatorio para execucao autonoma do Codex em alteracoes tecnicas",
     "rule": "Com contexto suficiente, executar sem pedir confirmacao: commit -> push -> PR -> merge (squash)",
     "autopilotProductRule": "Toda alteracao local relevante no repo autopilot deve ser sincronizada com GitHub automaticamente no mesmo ciclo; nao deixar conhecimento apenas local/sessao.",
+    "autopilotCommitTraceabilityRule": "Commits no repo autopilot devem incluir marcador de rastreio '[codex-autopilot]' para facilitar visualizacao na esteira. Nao aplicar esse marcador em commits de esteiras/repositorios empresariais.",
     "guardrails": [
       "Nunca operar sem workspace_id identificado",
       "Nunca misturar contextos entre workspaces",
@@ -203,7 +204,7 @@
     "automationScript": {
       "path": "scripts/codex/auto-pr-merge.sh",
       "usage": "GITHUB_TOKEN=<token> scripts/codex/auto-pr-merge.sh (ou GH_TOKEN / gh auth login). Opcional: AUTO_COMMIT=true COMMIT_MESSAGE='chore: ...'",
-      "does": "Opcionalmente cria commit automatico (git add -A + commit) quando houver alteracoes locais, configura origin se ausente, resolve token (GITHUB_TOKEN/GH_TOKEN/gh auth token), faz push da branch atual, cria/atualiza PR para main e tenta auto-merge; se indisponivel, faz squash merge direto"
+      "does": "Opcionalmente cria commit automatico (git add -A + commit) quando houver alteracoes locais, aplica marcador '[codex-autopilot]' automaticamente quando REPO=lucassfreiree/autopilot, configura origin se ausente, resolve token (GITHUB_TOKEN/GH_TOKEN/gh auth token), faz push da branch atual, cria/atualiza PR para main e tenta auto-merge; se indisponivel, faz squash merge direto"
     },
     "autopilotSyncScript": {
       "path": "scripts/codex/sync-autopilot-product.sh",

--- a/scripts/codex/auto-pr-merge.sh
+++ b/scripts/codex/auto-pr-merge.sh
@@ -10,12 +10,17 @@ MERGE_MODE="${MERGE_MODE:-squash}"
 AUTO_MERGE="${AUTO_MERGE:-true}"
 AUTO_COMMIT="${AUTO_COMMIT:-true}"
 COMMIT_MESSAGE="${COMMIT_MESSAGE:-chore: codex autonomous update}"
+COMMIT_MARKER="${COMMIT_MARKER:-[codex-autopilot]}"
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
 if [[ "$BRANCH" == "$BASE_BRANCH" ]]; then
   echo "[ERROR] Current branch is '$BASE_BRANCH'. Create/use a feature branch first." >&2
   exit 1
+fi
+
+if [[ "$REPO" == "lucassfreiree/autopilot" ]] && [[ "$COMMIT_MESSAGE" != *"$COMMIT_MARKER"* ]]; then
+  COMMIT_MESSAGE="${COMMIT_MARKER} ${COMMIT_MESSAGE}"
 fi
 
 if [[ "$AUTO_COMMIT" == "true" ]]; then

--- a/scripts/codex/sync-autopilot-product.sh
+++ b/scripts/codex/sync-autopilot-product.sh
@@ -27,8 +27,8 @@ fi
 echo "[INFO] syncing local Autopilot changes to GitHub (${REPO})"
 SYNC_OUTPUT="$(
   AUTO_COMMIT="${AUTO_COMMIT:-true}" \
-  COMMIT_MESSAGE="${COMMIT_MESSAGE:-chore: codex sync autopilot product state}" \
-  PR_TITLE="${PR_TITLE:-chore: sync autopilot product updates}" \
+  COMMIT_MESSAGE="${COMMIT_MESSAGE:-[codex-autopilot] chore: sync autopilot product state}" \
+  PR_TITLE="${PR_TITLE:-[codex-autopilot] chore: sync autopilot product updates}" \
   PR_BODY="${PR_BODY:-Automatic sync executed by scripts/codex/sync-autopilot-product.sh}" \
   scripts/codex/auto-pr-merge.sh
 )"


### PR DESCRIPTION
Adds a clear codex marker for autopilot commits only, without affecting enterprise pipelines.