### PR TITLE
chore: re-enable spark-sync-state workflow triggers

### DIFF
--- a/.github/workflows/spark-sync-state.yml
+++ b/.github/workflows/spark-sync-state.yml
@@ -23,6 +23,7 @@ on:
       - 'trigger/source-change.json'
       - 'references/spark-dashboard/**'
   workflow_dispatch: {}
+  # v2: script extracted to scripts/dashboard/collect-state.sh (fix 21000 char limit)
 
 permissions:
   contents: write


### PR DESCRIPTION
Force GitHub to re-parse and re-enable spark-sync-state triggers after 93+ failures caused throttling.

https://claude.ai/code/session_01UUEz9wrwdB57dxdkLXc5Kw