### PR TITLE
[claude] fix: sync-codex-prompt race condition + agent ID in dashboard

### DIFF
--- a/.github/workflows/auto-merge-to-main.yml
+++ b/.github/workflows/auto-merge-to-main.yml
@@ -1,5 +1,5 @@
 name: "[Core] Auto-Merge PR to main"
-run-name: "${{ github.workflow }} • PR #${{ github.event.pull_request.number }} • ${{ github.event.pull_request.head.ref }} → main"
+run-name: "${{ github.workflow }} • PR #${{ github.event.pull_request.number }} • ${{ startsWith(github.event.pull_request.head.ref, 'claude/') && '(Claude)' || startsWith(github.event.pull_request.head.ref, 'codex/') && '(Codex)' || '' }} ${{ github.event.pull_request.head.ref }} → main"
 
 on:
   pull_request_target:

--- a/.github/workflows/sync-codex-prompt.yml
+++ b/.github/workflows/sync-codex-prompt.yml
@@ -1,5 +1,5 @@
 name: "[Infra] Sync Codex Prompt"
-run-name: "${{ github.workflow }} • ${{ github.event_name }} • ws=${{ github.event.inputs.workspace_id || 'n/a' }} • ref=${{ github.ref_name }}"
+run-name: "${{ github.workflow }} • ${{ github.event_name }} • ${{ github.event.head_commit && (startsWith(github.event.head_commit.message, '[claude]') && '(Claude)' || startsWith(github.event.head_commit.message, '[codex]') && '(Codex)' || '') || '' }} ref=${{ github.ref_name }}"
 
 # Auto-regenerates AGENTS.md whenever
 # workflows, schemas, contracts, or triggers change.
@@ -396,8 +396,17 @@ jobs:
           else
             LINES=$(wc -l < AGENTS.md)
             git commit -m "docs: auto-sync codex prompt ($LINES lines) [skip ci]"
-            git push origin main
-            echo "Pushed updated codex prompt ($LINES lines)"
+            # Retry with rebase to handle race conditions (other workflows pushing to main concurrently)
+            for i in 1 2 3 4; do
+              if git push origin main; then
+                echo "Pushed updated codex prompt ($LINES lines)"
+                break
+              else
+                echo "::warning ::Push attempt $i failed, rebasing and retrying..."
+                git pull --rebase origin main
+                sleep $((i * 2))
+              fi
+            done
           fi
 
       - name: "Summary"


### PR DESCRIPTION
## Summary
- Fix sync-codex-prompt push rejection (retry with rebase up to 4x)
- Show (Claude) or (Codex) in workflow run-name for visual identification in Actions dashboard

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb