### PR TITLE
[claude] fix: autonomous pipeline — compliance gate + ci-monitor auto-activation

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -962,3 +962,38 @@ jobs:
           echo "| 4. Promote | ${{ needs.promote.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| 5. Save State | ${{ needs.save-state.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| 6. Audit | running |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 7. CI Monitor | dispatched |" >> "$GITHUB_STEP_SUMMARY"
+
+  # ═══════════════════════════════════════════════════════════════
+  #  STAGE 7 → CI Monitor: activate autonomous CI monitoring loop
+  # ═══════════════════════════════════════════════════════════════
+  ci-monitor:
+    name: "7. CI Monitor (activate)"
+    needs: [setup, apply-and-push, audit]
+    if: always() && needs.apply-and-push.outputs.pushed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Dispatch ci-monitor-loop"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -e
+          WS_ID="${{ needs.setup.outputs.ws_id }}"
+          COMPONENT="${{ needs.setup.outputs.component }}"
+          COMMIT_SHA="${{ needs.apply-and-push.outputs.sha }}"
+
+          echo "=== Stage 7: Activating CI Monitor Loop ==="
+          echo "workspace=$WS_ID component=$COMPONENT sha=$COMMIT_SHA"
+
+          gh workflow run ci-monitor-loop.yml \
+            --repo "$AUTOPILOT_REPO" \
+            --ref main \
+            --field workspace_id="$WS_ID" \
+            --field component="$COMPONENT" \
+            --field commit_sha="$COMMIT_SHA"
+
+          echo "CI Monitor Loop dispatched — will poll corporate CI, auto-diagnose failures, and auto-fix."
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## 7. CI Monitor" >> "$GITHUB_STEP_SUMMARY"
+          echo "Dispatched ci-monitor-loop for **$COMPONENT** (sha: \`$COMMIT_SHA\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "The loop will poll the corporate Esteira de Build NPM and auto-remediate failures." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/autonomous-merge-direct.yml
+++ b/.github/workflows/autonomous-merge-direct.yml
@@ -89,9 +89,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const headSha   = '${{ steps.policy.outputs.head_sha }}';
-            const maxWaitMs = 3 * 60 * 1000; // 3 minutes max (was 10)
-            const pollMs    = 15 * 1000;      // 15 seconds (was 30)
+            const maxWaitMs = 15 * 60 * 1000; // 15 minutes — compliance gate needs npm ci + tsc + jest
+            const pollMs    = 20 * 1000;      // 20 seconds
+            const initialWaitMs = 30 * 1000;  // 30s initial delay so check suites are created
             const start     = Date.now();
+
+            // Wait for GitHub to create check suites before polling
+            core.notice('Initial 30s wait for check suites to be created…');
+            await new Promise(r => setTimeout(r, initialWaitMs));
 
             // Collect ALL merge-related workflow run IDs to exclude them.
             // These workflows wait for each other = deadlock if we wait for them.
@@ -121,17 +126,19 @@ jobs:
               }
             } catch (e) { core.warning(`Could not list running workflows: ${e.message}`); }
 
-            // Also exclude suites that are "queued" (waiting for approval) — these will never complete
-            core.notice(`Waiting for checks on ${headSha} (max 3 min)…`);
+            // Only exclude action_required suites (manual approval gates) — NOT queued ones
+            // queued = GitHub Actions not started yet (must wait), action_required = manual gate (will never auto-complete)
+            core.notice(`Polling checks on ${headSha} (max 15 min)…`);
 
             while (true) {
               const { data: suites } = await github.rest.checks.listSuitesForRef({
                 owner: context.repo.owner, repo: context.repo.repo, ref: headSha, per_page: 100,
               });
 
-              // Exclude merge workflows + queued/action_required suites (they'll never complete on their own)
+              // Exclude: merge workflows (deadlock) + action_required (manual gates that won't complete)
+              // Do NOT exclude 'queued' — those are checks waiting to start (compliance-gate, etc.)
               const relevant = suites.check_suites.filter(s =>
-                !excludeSuiteIds.has(s.id) && s.status !== 'queued'
+                !excludeSuiteIds.has(s.id) && s.conclusion !== 'action_required'
               );
 
               const pending = relevant.filter(s => s.status !== 'completed');


### PR DESCRIPTION
## Problemas corrigidos

**Bug 1: Compliance gate nunca rodava antes do merge**
`autonomous-merge-direct.yml` filtrava suites com status `queued` fora do polling. Como o compliance-gate estava `queued` quando o PR abria, `pending.length === 0` → merge imediato em 7 segundos sem validação.

Fix: não filtrar `queued`, esperar 30s inicial, timeout 15min.

**Bug 2: ci-monitor-loop nunca disparava**
Dependia exclusivamente do trigger `workflow_run` que não estava funcionando. Nenhum `ci-monitor-*.json` existia no autopilot-state.

Fix: Stage 7 adicionado no `apply-source-change` que dispara `ci-monitor-loop` explicitamente via `gh workflow run` após todo deploy bem-sucedido.