### PR TITLE
fix: panel dashboard sync runs independently of Spark config

### DIFF
--- a/.github/workflows/spark-sync-state.yml
+++ b/.github/workflows/spark-sync-state.yml
@@ -46,7 +46,6 @@ jobs:
           fi
 
       - name: Collect comprehensive state
-        if: steps.config.outputs.skip != 'true'
         id: state
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -431,7 +430,7 @@ jobs:
           fi
 
       - name: Update panel/dashboard/state.json (GitHub Pages)
-        if: steps.config.outputs.skip != 'true'
+        if: always() && steps.state.outputs.state_b64 != ''
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |


### PR DESCRIPTION
Fix: state collection and panel/dashboard sync must run always, not only when Spark repo is configured.\n\nhttps://claude.ai/code/session_01C2jHzg9iscD8qutXUiqKy1