### PR TITLE
feat: detect external dev activity on corporate repos

### DIFF
--- a/.github/workflows/spark-sync-state.yml
+++ b/.github/workflows/spark-sync-state.yml
@@ -150,6 +150,46 @@ jobs:
 
           echo "::notice ::Real versions — Controller: $CTRL_REAL_VER (CAP: $CTRL_CAP_TAG), Agent: $AGENT_REAL_VER (CAP: $AGENT_CAP_TAG)"
 
+          # ══════════════════════════════════════════════════════════
+          # ── BRANCH & ACTIVITY INTELLIGENCE                       ──
+          # Detect: feature branches, external devs, manual deploys ──
+          # ══════════════════════════════════════════════════════════
+
+          # Controller branches (detect test/feature branches)
+          CTRL_BRANCHES="[]"
+          if [ -n "$BBVINET_TOKEN" ]; then
+            CTRL_BRANCHES=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/bbvinet/psc-sre-automacao-controller/branches?per_page=20" \
+              --jq '[.[] | {name: .name, sha: .commit.sha[:8], protected: .protected}]' 2>/dev/null || echo '[]')
+          fi
+
+          # Agent branches
+          AGENT_BRANCHES="[]"
+          if [ -n "$BBVINET_TOKEN" ]; then
+            AGENT_BRANCHES=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/bbvinet/psc-sre-automacao-agent/branches?per_page=20" \
+              --jq '[.[] | {name: .name, sha: .commit.sha[:8], protected: .protected}]' 2>/dev/null || echo '[]')
+          fi
+
+          # Controller open PRs (detect active development by others)
+          CTRL_PRS="[]"
+          if [ -n "$BBVINET_TOKEN" ]; then
+            CTRL_PRS=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/bbvinet/psc-sre-automacao-controller/pulls?state=open&per_page=10" \
+              --jq '[.[] | {number: .number, title: .title, author: .user.login, branch: .head.ref, created: .created_at, draft: .draft}]' 2>/dev/null || echo '[]')
+          fi
+
+          # Agent open PRs
+          AGENT_PRS="[]"
+          if [ -n "$BBVINET_TOKEN" ]; then
+            AGENT_PRS=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/bbvinet/psc-sre-automacao-agent/pulls?state=open&per_page=10" \
+              --jq '[.[] | {number: .number, title: .title, author: .user.login, branch: .head.ref, created: .created_at, draft: .draft}]' 2>/dev/null || echo '[]')
+          fi
+
+          # Detect external activity (commits NOT by github-actions bot = human dev)
+          CTRL_EXTERNAL_COMMITS=$(echo "$CTRL_LATEST_COMMITS" | jq '[.[] | select(.author != "github-actions[bot]" and .author != "github-actions")]' 2>/dev/null || echo '[]')
+          AGENT_EXTERNAL_COMMITS=$(echo "$AGENT_LATEST_COMMITS" | jq '[.[] | select(.author != "github-actions[bot]" and .author != "github-actions")]' 2>/dev/null || echo '[]')
+
+          echo "::notice ::Controller branches: $(echo "$CTRL_BRANCHES" | jq 'length'), external commits: $(echo "$CTRL_EXTERNAL_COMMITS" | jq 'length'), open PRs: $(echo "$CTRL_PRS" | jq 'length')"
+          echo "::notice ::Agent branches: $(echo "$AGENT_BRANCHES" | jq 'length'), external commits: $(echo "$AGENT_EXTERNAL_COMMITS" | jq 'length'), open PRs: $(echo "$AGENT_PRS" | jq 'length')"
+
           # ── Build comprehensive state.json with FULL intelligence ──
           jq -n \
             --argjson ctrl "$CTRL_STATE" \
@@ -173,6 +213,12 @@ jobs:
             --argjson agent_commits "$AGENT_LATEST_COMMITS" \
             --argjson ctrl_builds "$CTRL_BUILDS" \
             --argjson agent_builds "$AGENT_BUILDS" \
+            --argjson ctrl_branches "$CTRL_BRANCHES" \
+            --argjson agent_branches "$AGENT_BRANCHES" \
+            --argjson ctrl_prs "$CTRL_PRS" \
+            --argjson agent_prs "$AGENT_PRS" \
+            --argjson ctrl_ext "$CTRL_EXTERNAL_COMMITS" \
+            --argjson agent_ext "$AGENT_EXTERNAL_COMMITS" \
             '{
               lastSync: now | strftime("%Y-%m-%dT%H:%M:%SZ"),
               syncSource: "autopilot/spark-sync-state.yml",
@@ -360,6 +406,30 @@ jobs:
                   driftDetail: (if $agent_real != "?" and ($agent.lastTag // "?") != "?" and $agent_real != ($agent.lastTag // "?") then ("autopilot=" + ($agent.lastTag // "?") + " real=" + $agent_real) else null end)
                 },
                 lastChecked: now | strftime("%Y-%m-%dT%H:%M:%SZ")
+              },
+
+              corporateActivity: {
+                description: "Real-time activity from corporate repos — branches, PRs, external commits by other devs",
+                controller: {
+                  branches: $ctrl_branches,
+                  branchCount: ($ctrl_branches | length),
+                  featureBranches: [($ctrl_branches // [])[] | select(.name != "main" and .name != "master")],
+                  openPRs: $ctrl_prs,
+                  openPRCount: ($ctrl_prs | length),
+                  externalCommits: $ctrl_ext,
+                  externalCommitCount: ($ctrl_ext | length),
+                  hasExternalActivity: (($ctrl_ext | length) > 0 or ($ctrl_prs | length) > 0)
+                },
+                agent: {
+                  branches: $agent_branches,
+                  branchCount: ($agent_branches | length),
+                  featureBranches: [($agent_branches // [])[] | select(.name != "main" and .name != "master")],
+                  openPRs: $agent_prs,
+                  openPRCount: ($agent_prs | length),
+                  externalCommits: $agent_ext,
+                  externalCommitCount: ($agent_ext | length),
+                  hasExternalActivity: (($agent_ext | length) > 0 or ($agent_prs | length) > 0)
+                }
               },
 
               metadata: {

--- a/panel/dashboard/index.html
+++ b/panel/dashboard/index.html
@@ -178,6 +178,10 @@
         <div class="section"><h3>Controller Recent Commits</h3><div id="ctrlCommits"></div></div>
         <div class="section"><h3>Agent Recent Commits</h3><div id="agentCommits"></div></div>
       </div>
+      <div class="grid-2" style="margin-top:16px">
+        <div class="section"><h3>Controller Branches & PRs</h3><div id="ctrlBranches"></div></div>
+        <div class="section"><h3>Agent Branches & PRs</h3><div id="agentBranches"></div></div>
+      </div>
     </div>
 
     <!-- AGENTS -->
@@ -356,6 +360,19 @@
     // CAP vs source drift
     if(ctrlReal.sourceVersion&&ctrlReal.capTag&&ctrlReal.sourceVersion!=='?'&&ctrlReal.capTag!=='?'&&ctrlReal.sourceVersion!==ctrlReal.capTag)alerts.push({type:'warn',msg:`Controller source (${ctrlReal.sourceVersion}) != CAP tag (${ctrlReal.capTag}) — promote may be pending`,icon:'arrow'});
     if(agentReal.sourceVersion&&agentReal.capTag&&agentReal.sourceVersion!=='?'&&agentReal.capTag!=='?'&&agentReal.sourceVersion!==agentReal.capTag)alerts.push({type:'warn',msg:`Agent source (${agentReal.sourceVersion}) != CAP tag (${agentReal.capTag}) — promote may be pending`,icon:'arrow'});
+
+    // CORPORATE ACTIVITY — external devs working on repos
+    const act=state.corporateActivity||{};
+    const ctrlAct=act.controller||{};
+    const agentAct=act.agent||{};
+    if(ctrlAct.externalCommitCount>0)alerts.push({type:'info',msg:`Controller: ${ctrlAct.externalCommitCount} external commit(s) by other devs — not from autopilot`,icon:'dev'});
+    if(agentAct.externalCommitCount>0)alerts.push({type:'info',msg:`Agent: ${agentAct.externalCommitCount} external commit(s) by other devs`,icon:'dev'});
+    if(ctrlAct.openPRCount>0)alerts.push({type:'info',msg:`Controller: ${ctrlAct.openPRCount} open PR(s) from other devs`,icon:'pr'});
+    if(agentAct.openPRCount>0)alerts.push({type:'info',msg:`Agent: ${agentAct.openPRCount} open PR(s) from other devs`,icon:'pr'});
+    const ctrlFeature=(ctrlAct.featureBranches||[]).length;
+    const agentFeature=(agentAct.featureBranches||[]).length;
+    if(ctrlFeature>0)alerts.push({type:'info',msg:`Controller: ${ctrlFeature} feature branch(es): ${(ctrlAct.featureBranches||[]).map(b=>b.name).join(', ')}`,icon:'branch'});
+    if(agentFeature>0)alerts.push({type:'info',msg:`Agent: ${agentFeature} feature branch(es): ${(agentAct.featureBranches||[]).map(b=>b.name).join(', ')}`,icon:'branch'});
 
     return alerts;
   }
@@ -612,6 +629,44 @@
     }
     renderCommits(cc.recentCommits||[],'ctrlCommits');
     renderCommits(ca.recentCommits||[],'agentCommits');
+
+    // Branches & PRs from corporate repos
+    const act=state.corporateActivity||{};
+    function renderBranchesAndPRs(data,elId){
+      const el=document.getElementById(elId);
+      if(!data){el.innerHTML='<div class="empty">No data</div>';return}
+      const branches=data.featureBranches||[];
+      const prs=data.openPRs||[];
+      const ext=data.externalCommits||[];
+      let html='';
+
+      // External commits alert
+      if(ext.length>0){
+        html+=`<div class="alert-bar alert-info" style="margin-bottom:8px">👤 ${ext.length} commit(s) by external devs (not autopilot)</div>`;
+        html+=ext.map(cm=>`<div style="display:flex;gap:8px;padding:4px 0;font-size:11px;border-bottom:1px solid var(--border)"><code style="color:var(--blue)">${esc(cm.sha)}</code><div style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(cm.message)}</div><strong>${esc(cm.author)}</strong></div>`).join('');
+      }
+
+      // Feature branches
+      if(branches.length>0){
+        html+=`<div style="margin-top:10px;font-size:12px;font-weight:600">Branches (${branches.length + 1} total)</div>`;
+        html+=`<div style="display:flex;flex-wrap:wrap;gap:4px;margin-top:4px">`;
+        html+=`<span class="badge b-green" style="font-size:10px">main</span>`;
+        html+=branches.map(b=>`<span class="badge b-blue" style="font-size:10px">${esc(b.name)}</span>`).join('');
+        html+=`</div>`;
+      }else{
+        html+=`<div style="margin-top:10px;font-size:12px;color:var(--muted)">Only main branch — no feature branches</div>`;
+      }
+
+      // Open PRs
+      if(prs.length>0){
+        html+=`<div style="margin-top:10px;font-size:12px;font-weight:600">Open PRs (${prs.length})</div>`;
+        html+=prs.map(pr=>`<div style="padding:6px 0;border-bottom:1px solid var(--border);font-size:11px"><span class="mono" style="color:var(--muted)">#${pr.number}</span> <strong>${esc(pr.title)}</strong><br><span style="color:var(--muted)">${esc(pr.author)} · ${esc(pr.branch)} · ${fmtDate(pr.created)}</span></div>`).join('');
+      }
+
+      el.innerHTML=html||'<div class="empty">No external activity detected</div>';
+    }
+    renderBranchesAndPRs(act.controller,'ctrlBranches');
+    renderBranchesAndPRs(act.agent,'agentBranches');
   }
 
   function renderCompliance(){


### PR DESCRIPTION
## Summary
Detects external developer activity on corporate repos (bbvinet/*).\n\n- Collects branches, open PRs, and commits by non-autopilot authors\n- Dashboard shows alerts for external commits, feature branches, open PRs\n- Distinguishes autopilot bot commits from human dev commits\n\nhttps://claude.ai/code/session_01C2jHzg9iscD8qutXUiqKy1