### PR TITLE
[claude] feat(controller): cronjob callback + OAS query — deploy 3.6.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ ops/terraform/
 - **CAP values path**: `releases/openshift/hml/deploy/values.yaml`
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.6.3`
+- **Current deployed tag**: `3.6.5`
 - **Image line**: `image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:<TAG>`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -1014,8 +1014,8 @@
     ]
   },
   "versioningRules": {
-    "currentVersion": "3.6.3",
-    "previousVersion": "3.6.2",
+    "currentVersion": "3.6.5",
+    "previousVersion": "3.6.4",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versioningPattern": "CRITICO: Apos X.Y.9, a proxima versao e X.(Y+1).0 — NUNCA X.Y.10. Exemplos: 3.5.9 → 3.6.0, 3.6.9 → 3.7.0, 3.9.9 → 3.10.0. O terceiro digito (patch) vai de 0 a 9 apenas.",
     "versionFiles": [
@@ -1070,10 +1070,10 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 53,
+    "lastTriggerRun": 54,
     "lastSuccessfulRun": 38,
-    "lastDeployPR": 144,
-    "pipelineStatus": "IDLE — last trigger run 53 (3.6.4). Trigger file run=53.",
+    "lastDeployPR": 197,
+    "pipelineStatus": "IN_PROGRESS — deploy controller 3.6.5 (run #54). Historia #930217 cronjob callback.",
     "multiFilePayload": {
       "change_type": "multi-file",
       "changesFormat": [

--- a/patches/cronjob-result.controller.ts
+++ b/patches/cronjob-result.controller.ts
@@ -1,0 +1,395 @@
+import type {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
+import {
+  initExecution,
+  getExecutionSnapshot,
+  pushAgentExecutionLogs,
+  type AnyLogEntry,
+} from "./agents-execute-logs.controller";
+import { timestampSP } from "../util/time";
+
+// ── Types ──────────────────────────────────────────────────────
+
+type JsonRecord = Record<string, unknown>;
+
+type CronjobComplianceStatus = "success" | "failed" | "error";
+
+interface CronjobResultBase {
+  compliance_status: CronjobComplianceStatus;
+  namespace: string;
+  cluster_type: string;
+  timestamp: string;
+  execId: string;
+}
+
+interface CronjobResultSuccess extends CronjobResultBase {
+  compliance_status: "success";
+  captured_data: JsonRecord;
+}
+
+interface CronjobResultFailed extends CronjobResultBase {
+  compliance_status: "failed";
+  failures: JsonRecord[];
+}
+
+interface CronjobResultError extends CronjobResultBase {
+  compliance_status: "error";
+  errors: JsonRecord[];
+}
+
+type CronjobResult =
+  | CronjobResultSuccess
+  | CronjobResultFailed
+  | CronjobResultError;
+
+type ValidationResult =
+  | { ok: true; result: CronjobResult }
+  | { ok: false; errors: string[] };
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function isRecord(v: unknown): v is JsonRecord {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function safeString(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function sanitizeForOutput(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[<>"'&]/g, "")
+    .replace(/[\r\n\t]+/g, " ")
+    .trim()
+    .slice(0, 256);
+}
+
+const VALID_COMPLIANCE_STATUSES: CronjobComplianceStatus[] = [
+  "success",
+  "failed",
+  "error",
+];
+
+// ── Validation ─────────────────────────────────────────────────
+
+function validateCronjobResult(body: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(body)) {
+    return { ok: false, errors: ["Request body must be a JSON object."] };
+  }
+
+  const complianceStatus = safeString(body.compliance_status).toLowerCase();
+  if (
+    !complianceStatus ||
+    !VALID_COMPLIANCE_STATUSES.includes(
+      complianceStatus as CronjobComplianceStatus,
+    )
+  ) {
+    errors.push(
+      "Field 'compliance_status' is required. Allowed values: success, failed, error.",
+    );
+  }
+
+  const namespace = safeString(body.namespace);
+  if (!namespace) {
+    errors.push("Field 'namespace' is required (non-empty string).");
+  }
+
+  const clusterType = safeString(body.cluster_type);
+  if (!clusterType) {
+    errors.push("Field 'cluster_type' is required (non-empty string).");
+  }
+
+  const timestamp = safeString(body.timestamp);
+  if (!timestamp) {
+    errors.push("Field 'timestamp' is required (ISO 8601 string).");
+  }
+
+  const execId = safeString(body.execId);
+  if (!execId) {
+    errors.push("Field 'execId' is required (non-empty string).");
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const status = complianceStatus as CronjobComplianceStatus;
+
+  if (status === "success") {
+    if (!isRecord(body.captured_data)) {
+      errors.push(
+        "Field 'captured_data' is required when compliance_status is 'success' (must be a JSON object).",
+      );
+    }
+  } else if (status === "failed") {
+    if (!Array.isArray(body.failures) || body.failures.length < 1) {
+      errors.push(
+        "Field 'failures' is required when compliance_status is 'failed' (non-empty array).",
+      );
+    }
+  } else if (status === "error") {
+    if (!Array.isArray(body.errors) || body.errors.length < 1) {
+      errors.push(
+        "Field 'errors' is required when compliance_status is 'error' (non-empty array).",
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    result: {
+      compliance_status: status,
+      namespace,
+      cluster_type: clusterType,
+      timestamp,
+      execId,
+      ...(status === "success" && {
+        captured_data: body.captured_data as JsonRecord,
+      }),
+      ...(status === "failed" && {
+        failures: body.failures as JsonRecord[],
+      }),
+      ...(status === "error" && {
+        errors: body.errors as JsonRecord[],
+      }),
+    } as CronjobResult,
+  };
+}
+
+// ── Adapter: compliance_status → execution log entries ─────────
+
+function mapComplianceStatusToExecStatus(
+  status: CronjobComplianceStatus,
+): "DONE" | "ERROR" {
+  if (status === "success") return "DONE";
+  return "ERROR";
+}
+
+function adaptCronjobResultToLogEntries(
+  result: CronjobResult,
+): AnyLogEntry[] {
+  const ts = result.timestamp || timestampSP();
+  const execStatus = mapComplianceStatusToExecStatus(result.compliance_status);
+
+  const baseEntry: AnyLogEntry = {
+    ts,
+    execId: result.execId,
+    source: "cronjob-callback",
+    from: "agent",
+    level: result.compliance_status === "success" ? "INFO" : "ERROR",
+    status: execStatus,
+    execStatus,
+    message: `Cronjob result: compliance_status=${result.compliance_status} namespace=${result.namespace} cluster_type=${result.cluster_type}`,
+    data: {
+      compliance_status: result.compliance_status,
+      namespace: result.namespace,
+      cluster_type: result.cluster_type,
+    },
+  };
+
+  if (result.compliance_status === "success") {
+    return [
+      {
+        ...baseEntry,
+        data: {
+          ...(baseEntry.data as JsonRecord),
+          captured_data: result.captured_data,
+        },
+      },
+    ];
+  }
+
+  if (result.compliance_status === "failed") {
+    return [
+      {
+        ...baseEntry,
+        data: {
+          ...(baseEntry.data as JsonRecord),
+          failures: result.failures,
+        },
+      },
+    ];
+  }
+
+  // error
+  return [
+    {
+      ...baseEntry,
+      data: {
+        ...(baseEntry.data as JsonRecord),
+        errors: result.errors,
+      },
+    },
+  ];
+}
+
+// ── Cronjob result index (namespace + execId) ──────────────────
+
+const cronjobIndex = new Map<string, string>();
+
+function indexKey(namespace: string, execId: string): string {
+  return `${namespace}::${execId}`;
+}
+
+function indexCronjobResult(namespace: string, execId: string): void {
+  cronjobIndex.set(indexKey(namespace, execId), execId);
+  cronjobIndex.set(execId, execId);
+}
+
+// ── Handlers ───────────────────────────────────────────────────
+
+/**
+ * POST /api/cronjob/result
+ *
+ * Receives the final cronjob execution result from the Agent,
+ * adapts the compliance_status payload to the existing execution log
+ * format, stores it using the execution snapshot infrastructure,
+ * and indexes by namespace + execId.
+ */
+export async function receiveCronjobResult(
+  req: ExpressRequest,
+  res: ExpressResponse,
+): Promise<void> {
+  const validation = validateCronjobResult(req.body);
+
+  if (!validation.ok) {
+    res.status(400).json({
+      ok: false,
+      error: "Invalid cronjob result payload",
+      details: validation.errors,
+    });
+    return;
+  }
+
+  const { result } = validation;
+  const { execId, namespace } = result;
+
+  try {
+    // Ensure execution state exists
+    initExecution(execId);
+
+    // Adapt compliance_status → execution log entries
+    const entries = adaptCronjobResultToLogEntries(result);
+
+    // Push using existing pushAgentExecutionLogs infrastructure
+    // by building a synthetic request
+    const syntheticReq = {
+      body: {
+        execId,
+        source: "cronjob-callback",
+        from: "agent",
+        entries,
+      },
+      query: {},
+      header: () => undefined,
+      agentCallbackJwt: {},
+    } as unknown as ExpressRequest;
+
+    const captured: { statusCode: number; body: unknown } = {
+      statusCode: 202,
+      body: null,
+    };
+
+    const syntheticRes = {
+      status(code: number) {
+        captured.statusCode = code;
+        return this;
+      },
+      json(data: unknown) {
+        captured.body = data;
+        return this;
+      },
+    } as unknown as ExpressResponse;
+
+    await pushAgentExecutionLogs(syntheticReq, syntheticRes);
+
+    // Index by namespace + execId
+    indexCronjobResult(namespace, execId);
+
+    console.info(
+      "[cronjob-result] stored execId=%s namespace=%s compliance_status=%s",
+      sanitizeForOutput(execId),
+      sanitizeForOutput(namespace),
+      sanitizeForOutput(result.compliance_status),
+    );
+
+    res.status(200).json({
+      ok: true,
+      execId,
+      namespace,
+      compliance_status: result.compliance_status,
+      indexed: true,
+      statusEndpoint: `/api/cronjob/status/${encodeURIComponent(execId)}`,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(
+      "[cronjob-result] error execId=%s detail=%s",
+      sanitizeForOutput(execId),
+      sanitizeForOutput(msg),
+    );
+
+    res.status(500).json({
+      ok: false,
+      error: "Failed to store cronjob result",
+      detail: sanitizeForOutput(msg),
+    });
+  }
+}
+
+/**
+ * GET /api/cronjob/status/:execId
+ *
+ * Returns the stored cronjob execution result for a given execId.
+ * Uses the existing execution snapshot infrastructure.
+ */
+export async function getCronjobStatus(
+  req: ExpressRequest,
+  res: ExpressResponse,
+): Promise<void> {
+  const execId = safeString(req.params.execId);
+
+  if (!execId) {
+    res.status(400).json({
+      ok: false,
+      error: "Parameter 'execId' is required.",
+    });
+    return;
+  }
+
+  try {
+    const snapshot = await getExecutionSnapshot(execId);
+
+    res.status(200).json({
+      ok: true,
+      execId: snapshot.execId,
+      status: snapshot.status,
+      statusLabel: snapshot.statusLabel,
+      finished: snapshot.finished,
+      lastUpdate: snapshot.lastUpdate,
+      count: snapshot.count,
+      entries: snapshot.entries,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(
+      "[cronjob-status] error execId=%s detail=%s",
+      sanitizeForOutput(execId),
+      sanitizeForOutput(msg),
+    );
+
+    res.status(500).json({
+      ok: false,
+      error: "Failed to retrieve cronjob status",
+      detail: sanitizeForOutput(msg),
+    });
+  }
+}

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.6.4
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.6.5
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,49 +3,46 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "changes": [
     {
-      "target_path": "src/controllers/oas-sre-controller.controller.ts",
       "action": "replace-file",
-      "content_ref": "patches/oas-sre-controller.controller.ts"
+      "target_path": "src/controllers/cronjob-result.controller.ts",
+      "content_ref": "patches/cronjob-result.controller.ts"
     },
     {
-      "target_path": "src/controllers/execute.controller.ts",
-      "action": "replace-file",
-      "content_ref": "patches/execute.controller.fixed.ts"
+      "action": "search-replace",
+      "target_path": "src/routes/agentsRouter.ts",
+      "search": "import { getAgentErrors } from \"../controllers/agent-errors.controller\";",
+      "replace": "import { getAgentErrors } from \"../controllers/agent-errors.controller\";\nimport {\n  receiveCronjobResult,\n  getCronjobStatus,\n} from \"../controllers/cronjob-result.controller\";"
     },
     {
-      "target_path": "src/controllers/oas-execute.controller.ts",
-      "action": "replace-file",
-      "content_ref": "patches/oas-execute.controller.ts"
+      "action": "search-replace",
+      "target_path": "src/routes/agentsRouter.ts",
+      "search": "router.get(\"/agent/errors\", getAgentErrors);",
+      "replace": "router.get(\"/agent/errors\", getAgentErrors);\n\n// ── Cronjob result endpoints (historia #930217) ──\nrouter.post(\n  \"/api/cronjob/result\",\n  requireAgentCallbackJwt,\n  requireAgentCallbackScopes([SCOPES.SEND]),\n  receiveCronjobResult,\n);\n\nrouter.get(\n  \"/api/cronjob/status/:execId\",\n  requireJwt,\n  requireScopes([SCOPES.READ]),\n  getCronjobStatus,\n);"
     },
     {
-      "target_path": "src/controllers/agents-execute-logs.controller.ts",
-      "action": "replace-file",
-      "content_ref": "patches/agents-execute-logs.controller.ts"
-    },
-    {
+      "action": "search-replace",
       "target_path": "package.json",
-      "action": "search-replace",
-      "search": "\"version\": \"3.6.3\"",
-      "replace": "\"version\": \"3.6.4\""
+      "search": "\"version\": \"3.6.4\"",
+      "replace": "\"version\": \"3.6.5\""
     },
     {
+      "action": "search-replace",
       "target_path": "package-lock.json",
-      "action": "search-replace",
-      "search": "\"version\": \"3.6.3\"",
-      "replace": "\"version\": \"3.6.4\""
+      "search": "\"version\": \"3.6.4\"",
+      "replace": "\"version\": \"3.6.5\""
     },
     {
-      "target_path": "src/swagger/swagger.json",
       "action": "search-replace",
-      "search": "\"version\": \"3.6.3\"",
-      "replace": "\"version\": \"3.6.4\""
+      "target_path": "src/swagger/swagger.json",
+      "search": "\"version\": \"3.6.4\"",
+      "replace": "\"version\": \"3.6.5\""
     }
   ],
-  "commit_message": "fix(controller): ajuste timeout padrão de chamada do agent (3.6.4)",
+  "commit_message": "feat(controller): cronjob callback result endpoint + OAS query (3.6.5) #930217",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 53
+  "run": 54
 }


### PR DESCRIPTION
## Summary
Historia #930217 — Controller side (Deploy 1 de 2)

- **NEW**: `src/controllers/cronjob-result.controller.ts`
  - `POST /api/cronjob/result` — recebe payload compliance_status do Agent, adapta para execution log, armazena
  - `GET /api/cronjob/status/:execId` — OAS consulta resultado por execId
- Rotas adicionadas no `agentsRouter.ts` com auth JWT
- Adapter: `compliance_status` (success/failed/error) → `ExecutionSnapshot`
- Index por `namespace + execId`
- Version bump 3.6.4 → 3.6.5

## Deploy 2 (Agent) sera feito apos este passar na esteira

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb