### PR TITLE
feat: deploy controller 3.7.0 — e2e validation

### DIFF
--- a/patches/controller-swagger.json
+++ b/patches/controller-swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PSC SRE Automacao Controller",
     "description": "API do Controller de automacao SRE. Orquestra a execucao de automacoes nos Agents distribuidos por cluster, gerencia logs de execucao, autenticacao JWT e integracao com o OAS (Orquestrador de Automacao de Servicos).",
-    "version": "3.6.9",
+    "version": "3.7.0",
     "contact": {
       "name": "PSC SRE Automacao"
     }

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.6.8
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.7.0
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -1,35 +1,30 @@
 {
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
-  "component": "agent",
+  "component": "controller",
   "change_type": "multi-file",
-  "version": "2.3.1",
+  "version": "3.7.0",
   "changes": [
     {
       "action": "replace-file",
-      "target_path": "src/routes/cronjob-callback.ts",
-      "content_ref": "patches/cronjob-callback.ts"
-    },
-    {
-      "action": "replace-file",
       "target_path": "src/swagger/swagger.json",
-      "content_ref": "patches/agent-swagger.json"
+      "content_ref": "patches/controller-swagger.json"
     },
     {
       "action": "search-replace",
       "target_path": "package.json",
-      "search": "\"version\": \"2.3.0\"",
-      "replace": "\"version\": \"2.3.1\""
+      "search": "\"version\": \"3.6.9\"",
+      "replace": "\"version\": \"3.7.0\""
     },
     {
       "action": "search-replace",
       "target_path": "package-lock.json",
-      "search": "\"version\": \"2.3.0\"",
-      "replace": "\"version\": \"2.3.1\""
+      "search": "\"version\": \"3.6.9\"",
+      "replace": "\"version\": \"3.7.0\""
     }
   ],
-  "commit_message": "fix(agent): resolve no-nested-ternary in cronjob-callback + version 2.3.1",
+  "commit_message": "chore(controller): version bump 3.7.0 — e2e validation test",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 69
+  "run": 70
 }


### PR DESCRIPTION
Deploy controller 3.7.0 (e2e validation test). Version bump 3.6.9 → 3.7.0.\n\nhttps://claude.ai/code/session_01C2jHzg9iscD8qutXUiqKy1