### PR TITLE
fix(agent): fix body-parser strict mode in test 2.3.3 run#76

### DIFF
--- a/patches/cronjob-callback.test.ts
+++ b/patches/cronjob-callback.test.ts
@@ -64,10 +64,10 @@ describe("CronjobCallbackAPI", () => {
   describe("validateCronjobCallback", () => {
     test("returns 400 when body is not a JSON object", async () => {
       const app = await makeApp();
+      // Arrays pass body-parser strict mode but fail our isRecord() check
       const res = await request(app)
         .post("/api/cronjob/callback")
-        .set("Content-Type", "application/json")
-        .send('"not-an-object"');
+        .send([]);
       expect(res.status).toBe(400);
       expect(res.body.ok).toBe(false);
       expect(res.body.details).toContain("Request body must be a JSON object.");

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -7,27 +7,12 @@
   "changes": [
     {
       "action": "replace-file",
-      "target_path": "src/routes/cronjob-callback.ts",
-      "content_ref": "patches/cronjob-callback.ts"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "src/apis/cronjob-callback.ts",
-      "content_ref": "patches/cronjob-callback.ts"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "test/apis/cronjob-callback.test.ts",
-      "content_ref": "patches/cronjob-callback-stub.test.ts"
-    },
-    {
-      "action": "replace-file",
       "target_path": "src/__tests__/unit/cronjob-callback.test.ts",
       "content_ref": "patches/cronjob-callback.test.ts"
     }
   ],
-  "commit_message": "fix(agent): move test to unit dir, correct import paths (#930188)",
+  "commit_message": "fix(agent): fix body-parser strict mode in test (#930188)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 75
+  "run": 76
 }


### PR DESCRIPTION
## Root cause identified — run #76

### Bug
Test "returns 400 when body is not a JSON object" was sending `'"not-an-object"'` (a raw JSON string) with `Content-Type: application/json`.

Express's `body-parser` with `strict: true` (default) **rejects all non-object/array JSON bodies before the request reaches our route handler**. So `req.body` was never set, `res.body.ok` was `undefined`, and `expect(res.body.ok).toBe(false)` failed.

This is why the same 1 test failed across runs #73, #74, and #75 despite all other fixes.

### Fix
Send `[]` (empty array) instead. Arrays pass `body-parser`'s strict mode but fail our `isRecord()` check (`Array.isArray([])` is true), so our handler correctly returns 400 with `{ ok: false, details: ["Request body must be a JSON object."] }`.

### Deploy
Only `src/__tests__/unit/cronjob-callback.test.ts` is updated (already in place from run #75).

https://claude.ai/code/session_01YWFtCYyuoeM3egcNVpC9R9