### PR TITLE
fix: dashboard escaped backticks in renderTokens

### DIFF
--- a/panel/dashboard/index.html
+++ b/panel/dashboard/index.html
@@ -1386,13 +1386,13 @@
           ${(state.recentWorkflows||[]).slice(0,15).map(w=>{
             const c=w.conclusion==='success'?'green':w.conclusion==='failure'?'red':'muted';
             const icon=w.conclusion==='success'?'✓':w.conclusion==='failure'?'✗':'·';
-            return \`<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 8px;background:var(--surface2);border-radius:4px;font-size:12px">
+            return`<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 8px;background:var(--surface2);border-radius:4px;font-size:12px">
               <div style="display:flex;align-items:center;gap:8px">
-                <span style="color:var(--\${c});font-weight:700">\${icon}</span>
-                <span>\${esc(w.name||'?')}</span>
+                <span style="color:var(--${c});font-weight:700">${icon}</span>
+                <span>${esc(w.name||'?')}</span>
               </div>
-              <span style="color:var(--muted)">\${w.created?new Date(w.created).toLocaleString('pt-BR',{day:'2-digit',month:'2-digit',hour:'2-digit',minute:'2-digit'}):'—'}</span>
-            </div>\`;
+              <span style="color:var(--muted)">${w.created?new Date(w.created).toLocaleString('pt-BR',{day:'2-digit',month:'2-digit',hour:'2-digit',minute:'2-digit'}):'—'}</span>
+            </div>`;
           }).join('')}
         </div>
       </div>


### PR DESCRIPTION
Fix escaped backticks in renderTokens that broke template literal rendering.

https://claude.ai/code/session_01UUEz9wrwdB57dxdkLXc5Kw