### PR TITLE
[claude] fix: re-trigger controller deploy 3.6.5 (run 55)

### DIFF
--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -44,5 +44,5 @@
   "commit_message": "feat(controller): cronjob callback result endpoint + OAS query (3.6.5) #930217",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 54
+  "run": 55
 }


### PR DESCRIPTION
Re-trigger controller deploy 3.6.5 — run 54 did not trigger workflow.

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb