### PR TITLE
fix: dashboard state.json 22h stale — output flag for step condition

### DIFF
--- a/.github/workflows/spark-sync-state.yml
+++ b/.github/workflows/spark-sync-state.yml
@@ -115,7 +115,7 @@ jobs:
             echo "::warning ::Failed to push dashboard HTML to $SPARK_REPO (non-critical)"
 
       - name: Update panel/dashboard/state.json (GitHub Pages)
-        if: always() && steps.state.outputs.state_b64 != ''
+        if: always() && steps.state.outputs.state_ready == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |

--- a/scripts/dashboard/collect-state.sh
+++ b/scripts/dashboard/collect-state.sh
@@ -416,3 +416,4 @@ fi
 
 jq -r '.lastSync' /tmp/state.json 2>/dev/null || echo "unknown"
 echo "state_b64=$(base64 -w0 /tmp/state.json)" >> "$GITHUB_OUTPUT"
+echo "state_ready=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Dashboard state.json was 22h stale — step 7 SKIPPED because 53KB base64 in GHA expression. Fix: use `state_ready=true` flag.

https://claude.ai/code/session_01UUEz9wrwdB57dxdkLXc5Kw