### PR TITLE
fix: permanently disable duplicate merge workflows

### DIFF
--- a/.github/workflows/auto-merge-to-main.yml
+++ b/.github/workflows/auto-merge-to-main.yml
@@ -19,7 +19,13 @@ concurrency:
 
 jobs:
   enable-auto-merge:
-    if: github.event.pull_request.base.ref == 'main'
+    # Skip agent branches — autonomous-merge-direct.yml handles those.
+    # This workflow ONLY handles non-agent PRs with 'automerge' label.
+    if: |
+      github.event.pull_request.base.ref == 'main' &&
+      !startsWith(github.event.pull_request.head.ref, 'claude/') &&
+      !startsWith(github.event.pull_request.head.ref, 'codex/') &&
+      !startsWith(github.event.pull_request.head.ref, 'copilot/')
     runs-on: ubuntu-latest
     steps:
       - name: Validate policy for auto-merge

--- a/.github/workflows/autonomous-pr-lane.yml
+++ b/.github/workflows/autonomous-pr-lane.yml
@@ -24,6 +24,9 @@ env:
 jobs:
   label-and-automerge:
     name: "Label & Enable Auto-merge"
+    # DISABLED: autonomous-merge-direct.yml handles all agent PRs.
+    # This workflow was causing duplicate runs. DO NOT RE-ENABLE.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate eligibility


### PR DESCRIPTION
Permanently disable duplicate merge workflows. DO NOT RE-ENABLE.