### PR TITLE
[claude] ci-diagnose: agent 2.3.3 run73 real failure check

### DIFF
--- a/trigger/ci-diagnose.json
+++ b/trigger/ci-diagnose.json
@@ -2,6 +2,6 @@
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
   "component": "agent",
-  "note": "Diagnose agent 2.3.3 CI failure — cronjob callback deploy #930188",
-  "run": 26
+  "note": "Diagnose agent 2.3.3 CI failure — cronjob callback deploy #930188 run73",
+  "run": 27
 }


### PR DESCRIPTION
Trigger ci-diagnose run #27 para verificar se a falha do CI Gate no run #73 (agent 2.3.3) é real ou falso positivo pre-existing.