### PR TITLE
fix: remove locked workspaces + CAP tag versions + map docs

### DIFF
--- a/.github/workflows/spark-sync-state.yml
+++ b/.github/workflows/spark-sync-state.yml
@@ -263,7 +263,7 @@ jobs:
               syncSource: "autopilot/spark-sync-state.yml",
 
               controller: {
-                version: ($ctrl.lastTag // $trigger.version // "?"),
+                version: (if $ctrl_cap != "?" then $ctrl_cap else ($ctrl.lastTag // $trigger.version // "?") end),
                 status: ($ctrl.status // "unknown"),
                 ciResult: ($ctrl.ciResult // "unknown"),
                 promoted: ($ctrl.promoted // false),
@@ -275,7 +275,7 @@ jobs:
               },
 
               agent: {
-                version: ($agent.lastTag // "?"),
+                version: (if $agent_cap != "?" then $agent_cap else ($agent.lastTag // "?") end),
                 status: ($agent.status // "unknown"),
                 ciResult: ($agent.ciResult // "unknown"),
                 promoted: ($agent.promoted // false),
@@ -339,8 +339,8 @@ jobs:
                   status: "active",
                   stack: "Node/TypeScript (NestJS, Jest, ESLint)",
                   token: "BBVINET_TOKEN",
-                  controllerVersion: ($ctrl.lastTag // $trigger.version // "?"),
-                  agentVersion: ($agent.lastTag // "?"),
+                  controllerVersion: (if $ctrl_cap != "?" then $ctrl_cap else ($ctrl.lastTag // $trigger.version // "?") end),
+                  agentVersion: (if $agent_cap != "?" then $agent_cap else ($agent.lastTag // "?") end),
                   pipelineStatus: ($copilot.currentState.pipelineStatus // "idle"),
                   repos: ["psc-sre-automacao-controller", "psc-sre-automacao-agent", "psc_releases_cap_sre-aut-controller", "psc_releases_cap_sre-aut-agent"]
                 },
@@ -355,28 +355,6 @@ jobs:
                   pipelineStatus: "not-configured",
                   repos: []
                 },
-                {
-                  id: "ws-socnew",
-                  company: "SocNew (terceiro)",
-                  status: "locked",
-                  stack: null,
-                  token: null,
-                  controllerVersion: null,
-                  agentVersion: null,
-                  pipelineStatus: "locked",
-                  repos: []
-                },
-                {
-                  id: "ws-corp-1",
-                  company: "Corp-1 (terceiro)",
-                  status: "locked",
-                  stack: null,
-                  token: null,
-                  controllerVersion: null,
-                  agentVersion: null,
-                  pipelineStatus: "locked",
-                  repos: []
-                }
               ],
 
               recentWorkflows: $runs,
@@ -477,7 +455,7 @@ jobs:
                 autopilotRepo: "lucassfreiree/autopilot",
                 sparkRepo: "lucassfreiree/spark-dashboard",
                 totalAgents: 1,
-                totalWorkspaces: 4,
+                totalWorkspaces: 2,
                 syncInterval: "5min business hours (8-17 BRT Mon-Fri) / 15min off-hours",
                 stateVersion: 5
               }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,6 +542,15 @@ Maps errors to known patterns, generates learning report with pipeline visualiza
 |----------|---------|
 | continuous-improvement.yml | Weekly self-analysis: scan → auto-fix → learn → alert (6-stage pipeline) |
 
+### Intelligent Monitoring Stack (5 layers of self-healing)
+| Workflow | Schedule | Purpose |
+|----------|----------|---------|
+| builds-validation-gate.yml | On PR + weekly | **Layer 1 (Prevention)**: Validates ALL workflow YAML syntax, deprecated actions, missing concurrency, hardcoded secrets. Blocks broken workflows. |
+| workflow-health-monitor.yml | 30min / 2h | **Layer 2 (Detection)**: Scans ALL 69+ workflows, detects consecutive failures, calculates fail rates, creates alert Issues. |
+| workflow-auto-repair.yml | On-demand | **Layer 3 (Repair)**: Auto-fixes disabled workflows, stuck runs (>60min), expired locks, queued pile-ups. Triggered by health-monitor. |
+| intelligent-orchestrator.yml | 15min / 30min / 1h | **Layer 4 (Brain)**: OBSERVE → DECIDE → ACT → LEARN loop. Persistent knowledge base on autopilot-state. Learns from outcomes. |
+| workflow-sentinel.yml | 4h | **Layer 5 (Meta-monitor)**: Watches the monitoring stack itself. Re-enables disabled monitors, re-runs failed monitors, escalates via Issue. |
+
 ### Infrastructure
 | Workflow | Purpose |
 |----------|---------|
@@ -573,8 +582,12 @@ Maps errors to known patterns, generates learning report with pipeline visualiza
 | copilot-task-dispatch.yml | Dispatch tasks to Copilot via issue creation |
 | repo-cleanup.yml | Clean up unused files and branches |
 | promote-cap.yml | Manual CAP promotion (trigger via `trigger/promote-cap.json`) |
-| spark-sync-state.yml | Sync state.json to Spark dashboard repo (every 15 min) |
+| spark-sync-state.yml | Sync state.json to Spark dashboard repo (every 5/15 min). Uses safe_api/safe_content helpers — crash-proof. |
 | post-merge-monitor.yml | Monitor workflows after PR merge |
+| dashboard-auto-improve.yml | Daily dashboard data accuracy validation (version consistency, sync freshness, HTML integrity) |
+| auto-dispatch-task.yml | Auto-dispatch tasks from Issues to appropriate agents |
+| dispatch-proxy.yml | Operations dispatch proxy for multi-workspace routing |
+| token-auto-optimize.yml | Daily token usage optimization (compact memory, archive old sessions) |
 | sync-copilot-prompt.yml | Auto-regenerates Copilot prompt when project changes |
 
 ### Codex Automation

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -1267,6 +1267,23 @@
       "Usar git checkout -B (force) em vez de delete + create"
     ]
   },
+  "monitoringStack": {
+    "description": "5-layer self-healing monitoring architecture — built session 01UUEz9wrwdB57dxdkLXc5Kw",
+    "layers": [
+      {"layer": 1, "name": "Prevention", "workflow": "builds-validation-gate.yml", "schedule": "on PR + weekly", "purpose": "Validates workflow YAML before merge"},
+      {"layer": 2, "name": "Detection", "workflow": "workflow-health-monitor.yml", "schedule": "30min/2h", "purpose": "Scans all 69+ workflows for failures"},
+      {"layer": 3, "name": "Repair", "workflow": "workflow-auto-repair.yml", "schedule": "on-demand", "purpose": "Auto-fixes disabled, stuck, expired, piled-up"},
+      {"layer": 4, "name": "Brain", "workflow": "intelligent-orchestrator.yml", "schedule": "15min/30min/1h", "purpose": "OBSERVE-DECIDE-ACT-LEARN loop with knowledge base"},
+      {"layer": 5, "name": "Sentinel", "workflow": "workflow-sentinel.yml", "schedule": "4h", "purpose": "Meta-monitor watches the monitors"}
+    ],
+    "knowledgeBase": "state/orchestrator-knowledge.json on autopilot-state",
+    "fixes_applied_session": {
+      "pipefail_removed": 18,
+      "concurrency_added": 7,
+      "spark_sync_rewritten": true,
+      "total_workflows_fixed": 27
+    }
+  },
   "commonPatterns": {
     "patchCreation": {
       "location": "patches/",


### PR DESCRIPTION
- Remove ws-socnew/ws-corp-1 from dashboard (locked third-party)
- Use CAP tag as version source of truth (fixes agent showing wrong version)
- Map all new monitoring workflows in CLAUDE.md and session memory

https://claude.ai/code/session_01UUEz9wrwdB57dxdkLXc5Kw