### PR TITLE
[claude] docs: corporate repos reference — all 4 repos mapped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,53 @@ ops/terraform/
 9. Always validate jq output with fallbacks: `jq -r '.field // ""' 2>/dev/null || echo ""`
 10. Use base64 encoding when passing content between workflow jobs (avoids shell quoting issues)
 
+## Corporate Repos — Getronics (ws-default)
+
+All 4 repos below are on GitHub under `bbvinet` org. Access via `BBVINET_TOKEN`.
+
+### Source Code Repos (where application code lives)
+
+| Repo | Role | Current Version | Stack | CI |
+|------|------|-----------------|-------|----|
+| [`bbvinet/psc-sre-automacao-controller`](https://github.com/bbvinet/psc-sre-automacao-controller) | Controller — orchestrates automations, dispatches to agents, manages execution logs | 3.6.6 | Node 22, TypeScript, Express, Jest | Esteira de Build NPM (corporate runner) |
+| [`bbvinet/psc-sre-automacao-agent`](https://github.com/bbvinet/psc-sre-automacao-agent) | Agent — executes automations on clusters, receives cronjob callbacks, pushes logs to controller | 2.2.9 | Node 22, TypeScript, Express, Jest, K8s client | Esteira de Build NPM (corporate runner) |
+
+**How to work with source repos:**
+- **Read files**: `fetch-files.yml` workflow (trigger via `trigger/fetch-files.json`)
+- **Push changes**: `apply-source-change.yml` workflow (trigger via `trigger/source-change.json`)
+- **Check CI status**: `ci-status-check.yml` (trigger via `trigger/ci-status.json`) — reads check-runs + workflow-runs for a commit
+- **Diagnose CI failure**: `ci-diagnose.yml` (trigger via `trigger/ci-diagnose.json`) — downloads logs, reproduces locally
+- **CI logs**: saved in `state/workspaces/ws-default/ci-logs-<component>-<job_id>.txt` on autopilot-state
+- **CI status result**: saved in `state/workspaces/ws-default/ci-status-<component>.json` on autopilot-state
+- **NEVER push directly** — always via `apply-source-change.yml` with `BBVINET_TOKEN`
+
+### CAP/Deploy Repos (where K8s deploy manifests live)
+
+| Repo | Role | Values Path | Auto-Promote |
+|------|------|-------------|:---:|
+| [`bbvinet/psc_releases_cap_sre-aut-controller`](https://github.com/bbvinet/psc_releases_cap_sre-aut-controller) | Controller CAP — K8s deployment manifest (Deployment, Service, Ingress, RBAC, Secrets) | `releases/openshift/hml/deploy/values.yaml` | Yes (Stage 4) |
+| [`bbvinet/psc_releases_cap_sre-aut-agent`](https://github.com/bbvinet/psc_releases_cap_sre-aut-agent) | Agent CAP — K8s deployment manifest | `releases/openshift/hml/deploy/values.yaml` | Yes (Stage 4) |
+
+**How to work with CAP repos:**
+- **Auto-promote**: Stage 4 of `apply-source-change.yml` updates image tag after corporate CI passes
+- **Manual promote**: `promote-cap.yml` workflow (trigger via `trigger/promote-cap.json`)
+- **Image tag line**: `image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-<component>:<TAG>`
+- **Config source**: `workspace.json` fields `controller.capRepo` / `agent.capRepo` (on autopilot-state branch)
+- **Reference file**: `references/controller-cap/values.yaml` (local copy for reference)
+
+### Workspace Config Location
+```
+# autopilot-state branch (SOURCE OF TRUTH for workflows)
+state/workspaces/ws-default/workspace.json
+  → controller.sourceRepo, controller.capRepo, controller.capValuesPath, controller.imagePattern
+  → agent.sourceRepo, agent.capRepo, agent.capValuesPath, agent.imagePattern
+
+# main branch (local reference, may be in .gitignore)
+state/workspaces/ws-default/workspace.json
+```
+
+**CRITICAL**: When adding new fields to workspace.json, update BOTH the local file AND the autopilot-state branch via GitHub API.
+
 ## Controller CAP (GitHub — auto-promote enabled)
 - **CAP repo**: `bbvinet/psc_releases_cap_sre-aut-controller` (GitHub)
 - **CAP values path**: `releases/openshift/hml/deploy/values.yaml`

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -18,8 +18,50 @@
           "bbvinet/psc_releases_cap_sre-aut-agent",
           "bbvinet/psc_releases_cap_sre-aut-controller"
         ],
+        "repoDetails": {
+          "bbvinet/psc-sre-automacao-controller": {
+            "role": "Controller — orquestra automacoes, despacha para agents, gerencia logs de execucao",
+            "type": "source-code",
+            "currentVersion": "3.6.6",
+            "stack": "Node 22, TypeScript, Express, Jest, SQLite, S3",
+            "ci": "Esteira de Build NPM (corporate runner)",
+            "actionsUrl": "https://github.com/bbvinet/psc-sre-automacao-controller/actions",
+            "howToRead": "fetch-files.yml com component=controller",
+            "howToPush": "apply-source-change.yml com component=controller",
+            "howToCheckCI": "ci-status-check.yml com component=controller + commit_sha"
+          },
+          "bbvinet/psc-sre-automacao-agent": {
+            "role": "Agent — executa automacoes nos clusters, recebe callbacks de cronjob, envia logs ao controller",
+            "type": "source-code",
+            "currentVersion": "2.2.9",
+            "stack": "Node 22, TypeScript, Express, Jest, K8s client",
+            "ci": "Esteira de Build NPM (corporate runner)",
+            "actionsUrl": "https://github.com/bbvinet/psc-sre-automacao-agent/actions",
+            "howToRead": "fetch-files.yml com component=agent",
+            "howToPush": "apply-source-change.yml com component=agent",
+            "howToCheckCI": "ci-status-check.yml com component=agent + commit_sha"
+          },
+          "bbvinet/psc_releases_cap_sre-aut-controller": {
+            "role": "Controller CAP — manifesto K8s (Deployment, Service, Ingress, RBAC, Secrets)",
+            "type": "cap-deploy",
+            "valuesPath": "releases/openshift/hml/deploy/values.yaml",
+            "imagePattern": "image: .*psc-sre-automacao-controller:",
+            "actionsUrl": "https://github.com/bbvinet/psc_releases_cap_sre-aut-controller/actions",
+            "howToPromote": "promote-cap.yml com component=controller, OU automatico via Stage 4 do apply-source-change",
+            "workspaceJsonField": "controller.capRepo"
+          },
+          "bbvinet/psc_releases_cap_sre-aut-agent": {
+            "role": "Agent CAP — manifesto K8s de deploy do agent",
+            "type": "cap-deploy",
+            "valuesPath": "releases/openshift/hml/deploy/values.yaml",
+            "imagePattern": "image: .*psc-sre-automacao-agent:",
+            "actionsUrl": "https://github.com/bbvinet/psc_releases_cap_sre-aut-agent/actions",
+            "howToPromote": "promote-cap.yml com component=agent, OU automatico via Stage 4 do apply-source-change",
+            "workspaceJsonField": "agent.capRepo"
+          }
+        },
         "status": "active",
-        "lastDeploy": "3.6.3 (current deployed — security fixes)",
+        "lastDeploy": "controller 3.6.6, agent 2.2.9 (historia #930217 — cronjob callback)",
         "notes": "Pipeline completo e funcional. Controller CAP agora no GitHub (bbvinet/psc_releases_cap_sre-aut-controller) com auto-promote HABILITADO no Stage 4 do apply-source-change. Esteira de Build NPM. Controller v3.6.3 operacional no cluster k8shmlbb111b (HML). Security fixes: XSS sanitizeForOutput, DoS MAX_RESULTS=1000, error detail hardening. Pre-deploy validation workflow criado."
       },
       "cit": {


### PR DESCRIPTION
## Summary
Maps all 4 Getronics corporate repos with roles, URLs, workflows, and how to work with each.

| Repo | Type | How to interact |
|------|------|----------------|
| `bbvinet/psc-sre-automacao-controller` | Source code | fetch-files / apply-source-change / ci-status-check |
| `bbvinet/psc-sre-automacao-agent` | Source code | fetch-files / apply-source-change / ci-status-check |
| `bbvinet/psc_releases_cap_sre-aut-controller` | CAP deploy | promote-cap / Stage 4 auto-promote |
| `bbvinet/psc_releases_cap_sre-aut-agent` | CAP deploy | promote-cap / Stage 4 auto-promote |

https://claude.ai/code/session_01T7W5ikUFgkK1BHWAp85fHb