### PR TITLE
[claude] fix: handle PR-creation policy block in auto-pr workflow

### DIFF
--- a/.github/workflows/auto-pr-codex.yml
+++ b/.github/workflows/auto-pr-codex.yml
@@ -21,7 +21,7 @@ jobs:
     name: "Create/Update PR and enable auto-merge"
     runs-on: ubuntu-latest
     steps:
-      - name: Create or update PR
+      - name: Create or update PR (best effort)
         id: pr
         uses: actions/github-script@v7
         with:
@@ -59,11 +59,27 @@ jobs:
                 '- Merge strategy: squash + auto-merge when checks pass'
               ].join('\n');
 
-              const created = await github.rest.pulls.create({
-                owner, repo, title, head: branch, base, body,
-              });
-              pr = created.data;
-              core.notice(`Created PR #${pr.number}`);
+              try {
+                const created = await github.rest.pulls.create({
+                  owner, repo, title, head: branch, base, body,
+                });
+                pr = created.data;
+                core.notice(`Created PR #${pr.number}`);
+              } catch (e) {
+                const msg = (e && e.message) ? e.message : String(e);
+                const isBlockedByPolicy =
+                  msg.includes('GitHub Actions is not permitted to create or approve pull requests') ||
+                  (e && e.status === 403);
+                if (isBlockedByPolicy) {
+                  core.warning(
+                    'PR creation blocked by repository Actions policy for GITHUB_TOKEN. ' +
+                    'Set a PAT secret for this workflow or enable Actions to create PRs in repository settings.'
+                  );
+                  core.setOutput('skipped', 'true');
+                  return;
+                }
+                throw e;
+              }
             }
 
             try {
@@ -79,7 +95,7 @@ jobs:
             core.setOutput('skipped', 'false');
 
       - name: Enable auto-merge (squash)
-        if: steps.pr.outputs.skipped != 'true'
+        if: steps.pr.outputs.skipped != 'true' && steps.pr.outputs.pr_node_id != ''
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -350,6 +350,7 @@ Sincronizacao automatica recomendada:
 - Rastreabilidade: commits do repo autopilot devem incluir marcador `[claude]` para facilitar leitura na esteira.
 - Restricao: **nao** usar esse marcador em commits das esteiras/repositorios empresariais.
 - Teste operacional (2026-03-26): commit de validacao pode usar marcador `[codex-autopilot]` quando solicitado explicitamente pelo usuario para auditoria da esteira.
+- Se workflow `[Agent] Auto PR + Auto-Merge (Codex)` receber 403 `GitHub Actions is not permitted to create or approve pull requests`, tratar como bloqueio de policy do repo para `GITHUB_TOKEN` (nao erro de codigo) e orientar habilitar essa permissao ou usar PAT dedicado.
 
 ### Disparar E2E Release
 Editar `trigger/e2e-test.json` e fazer push em main:


### PR DESCRIPTION
Gracefully handles 403 when Actions token cannot create PRs; keeps workflow green with actionable warning.