### PR TITLE
feat: deploy agent 2.3.2 — e2e validation

### DIFF
--- a/patches/agent-swagger.json
+++ b/patches/agent-swagger.json
@@ -74,7 +74,7 @@
     },
     "info":  {
         "title":  "psc-sre-automacao-agent",
-        "version":  "2.3.1",
+        "version":  "2.3.2",
         "description":  "psc-sre-automacao-agent in node with expressjs",
         "license":  { "name":  "ISC" },
         "contact":  { "name":  "Equipe DS" }

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -1,30 +1,30 @@
 {
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
-  "component": "controller",
+  "component": "agent",
   "change_type": "multi-file",
-  "version": "3.7.0",
+  "version": "2.3.2",
   "changes": [
     {
       "action": "replace-file",
       "target_path": "src/swagger/swagger.json",
-      "content_ref": "patches/controller-swagger.json"
+      "content_ref": "patches/agent-swagger.json"
     },
     {
       "action": "search-replace",
       "target_path": "package.json",
-      "search": "\"version\": \"3.6.9\"",
-      "replace": "\"version\": \"3.7.0\""
+      "search": "\"version\": \"2.3.1\"",
+      "replace": "\"version\": \"2.3.2\""
     },
     {
       "action": "search-replace",
       "target_path": "package-lock.json",
-      "search": "\"version\": \"3.6.9\"",
-      "replace": "\"version\": \"3.7.0\""
+      "search": "\"version\": \"2.3.1\"",
+      "replace": "\"version\": \"2.3.2\""
     }
   ],
-  "commit_message": "chore(controller): version bump 3.7.0 — e2e validation test",
+  "commit_message": "chore(agent): version bump 2.3.2 — e2e validation test",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 70
+  "run": 71
 }


### PR DESCRIPTION
Deploy agent 2.3.2 (e2e validation). Version bump 2.3.1 → 2.3.2.\n\nhttps://claude.ai/code/session_01C2jHzg9iscD8qutXUiqKy1