### PR TITLE
[claude] fix: workspace.json autopilot-state + promote controller 3.6.5

### DIFF
--- a/trigger/promote-cap.json
+++ b/trigger/promote-cap.json
@@ -4,5 +4,5 @@
   "component": "controller",
   "version": "3.6.5",
   "note": "Promote controller 3.6.5 — esteira passed all 8 checks",
-  "run": 3
+  "run": 4
 }


### PR DESCRIPTION
Fixed workspace.json in autopilot-state (was missing controller.capRepo).
Re-trigger promote controller 3.6.5.

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb