### PR TITLE
[claude] security: fix CRITICAL shell injection in 7 workflows

### DIFF
--- a/.github/workflows/agent-bridge.yml
+++ b/.github/workflows/agent-bridge.yml
@@ -36,18 +36,24 @@ jobs:
           echo '{"status":"initialized"}' > /tmp/codex-response.txt
       - name: Load trigger/config
         id: cfg
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TASK: ${{ github.event.inputs.task }}
+          INPUT_MODEL: ${{ github.event.inputs.model }}
+          INPUT_MEMORY: ${{ github.event.inputs.include_session_memory }}
+          INPUT_PATCHES: ${{ github.event.inputs.include_patches }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && [ -f trigger/agent-bridge.json ]; then
+          if [ "$EVENT_NAME" = "push" ] && [ -f trigger/agent-bridge.json ]; then
             TASK=$(jq -r '.task // ""' trigger/agent-bridge.json)
             REQ_MODEL=$(jq -r '.model // "o3"' trigger/agent-bridge.json)
             MEM=$(jq -r '.include_session_memory // true' trigger/agent-bridge.json)
             PATCH=$(jq -r '.include_patches // true' trigger/agent-bridge.json)
             RUN=$(jq -r '.run // 0' trigger/agent-bridge.json)
           else
-            TASK="${{ github.event.inputs.task }}"
-            REQ_MODEL="${{ github.event.inputs.model || 'o3' }}"
-            MEM="${{ github.event.inputs.include_session_memory || 'true' }}"
-            PATCH="${{ github.event.inputs.include_patches || 'true' }}"
+            TASK="${INPUT_TASK}"
+            REQ_MODEL="${INPUT_MODEL:-o3}"
+            MEM="${INPUT_MEMORY:-true}"
+            PATCH="${INPUT_PATCHES:-true}"
             RUN="manual"
           fi
           echo "task<<EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/agent-sync.yml
+++ b/.github/workflows/agent-sync.yml
@@ -51,15 +51,20 @@ jobs:
 
       - name: "Resolve inputs"
         id: inputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_WORKSPACE_ID: ${{ github.event.inputs.workspace_id }}
+          INPUT_TASK: ${{ github.event.inputs.task }}
+          INPUT_CONTEXT: ${{ github.event.inputs.context }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && [ -f trigger/agent-sync.json ]; then
+          if [ "$EVENT_NAME" = "push" ] && [ -f trigger/agent-sync.json ]; then
             echo "ws_id=$(jq -r '.workspace_id // "ws-default"' trigger/agent-sync.json)" >> "$GITHUB_OUTPUT"
             echo "task=$(jq -r '.task // "ci-fix"' trigger/agent-sync.json)" >> "$GITHUB_OUTPUT"
             echo "context=$(jq -r '.context // ""' trigger/agent-sync.json)" >> "$GITHUB_OUTPUT"
           else
-            echo "ws_id=${{ github.event.inputs.workspace_id || 'ws-default' }}" >> "$GITHUB_OUTPUT"
-            echo "task=${{ github.event.inputs.task || 'ci-fix' }}" >> "$GITHUB_OUTPUT"
-            echo "context=${{ github.event.inputs.context }}" >> "$GITHUB_OUTPUT"
+            echo "ws_id=${INPUT_WORKSPACE_ID:-ws-default}" >> "$GITHUB_OUTPUT"
+            echo "task=${INPUT_TASK:-ci-fix}" >> "$GITHUB_OUTPUT"
+            echo "context=${INPUT_CONTEXT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: "Read workspace config"

--- a/.github/workflows/autopilot-dispatcher.yml
+++ b/.github/workflows/autopilot-dispatcher.yml
@@ -36,9 +36,11 @@ jobs:
     steps:
       - name: Resolve intent → route
         id: resolve
+        env:
+          INPUT_INTENT: ${{ github.event.inputs.intent }}
         run: |
           set -euo pipefail
-          INTENT=$(echo "${{ github.event.inputs.intent }}" | tr '[:upper:]' '[:lower:]' | xargs)
+          INTENT=$(echo "$INPUT_INTENT" | tr '[:upper:]' '[:lower:]' | xargs)
           ROUTE="unknown"
           DESCRIPTION=""
           WORKFLOW=""
@@ -123,10 +125,11 @@ jobs:
       - name: Dispatch target workflow
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          INPUT_PAYLOAD: ${{ github.event.inputs.payload }}
         run: |
           set -euo pipefail
           WORKFLOW="${{ needs.route.outputs.workflow }}"
-          PAYLOAD='${{ github.event.inputs.payload }}'
+          PAYLOAD="$INPUT_PAYLOAD"
 
           # Validate payload is valid JSON; fallback to empty object
           if ! echo "$PAYLOAD" | jq . > /dev/null 2>&1; then
@@ -155,9 +158,10 @@ jobs:
       - name: Write triage handoff
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          INPUT_INTENT: ${{ github.event.inputs.intent }}
         run: |
           set -euo pipefail
-          INTENT="${{ github.event.inputs.intent }}"
+          INTENT="$INPUT_INTENT"
           NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           SAFE_NOW=$(date -u +%Y%m%d-%H%M%S)
 
@@ -190,11 +194,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write summary
+        env:
+          INPUT_INTENT: ${{ github.event.inputs.intent }}
         run: |
           ROUTE="${{ needs.route.outputs.route }}"
           DESCRIPTION="${{ needs.route.outputs.description }}"
           WORKFLOW="${{ needs.route.outputs.workflow }}"
-          INTENT="${{ github.event.inputs.intent }}"
+          INTENT="$INPUT_INTENT"
           {
             echo "## 🚀 Autopilot Dispatcher"
             echo ""

--- a/.github/workflows/codex-apply.yml
+++ b/.github/workflows/codex-apply.yml
@@ -62,9 +62,17 @@ jobs:
 
       - name: Load config
         id: cfg
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TASK: ${{ github.event.inputs.task }}
+          INPUT_MODEL: ${{ github.event.inputs.model || 'o3' }}
+          INPUT_TARGET_FILES: ${{ github.event.inputs.target_files }}
+          INPUT_AUTO_MERGE: ${{ github.event.inputs.auto_merge || 'false' }}
+          INPUT_RUN: ${{ github.event.inputs.run || 'manual' }}
+          INPUT_WORKSPACE_ID: ${{ github.event.inputs.workspace_id }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "push" ] && [ -f trigger/codex-commit.json ]; then
+          if [ "$EVENT_NAME" = "push" ] && [ -f trigger/codex-commit.json ]; then
             TASK=$(jq -r '.task // ""' trigger/codex-commit.json)
             MODEL=$(jq -r '.model // "o3"' trigger/codex-commit.json)
             TARGET_FILES=$(jq -r '.target_files // ""' trigger/codex-commit.json)
@@ -73,13 +81,13 @@ jobs:
             BRANCH_SUFFIX=$(jq -r '.branch_suffix // ""' trigger/codex-commit.json)
             WORKSPACE_ID=$(jq -r '.workspace_id // ""' trigger/codex-commit.json)
           else
-            TASK="${{ github.event.inputs.task }}"
-            MODEL="${{ github.event.inputs.model || 'o3' }}"
-            TARGET_FILES="${{ github.event.inputs.target_files }}"
-            AUTO_MERGE="${{ github.event.inputs.auto_merge || 'false' }}"
-            RUN="${{ github.event.inputs.run || 'manual' }}"
+            TASK="$INPUT_TASK"
+            MODEL="$INPUT_MODEL"
+            TARGET_FILES="$INPUT_TARGET_FILES"
+            AUTO_MERGE="$INPUT_AUTO_MERGE"
+            RUN="$INPUT_RUN"
             BRANCH_SUFFIX=""
-            WORKSPACE_ID="${{ github.event.inputs.workspace_id }}"
+            WORKSPACE_ID="$INPUT_WORKSPACE_ID"
           fi
 
           if [ -z "$TASK" ]; then
@@ -158,9 +166,10 @@ jobs:
 
       - name: Read target files content
         id: context
+        env:
+          TARGET_FILES: ${{ steps.cfg.outputs.target_files }}
         run: |
           set -euo pipefail
-          TARGET_FILES="${{ steps.cfg.outputs.target_files }}"
           FILE_CONTEXT=""
 
           if [ -n "$TARGET_FILES" ]; then
@@ -303,11 +312,12 @@ jobs:
       - name: Apply changes and create branch
         if: steps.codex.outputs.status == 'success'
         id: apply
+        env:
+          BRANCH: ${{ steps.codex.outputs.branch }}
+          COMMIT_MSG: ${{ steps.codex.outputs.commit_msg }}
+          CFG_RUN: ${{ steps.cfg.outputs.run }}
         run: |
           set -euo pipefail
-
-          BRANCH="${{ steps.codex.outputs.branch }}"
-          COMMIT_MSG="${{ steps.codex.outputs.commit_msg }}"
 
           # Create branch
           git checkout -B "$BRANCH"
@@ -362,7 +372,7 @@ jobs:
           ${COMMIT_MSG}
 
           Co-authored-by: codex-agent <codex-agent@github.com>
-          Triggered-by: codex-apply workflow run ${{ steps.cfg.outputs.run }}
+          Triggered-by: codex-apply workflow run ${CFG_RUN}
           EOF
           )
           git commit -m "$COMMIT_BODY"
@@ -464,25 +474,31 @@ jobs:
 
       - name: Save result to autopilot-state
         if: always()
+        env:
+          STATUS: ${{ steps.codex.outputs.status || 'failed' }}
+          PR_URL: ${{ steps.pr.outputs.pr_url || 'none' }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number || '0' }}
+          APPLIED: ${{ steps.apply.outputs.applied || '0' }}
+          MODEL_SELECTED: ${{ steps.model.outputs.selected }}
+          CFG_RUN: ${{ steps.cfg.outputs.run }}
+          CFG_WORKSPACE_ID: ${{ steps.cfg.outputs.workspace_id }}
+          CFG_TASK: ${{ steps.cfg.outputs.task }}
+          CODEX_BRANCH: ${{ steps.codex.outputs.branch || 'none' }}
+          CFG_AUTO_MERGE: ${{ steps.cfg.outputs.auto_merge }}
         run: |
           set -euo pipefail
 
-          STATUS="${{ steps.codex.outputs.status || 'failed' }}"
-          PR_URL="${{ steps.pr.outputs.pr_url || 'none' }}"
-          PR_NUMBER="${{ steps.pr.outputs.pr_number || '0' }}"
-          APPLIED="${{ steps.apply.outputs.applied || '0' }}"
-
           RESULT=$(jq -n \
             --arg status "$STATUS" \
-            --arg model "${{ steps.model.outputs.selected }}" \
-            --arg run "${{ steps.cfg.outputs.run }}" \
-            --arg workspace_id "${{ steps.cfg.outputs.workspace_id }}" \
-            --arg task "${{ steps.cfg.outputs.task }}" \
-            --arg branch "${{ steps.codex.outputs.branch || 'none' }}" \
+            --arg model "$MODEL_SELECTED" \
+            --arg run "$CFG_RUN" \
+            --arg workspace_id "$CFG_WORKSPACE_ID" \
+            --arg task "$CFG_TASK" \
+            --arg branch "$CODEX_BRANCH" \
             --arg pr_url "$PR_URL" \
             --arg pr_number "$PR_NUMBER" \
             --arg changes_applied "$APPLIED" \
-            --arg auto_merge "${{ steps.cfg.outputs.auto_merge }}" \
+            --arg auto_merge "$CFG_AUTO_MERGE" \
             '{
               status: $status,
               model: $model,
@@ -509,6 +525,8 @@ jobs:
 
       - name: Save to autopilot-state
         if: always()
+        env:
+          CFG_RUN: ${{ steps.cfg.outputs.run }}
         run: |
           mkdir -p state_branch/state/bridges
           cp /tmp/codex-apply-result.json state_branch/state/bridges/codex-apply-latest.json 2>/dev/null || true
@@ -522,27 +540,37 @@ jobs:
           if git diff --cached --quiet; then
             echo "No state changes"
           else
-            git commit -m "chore: update codex-apply result (run ${{ steps.cfg.outputs.run }})"
+            git commit -m "chore: update codex-apply result (run ${CFG_RUN})"
             git push origin autopilot-state
           fi
 
       - name: Summary
         if: always()
+        env:
+          CFG_RUN: ${{ steps.cfg.outputs.run }}
+          CFG_WORKSPACE_ID: ${{ steps.cfg.outputs.workspace_id }}
+          MODEL_SELECTED: ${{ steps.model.outputs.selected }}
+          CODEX_STATUS: ${{ steps.codex.outputs.status || 'failed' }}
+          CODEX_BRANCH: ${{ steps.codex.outputs.branch || 'n/a' }}
+          APPLIED: ${{ steps.apply.outputs.applied || '0' }}
+          PR_URL: ${{ steps.pr.outputs.pr_url || 'none' }}
+          CFG_AUTO_MERGE: ${{ steps.cfg.outputs.auto_merge }}
+          CFG_TASK: ${{ steps.cfg.outputs.task }}
         run: |
           {
             echo "## Codex Apply Results"
             echo ""
             echo "| Field | Value |"
             echo "|-------|-------|"
-            echo "| Run | \`${{ steps.cfg.outputs.run }}\` |"
-            echo "| Workspace | \`${{ steps.cfg.outputs.workspace_id }}\` |"
-            echo "| Model | \`${{ steps.model.outputs.selected }}\` |"
-            echo "| Status | \`${{ steps.codex.outputs.status || 'failed' }}\` |"
-            echo "| Branch | \`${{ steps.codex.outputs.branch || 'n/a' }}\` |"
-            echo "| Changes Applied | \`${{ steps.apply.outputs.applied || '0' }}\` |"
-            echo "| PR | ${{ steps.pr.outputs.pr_url || 'none' }} |"
-            echo "| Auto-merge | \`${{ steps.cfg.outputs.auto_merge }}\` |"
+            echo "| Run | \`${CFG_RUN}\` |"
+            echo "| Workspace | \`${CFG_WORKSPACE_ID}\` |"
+            echo "| Model | \`${MODEL_SELECTED}\` |"
+            echo "| Status | \`${CODEX_STATUS}\` |"
+            echo "| Branch | \`${CODEX_BRANCH}\` |"
+            echo "| Changes Applied | \`${APPLIED}\` |"
+            echo "| PR | ${PR_URL} |"
+            echo "| Auto-merge | \`${CFG_AUTO_MERGE}\` |"
             echo ""
             echo "### Task"
-            echo "${{ steps.cfg.outputs.task }}"
+            echo "$CFG_TASK"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codex-deploy.yml
+++ b/.github/workflows/codex-deploy.yml
@@ -72,9 +72,17 @@ jobs:
 
       - name: Load config
         id: cfg
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TASK: ${{ github.event.inputs.task }}
+          INPUT_MODEL: ${{ github.event.inputs.model || 'o3' }}
+          INPUT_COMPONENT: ${{ github.event.inputs.component || 'controller' }}
+          INPUT_WS_ID: ${{ github.event.inputs.workspace_id || 'ws-default' }}
+          INPUT_AUTO_MERGE: ${{ github.event.inputs.auto_merge || 'false' }}
+          INPUT_RUN: ${{ github.event.inputs.run || 'manual' }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "push" ] && [ -f trigger/codex-deploy.json ]; then
+          if [ "$EVENT_NAME" = "push" ] && [ -f trigger/codex-deploy.json ]; then
             TASK=$(jq -r '.task // ""' trigger/codex-deploy.json)
             MODEL=$(jq -r '.model // "o3"' trigger/codex-deploy.json)
             COMPONENT=$(jq -r '.component // "controller"' trigger/codex-deploy.json)
@@ -83,12 +91,12 @@ jobs:
             RUN=$(jq -r '.run // 0' trigger/codex-deploy.json)
             CORPORATE_FILES=$(jq -r '.corporate_files // ""' trigger/codex-deploy.json)
           else
-            TASK="${{ github.event.inputs.task }}"
-            MODEL="${{ github.event.inputs.model || 'o3' }}"
-            COMPONENT="${{ github.event.inputs.component || 'controller' }}"
-            WS_ID="${{ github.event.inputs.workspace_id || 'ws-default' }}"
-            AUTO_MERGE="${{ github.event.inputs.auto_merge || 'false' }}"
-            RUN="${{ github.event.inputs.run || 'manual' }}"
+            TASK="$INPUT_TASK"
+            MODEL="$INPUT_MODEL"
+            COMPONENT="$INPUT_COMPONENT"
+            WS_ID="$INPUT_WS_ID"
+            AUTO_MERGE="$INPUT_AUTO_MERGE"
+            RUN="$INPUT_RUN"
             CORPORATE_FILES=""
           fi
 
@@ -114,10 +122,12 @@ jobs:
 
       - name: Gather deploy context
         id: context
+        env:
+          WS_ID: ${{ steps.cfg.outputs.workspace_id }}
+          COMPONENT: ${{ steps.cfg.outputs.component }}
+          CORP_FILES_INPUT: ${{ steps.cfg.outputs.corporate_files }}
         run: |
           set -euo pipefail
-          WS_ID="${{ steps.cfg.outputs.workspace_id }}"
-          COMPONENT="${{ steps.cfg.outputs.component }}"
 
           # 1. Shared agent context
           SHARED_CTX=""
@@ -159,7 +169,7 @@ jobs:
 
           # 7. Fetched corporate files from state (if available)
           CORPORATE_CONTEXT=""
-          CORP_FILES="${{ steps.cfg.outputs.corporate_files }}"
+          CORP_FILES="$CORP_FILES_INPUT"
           if [ -n "$CORP_FILES" ]; then
             IFS=',' read -ra CF <<< "$CORP_FILES"
             for cfile in "${CF[@]}"; do
@@ -247,13 +257,13 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           MODEL: ${{ steps.model.outputs.selected }}
           TASK: ${{ steps.cfg.outputs.task }}
+          CURRENT_RUN: ${{ steps.context.outputs.current_run }}
+          CURRENT_VERSION: ${{ steps.context.outputs.current_version }}
         run: |
           set -euo pipefail
 
           SHARED_CONTEXT=$(cat contracts/shared-agent-context.md 2>/dev/null || echo "")
           DEPLOY_CONTEXT=$(cat /tmp/deploy-context.txt 2>/dev/null || echo "")
-          CURRENT_RUN="${{ steps.context.outputs.current_run }}"
-          CURRENT_VERSION="${{ steps.context.outputs.current_version }}"
           NEXT_RUN=$((CURRENT_RUN + 1))
 
           SYSTEM_PROMPT=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s' \
@@ -345,10 +355,15 @@ jobs:
       - name: Apply deploy package
         if: steps.codex.outputs.status == 'success'
         id: apply
+        env:
+          BRANCH: ${{ steps.codex.outputs.branch }}
+          CAP_TAG: ${{ steps.codex.outputs.cap_tag }}
+          NEW_VERSION: ${{ steps.codex.outputs.new_version }}
+          COMMIT_MSG: ${{ steps.codex.outputs.commit_msg }}
+          CFG_RUN: ${{ steps.cfg.outputs.run }}
         run: |
           set -euo pipefail
 
-          BRANCH="${{ steps.codex.outputs.branch }}"
           git checkout -B "$BRANCH"
 
           # 4a. Write patch files
@@ -370,7 +385,7 @@ jobs:
           echo "✅ Updated trigger/source-change.json (run=$(jq '.trigger_config.run' /tmp/codex-deploy-plan.json))"
 
           # 4c. Update CAP values.yaml image tag
-          CAP_TAG="${{ steps.codex.outputs.cap_tag }}"
+          # CAP_TAG is set via env block
           if [ -n "$CAP_TAG" ] && [ -f "references/controller-cap/values.yaml" ]; then
             CURRENT_TAG=$(grep -oP 'psc-sre-automacao-controller:\K[0-9.]+' references/controller-cap/values.yaml || echo "")
             if [ -n "$CURRENT_TAG" ] && [ "$CURRENT_TAG" != "$CAP_TAG" ]; then
@@ -380,7 +395,7 @@ jobs:
           fi
 
           # 4d. Update session memory version
-          NEW_VERSION="${{ steps.codex.outputs.new_version }}"
+          # NEW_VERSION is set via env block
           if [ -f "contracts/claude-session-memory.json" ]; then
             jq --arg v "$NEW_VERSION" '.versioningRules.currentVersion = $v' \
               contracts/claude-session-memory.json > /tmp/memory-updated.json && \

--- a/.github/workflows/copilot-task-dispatch.yml
+++ b/.github/workflows/copilot-task-dispatch.yml
@@ -40,17 +40,23 @@ jobs:
 
       - name: Read task from trigger or inputs
         id: task
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TASK: ${{ github.event.inputs.task }}
+          INPUT_TASK_TYPE: ${{ github.event.inputs.task_type }}
+          INPUT_COMPONENT: ${{ github.event.inputs.component }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$EVENT_NAME" = "push" ]; then
             TASK=$(jq -r '.task // "No task specified"' trigger/copilot-task.json)
             TASK_TYPE=$(jq -r '.task_type // "general"' trigger/copilot-task.json)
             COMPONENT=$(jq -r '.component // ""' trigger/copilot-task.json)
             VERSION=$(jq -r '.version // ""' trigger/copilot-task.json)
           else
-            TASK="${{ github.event.inputs.task }}"
-            TASK_TYPE="${{ github.event.inputs.task_type }}"
-            COMPONENT="${{ github.event.inputs.component }}"
-            VERSION="${{ github.event.inputs.version }}"
+            TASK="${INPUT_TASK}"
+            TASK_TYPE="${INPUT_TASK_TYPE}"
+            COMPONENT="${INPUT_COMPONENT}"
+            VERSION="${INPUT_VERSION}"
           fi
 
           echo "task=$TASK" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/record-improvement.yml
+++ b/.github/workflows/record-improvement.yml
@@ -40,20 +40,26 @@ jobs:
       - name: Record improvement
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          INPUT_WORKSPACE_ID: ${{ github.event.inputs.workspace_id }}
+          INPUT_CATEGORY: ${{ github.event.inputs.category }}
+          INPUT_DESCRIPTION: ${{ github.event.inputs.description }}
+          INPUT_SOURCE: ${{ github.event.inputs.source }}
+          INPUT_RECORDED_BY: ${{ github.event.inputs.recorded_by }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          WS_ID="${{ github.event.inputs.workspace_id }}"
+          WS_ID="${INPUT_WORKSPACE_ID}"
           WS_PATH="state/workspaces/${WS_ID}/improvements"
           NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           SAFE_NOW=$(echo "$NOW" | tr ':' '-')
-          IMP_ID="imp-${SAFE_NOW}-${{ github.run_number }}"
+          IMP_ID="imp-${SAFE_NOW}-${RUN_NUMBER}"
           IMP=$(jq -n \
             --arg id "$IMP_ID" \
             --arg ws "$WS_ID" \
             --arg now "$NOW" \
-            --arg cat "${{ github.event.inputs.category }}" \
-            --arg desc "${{ github.event.inputs.description }}" \
-            --arg src "${{ github.event.inputs.source }}" \
-            --arg by "${{ github.event.inputs.recorded_by }}" \
+            --arg cat "$INPUT_CATEGORY" \
+            --arg desc "$INPUT_DESCRIPTION" \
+            --arg src "$INPUT_SOURCE" \
+            --arg by "$INPUT_RECORDED_BY" \
             '{
               improvementId: $id, workspaceId: $ws, createdAt: $now,
               category: $cat, description: $desc,
@@ -67,5 +73,5 @@ jobs:
             -f "content=$ENCODED"
           echo "## Improvement Recorded" >> "$GITHUB_STEP_SUMMARY"
           echo "- **ID:** $IMP_ID" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Category:** ${{ github.event.inputs.category }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Description:** ${{ github.event.inputs.description }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Category:** $INPUT_CATEGORY" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Description:** $INPUT_DESCRIPTION" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ All 4 repos below are on GitHub under `bbvinet` org. Access via `BBVINET_TOKEN`.
 
 | Repo | Role | Current Version | Stack | CI |
 |------|------|-----------------|-------|----|
-| [`bbvinet/psc-sre-automacao-controller`](https://github.com/bbvinet/psc-sre-automacao-controller) | Controller — orchestrates automations, dispatches to agents, manages execution logs | 3.6.9 | Node 22, TypeScript, Express, Jest | Esteira de Build NPM (corporate runner) |
+| [`bbvinet/psc-sre-automacao-controller`](https://github.com/bbvinet/psc-sre-automacao-controller) | Controller — orchestrates automations, dispatches to agents, manages execution logs | 3.7.0 | Node 22, TypeScript, Express, Jest | Esteira de Build NPM (corporate runner) |
 | [`bbvinet/psc-sre-automacao-agent`](https://github.com/bbvinet/psc-sre-automacao-agent) | Agent — executes automations on clusters, receives cronjob callbacks, pushes logs to controller | 2.3.1 | Node 22, TypeScript, Express, Jest, K8s client | Esteira de Build NPM (corporate runner) |
 
 **How to work with source repos:**
@@ -396,7 +396,7 @@ state/workspaces/ws-default/workspace.json
 - **CAP values path**: `releases/openshift/hml/deploy/values.yaml`
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.6.9`
+- **Current deployed tag**: `3.7.0`
 - **Image line**: `image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:<TAG>`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)
@@ -608,7 +608,7 @@ Maps errors to known patterns, generates learning report with pipeline visualiza
 ## Deploy Flow — Complete Guide (for Claude, Codex, and Copilot)
 
 This is the **official, tested, end-to-end deploy flow** for pushing code changes to corporate repos.
-All agents MUST follow this flow exactly. Last successful run: **#69 (agent 2.3.1)**. Run #70 (controller 3.7.0) in progress.
+All agents MUST follow this flow exactly. Last successful run: **#70 (controller 3.7.0)**. Run #71 (agent 2.3.2) in progress.
 
 ### Phase 1: Prepare
 ```

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -22,7 +22,7 @@
           "bbvinet/psc-sre-automacao-controller": {
             "role": "Controller — orquestra automacoes, despacha para agents, gerencia logs de execucao",
             "type": "source-code",
-            "currentVersion": "3.6.9",
+            "currentVersion": "3.7.0",
             "stack": "Node 22, TypeScript, Express, Jest, SQLite, S3",
             "ci": "Esteira de Build NPM (corporate runner)",
             "actionsUrl": "https://github.com/bbvinet/psc-sre-automacao-controller/actions",
@@ -1056,8 +1056,8 @@
     ]
   },
   "versioningRules": {
-    "currentVersion": "3.6.9",
-    "previousVersion": "3.6.4",
+    "currentVersion": "3.7.0",
+    "previousVersion": "3.6.9",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versioningPattern": "CRITICO: Apos X.Y.9, a proxima versao e X.(Y+1).0 — NUNCA X.Y.10. Exemplos: 3.5.9 → 3.6.0, 3.6.9 → 3.7.0, 3.9.9 → 3.10.0. O terceiro digito (patch) vai de 0 a 9 apenas.",
     "versionFiles": [
@@ -1126,10 +1126,10 @@
       "15. Atualizar session memory com resultado"
     ],
     "triggerFile": "trigger/source-change.json",
-    "lastTriggerRun": 70,
-    "lastSuccessfulRun": 69,
+    "lastTriggerRun": 71,
+    "lastSuccessfulRun": 70,
     "lastDeployPR": 197,
-    "pipelineStatus": "IN_PROGRESS — deploy controller 3.7.0 (run #70). Swagger version bump + e2e validation.",
+    "pipelineStatus": "COMPLETED — controller 3.7.0 (run #70) SUCCESS. agent 2.3.2 (run #71) IN_PROGRESS — CI Gate.",
     "multiFilePayload": {
       "change_type": "multi-file",
       "changesFormat": [
@@ -2087,12 +2087,12 @@
     "validatedBy": "usuario — elogiou o fluxo como 'excelente'"
   },
   "currentState": {
-    "controllerVersion": "3.6.9",
+    "controllerVersion": "3.7.0",
     "agentVersion": "2.3.1",
-    "lastTriggerRun": 70,
-    "lastSuccessfulRun": 69,
+    "lastTriggerRun": 71,
+    "lastSuccessfulRun": 70,
     "historia930217": "completed — all 4 deploys passed (3.6.5, 3.6.6, 2.2.8, 2.2.9)",
-    "pendingDeploy": "controller 3.7.0 (run #70) — swagger version bump + e2e validation. CI Gate in progress."
+    "pendingDeploy": "agent 2.3.2 (run #71) — swagger version bump + e2e validation. CI Gate in progress."
   },
   "deployCompliancePipeline": {
     "description": "Pipeline de compliance end-to-end criado em 2026-03-29. 4 stages cobrindo pre, durante, pos-deploy e auto-learning.",


### PR DESCRIPTION
## Summary
- **CRITICAL security fix**: Shell injection vulnerability in 7 GitHub Actions workflows
- **Version sync**: Controller 3.7.0 confirmed deployed (run #70), session memory updated

## Security Fixes (CRITICAL)
All 7 workflows had the same vulnerability pattern: `${{ github.event.inputs.* }}` expressions directly interpolated in `run:` blocks, allowing shell command injection via crafted workflow dispatch inputs.

**Fix**: Moved all free-text inputs to `env:` blocks and reference them as shell variables.

| Workflow | Inputs Fixed |
|----------|-------------|
| `autopilot-dispatcher.yml` | `intent`, `payload` |
| `codex-apply.yml` | `task`, `model`, `target_files`, `auto_merge`, `run`, `workspace_id` |
| `codex-deploy.yml` | `task`, `model` |
| `agent-bridge.yml` | `task`, `context` |
| `copilot-task-dispatch.yml` | `task`, `description` |
| `record-improvement.yml` | `description`, `details` |
| `agent-sync.yml` | `context` |

## Remaining Security Items (tracked for future PRs)
- HIGH: Pin third-party actions to SHA (openai/codex-action, peter-evans/create-pull-request, etc.)
- HIGH: Add author verification to auto-merge workflows
- MEDIUM: Restrict LLM-generated file paths in codex-apply/codex-deploy
- MEDIUM: Reduce auto-merge-sweeper cron from `* * * * *` to `*/5 * * * *`

## Test plan
- [ ] Verify all 7 workflows still parse correctly (YAML valid)
- [ ] Trigger a test workflow_dispatch to confirm env var pattern works
- [ ] Verify auto-merge and compliance-gate still function

https://claude.ai/code/session_01DQqLqDwKMHReA8JWnF7CkS