### PR TITLE
[claude] feat(agent): cronjob callback — deploy 2.2.7 #930217

### DIFF
--- a/patches/agent-apis.ts
+++ b/patches/agent-apis.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+import MetricsAPI from "./metrics.api";
+import RootAPI from "./root.api";
+import CriaPost from "./create-cronjob";
+import AgentRoutes from "./infoAgent";
+import ErrorAgentRoutes from "./errorAgent";
+import ExecuteRoutes from "./execute";
+import RegisterRoutes from "./register";
+
+// ADICIONADO: rota que recebe os logs do Agent e expõe consulta por execId
+import AgentExecuteLogsAPI from "./agent-execute-logs.api";
+
+// ADICIONADO: rota de callback para resultados de cronjob (#930217)
+import CronjobCallbackAPI from "./cronjob-callback";
+
+export class ApisRouter {
+  constructor(router: Router, ...args: unknown[]) {
+    new MetricsAPI(router, ...(args as []));
+    new RootAPI(router, ...(args as []));
+    new CriaPost(router, ...(args as []));
+    new AgentRoutes(router, ...(args as []));
+    new ErrorAgentRoutes(router, ...(args as []));
+    new ExecuteRoutes(router, ...(args as []));
+    new RegisterRoutes(router, ...(args as []));
+
+    // monta a nova rota SEM remover as existentes
+    new AgentExecuteLogsAPI(router, ...(args as []));
+
+    // monta rota de callback para resultados de cronjob
+    new CronjobCallbackAPI(router, ...(args as []));
+  }
+}
+
+export default ApisRouter;

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -1,41 +1,35 @@
 {
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
-  "component": "controller",
+  "component": "agent",
   "change_type": "multi-file",
-  "version": "3.6.5",
+  "version": "2.2.7",
   "changes": [
     {
       "action": "replace-file",
-      "target_path": "src/controllers/cronjob-result.controller.ts",
-      "content_ref": "patches/cronjob-result.controller.ts"
+      "target_path": "src/routes/cronjob-callback.ts",
+      "content_ref": "patches/cronjob-callback.ts"
     },
     {
       "action": "replace-file",
-      "target_path": "src/routes/agentsRouter.ts",
-      "content_ref": "patches/agentsRouter.ts"
+      "target_path": "src/routes/apis.ts",
+      "content_ref": "patches/agent-apis.ts"
     },
     {
       "action": "search-replace",
       "target_path": "package.json",
-      "search": "\"version\": \"3.6.4\"",
-      "replace": "\"version\": \"3.6.5\""
+      "search": "\"version\": \"2.2.6\"",
+      "replace": "\"version\": \"2.2.7\""
     },
     {
       "action": "search-replace",
       "target_path": "package-lock.json",
-      "search": "\"version\": \"3.6.4\"",
-      "replace": "\"version\": \"3.6.5\""
-    },
-    {
-      "action": "search-replace",
-      "target_path": "src/swagger/swagger.json",
-      "search": "\"version\": \"3.6.4\"",
-      "replace": "\"version\": \"3.6.5\""
+      "search": "\"version\": \"2.2.6\"",
+      "replace": "\"version\": \"2.2.7\""
     }
   ],
-  "commit_message": "feat(controller): cronjob callback result endpoint + OAS query (3.6.5) #930217",
+  "commit_message": "feat(agent): cronjob callback endpoint + forward to controller (2.2.7) #930217",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 58
+  "run": 60
 }


### PR DESCRIPTION
## Summary
Historia #930217 — Agent side (Deploy 2 de 2)

- **NEW**: `src/routes/cronjob-callback.ts` — POST /api/cronjob/callback
  - Validates compliance_status (success/failed/error)
  - Forwards to Controller /api/cronjob/result
- **MODIFIED**: `src/routes/apis.ts` — registers CronjobCallbackAPI
- Version bump 2.2.6 → 2.2.7

## Controller already deployed (3.6.5 — esteira passed, CAP promoted)

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb