### PR TITLE
fix(agent): fix timer leak + test mock in cronjob-callback 2.3.3 run#74

### DIFF
--- a/patches/cronjob-callback.test.ts
+++ b/patches/cronjob-callback.test.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import request from "supertest";
+import { JWTService } from "../../src/util/jwt";
 
 jest.setTimeout(15000);
 
@@ -262,7 +263,6 @@ describe("CronjobCallbackAPI", () => {
     });
 
     test("returns 500 when JWT generation throws", async () => {
-      const { JWTService } = await import("../../src/util/jwt");
       (JWTService.generateCallbackToken as jest.Mock).mockImplementationOnce(
         () => {
           throw new Error("JWT signing error");

--- a/patches/cronjob-callback.ts
+++ b/patches/cronjob-callback.ts
@@ -175,10 +175,16 @@ async function forwardToController(
   const abort = new AbortController();
   const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
 
-  const token = JWTService.generateCallbackToken({
-    execId: payload.execId,
-    scope: ["send_logs"],
-  });
+  let token: string;
+  try {
+    token = JWTService.generateCallbackToken({
+      execId: payload.execId,
+      scope: ["send_logs"],
+    });
+  } catch (tokenError) {
+    clearTimeout(timeoutId);
+    throw tokenError;
+  }
 
   try {
     const response = await fetch(url, {

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -7,12 +7,22 @@
   "changes": [
     {
       "action": "replace-file",
+      "target_path": "src/routes/cronjob-callback.ts",
+      "content_ref": "patches/cronjob-callback.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/apis/cronjob-callback.ts",
+      "content_ref": "patches/cronjob-callback.ts"
+    },
+    {
+      "action": "replace-file",
       "target_path": "test/apis/cronjob-callback.test.ts",
       "content_ref": "patches/cronjob-callback.test.ts"
     }
   ],
-  "commit_message": "fix(agent): correct test import paths for cronjob-callback (#930188)",
+  "commit_message": "fix(agent): fix timer leak and test mock in cronjob-callback (#930188)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 73
+  "run": 74
 }


### PR DESCRIPTION
## Fix agent 2.3.3 CI failure — run #74

### Root cause
`JWTService.generateCallbackToken` was called **before** the `try-catch-finally` block in `forwardToController`. When the test mocked it to throw, `clearTimeout` was never called → 30s timer stayed alive → Jest worker couldn't exit → force-killed → test counted as failed.

### Changes
- `patches/cronjob-callback.ts`: Move token generation inside a try-catch that re-throws after `clearTimeout` (fixes timer leak; 500 behavior preserved)
- `patches/cronjob-callback.test.ts`: Add static `import { JWTService }`, remove fragile dynamic import in "returns 500 when JWT generation throws" test
- `trigger/source-change.json`: run #74 — deploy to `src/routes/`, `src/apis/`, and `test/apis/`

https://claude.ai/code/session_01YWFtCYyuoeM3egcNVpC9R9