### PR TITLE
fix: 3 failing workflows — JSON injection + set -e fragility

### DIFF
--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          set -e
+          # No set -e — scan must complete even if individual checks fail
           SCOPE="${{ needs.setup.outputs.scope }}"
           ISSUES='[]'
           TOTAL=0; CRIT=0; HIGH=0; MED=0; LOW=0; FIXABLE=0
@@ -130,7 +130,7 @@ jobs:
           add_issue() {
             local SEV="$1" FILE="$2" DESC="$3" FIX="$4"
             ISSUES=$(echo "$ISSUES" | jq --arg s "$SEV" --arg f "$FILE" --arg d "$DESC" --arg fix "$FIX" \
-              '. + [{severity:$s, file:$f, description:$d, autoFixable:($fix == "true")}]')
+              '. + [{severity:$s, file:$f, description:$d, autoFixable:($fix == "true")}]' 2>/dev/null || echo "$ISSUES")
             TOTAL=$((TOTAL + 1))
             case "$SEV" in
               critical) CRIT=$((CRIT + 1)) ;;

--- a/.github/workflows/intelligent-orchestrator.yml
+++ b/.github/workflows/intelligent-orchestrator.yml
@@ -233,11 +233,16 @@ jobs:
     steps:
       - name: Build action plan
         id: plan
+        env:
+          IN_FAILING: ${{ needs.observe.outputs.failing_workflows }}
+          IN_KB: ${{ needs.observe.outputs.knowledge_base }}
         run: |
           HEALTH="${{ needs.observe.outputs.ecosystem_health }}"
-          FAILING='${{ needs.observe.outputs.failing_workflows }}'
+          FAILING="$IN_FAILING"
+          echo "$FAILING" | jq empty 2>/dev/null || FAILING='[]'
           DASH_STALE="${{ needs.observe.outputs.dashboard_stale }}"
-          KB='${{ needs.observe.outputs.knowledge_base }}'
+          KB="$IN_KB"
+          echo "$KB" | jq empty 2>/dev/null || KB='{}'
 
           ACTIONS="[]"
 
@@ -347,8 +352,12 @@ jobs:
     steps:
       - name: Execute action plan
         id: execute
+        env:
+          ACTION_PLAN: ${{ needs.decide.outputs.action_plan }}
         run: |
-          PLAN='${{ needs.decide.outputs.action_plan }}'
+          PLAN="$ACTION_PLAN"
+          # Validate JSON
+          echo "$PLAN" | jq empty 2>/dev/null || PLAN='[]'
           RESULTS="[]"
           SUCCESS=0
           FAILED=0
@@ -424,11 +433,19 @@ jobs:
       GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Update knowledge base
+        env:
+          IN_HEALTH: ${{ needs.observe.outputs.ecosystem_health || 'unknown' }}
+          IN_FAILING: ${{ needs.observe.outputs.failing_workflows || '[]' }}
+          IN_RESULTS: ${{ needs.act.outputs.results || '[]' }}
+          IN_KB: ${{ needs.observe.outputs.knowledge_base || '{}' }}
         run: |
-          HEALTH="${{ needs.observe.outputs.ecosystem_health || 'unknown' }}"
-          FAILING='${{ needs.observe.outputs.failing_workflows || '[]' }}'
-          RESULTS='${{ needs.act.outputs.results || '[]' }}'
-          KB='${{ needs.observe.outputs.knowledge_base || '{}' }}'
+          HEALTH="$IN_HEALTH"
+          FAILING="$IN_FAILING"
+          echo "$FAILING" | jq empty 2>/dev/null || FAILING='[]'
+          RESULTS="$IN_RESULTS"
+          echo "$RESULTS" | jq empty 2>/dev/null || RESULTS='[]'
+          KB="$IN_KB"
+          echo "$KB" | jq empty 2>/dev/null || KB='{}'
           NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
           # Build learning entry
@@ -489,7 +506,8 @@ jobs:
             --jq '.[0].number // ""' 2>/dev/null || echo "")
 
           if [ -z "$EXISTING" ]; then
-            FAILING='${{ needs.observe.outputs.failing_workflows || '[]' }}'
+            FAILING="${{ needs.observe.outputs.failing_workflows }}"
+            echo "$FAILING" | jq empty 2>/dev/null || FAILING='[]'
             FAILING_DETAIL=$(echo "$FAILING" | jq -r '.[] | select(.consecutive >= 5) | "- **\(.name)**: \(.consecutive) consecutive failures"' 2>/dev/null || echo "- Details unavailable")
 
             gh api "repos/$REPO/issues" \

--- a/.github/workflows/workflow-auto-repair.yml
+++ b/.github/workflows/workflow-auto-repair.yml
@@ -216,8 +216,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Execute repairs
+        env:
+          REPAIRS_JSON: ${{ needs.diagnose.outputs.repairs }}
         run: |
-          REPAIRS='${{ needs.diagnose.outputs.repairs }}'
+          REPAIRS="$REPAIRS_JSON"
+          echo "$REPAIRS" | jq empty 2>/dev/null || REPAIRS='[]'
           APPLIED=0
           FAILED=0
 
@@ -308,12 +311,16 @@ jobs:
           echo "- Skipped (alert-only): $(echo "$REPAIRS" | jq '[.[] | select(.type == "alert-only")] | length')" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save repair audit
+        env:
+          REPAIRS_JSON: ${{ needs.diagnose.outputs.repairs }}
         run: |
+          SAFE_REPAIRS="$REPAIRS_JSON"
+          echo "$SAFE_REPAIRS" | jq empty 2>/dev/null || SAFE_REPAIRS='[]'
           AUDIT=$(jq -n \
             --arg timestamp "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             --arg source "${{ github.event.inputs.source || 'scheduled' }}" \
             --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --argjson repairs '${{ needs.diagnose.outputs.repairs }}' \
+            --argjson repairs "$SAFE_REPAIRS" \
             '{timestamp: $timestamp, source: $source, runUrl: $run_url, repairs: $repairs}')
 
           AUDIT_B64=$(echo "$AUDIT" | base64 -w0)


### PR DESCRIPTION
Fix 3 failing workflows: JSON injection via single-quoted outputs + set -e fragility.

Pattern: `'${{ outputs.x }}'` breaks when JSON contains quotes. Fix: pass via env vars.

https://claude.ai/code/session_01UUEz9wrwdB57dxdkLXc5Kw