### PR TITLE
[claude] fix(agent): ESLint fix — deploy 2.2.8

### DIFF
--- a/patches/cronjob-callback.ts
+++ b/patches/cronjob-callback.ts
@@ -203,11 +203,14 @@ async function forwardToController(
     };
   } catch (error) {
     const isAbort = error instanceof Error && error.name === "AbortError";
-    const detail = isAbort
-      ? `Controller timeout after ${timeoutMs}ms`
-      : error instanceof Error
-        ? error.message
-        : String(error);
+    let detail: string;
+    if (isAbort) {
+      detail = `Controller timeout after ${timeoutMs}ms`;
+    } else if (error instanceof Error) {
+      detail = error.message;
+    } else {
+      detail = String(error);
+    }
     return { ok: false, status: 0, detail };
   } finally {
     clearTimeout(timeoutId);

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,7 +3,7 @@
   "workspace_id": "ws-default",
   "component": "agent",
   "change_type": "multi-file",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "changes": [
     {
       "action": "replace-file",
@@ -18,18 +18,18 @@
     {
       "action": "search-replace",
       "target_path": "package.json",
-      "search": "\"version\": \"2.2.6\"",
-      "replace": "\"version\": \"2.2.7\""
+      "search": "\"version\": \"2.2.7\"",
+      "replace": "\"version\": \"2.2.8\""
     },
     {
       "action": "search-replace",
       "target_path": "package-lock.json",
-      "search": "\"version\": \"2.2.6\"",
-      "replace": "\"version\": \"2.2.7\""
+      "search": "\"version\": \"2.2.7\"",
+      "replace": "\"version\": \"2.2.8\""
     }
   ],
-  "commit_message": "feat(agent): cronjob callback endpoint + forward to controller (2.2.7) #930217",
+  "commit_message": "fix(agent): fix no-nested-ternary ESLint error in cronjob-callback (2.2.8)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 60
+  "run": 61
 }


### PR DESCRIPTION
Fix ESLint no-nested-ternary in cronjob-callback.ts. Version 2.2.8.

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb