### PR TITLE
[claude] feat(agent): swagger cronjob callback — deploy 2.2.9

### DIFF
--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -1,30 +1,30 @@
 {
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
-  "component": "controller",
+  "component": "agent",
   "change_type": "multi-file",
-  "version": "3.6.6",
+  "version": "2.2.9",
   "changes": [
     {
       "action": "replace-file",
       "target_path": "src/swagger/swagger.json",
-      "content_ref": "patches/controller-swagger.json"
+      "content_ref": "patches/agent-swagger.json"
     },
     {
       "action": "search-replace",
       "target_path": "package.json",
-      "search": "\"version\": \"3.6.5\"",
-      "replace": "\"version\": \"3.6.6\""
+      "search": "\"version\": \"2.2.8\"",
+      "replace": "\"version\": \"2.2.9\""
     },
     {
       "action": "search-replace",
       "target_path": "package-lock.json",
-      "search": "\"version\": \"3.6.5\"",
-      "replace": "\"version\": \"3.6.6\""
+      "search": "\"version\": \"2.2.8\"",
+      "replace": "\"version\": \"2.2.9\""
     }
   ],
-  "commit_message": "feat(controller): add cronjob routes to swagger + version 3.6.6",
+  "commit_message": "feat(agent): add cronjob callback route to swagger + version 2.2.9",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 62
+  "run": 63
 }


### PR DESCRIPTION
Agent swagger with POST /api/cronjob/callback route — version 2.2.9

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb