### PR TITLE
feat(controller): deploy 3.7.1 — cronjob result endpoint (#930188)

### DIFF
--- a/patches/controller-swagger.json
+++ b/patches/controller-swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PSC SRE Automacao Controller",
     "description": "API do Controller de automacao SRE. Orquestra a execucao de automacoes nos Agents distribuidos por cluster, gerencia logs de execucao, autenticacao JWT e integracao com o OAS (Orquestrador de Automacao de Servicos).",
-    "version": "3.7.0",
+    "version": "3.7.1",
     "contact": {
       "name": "PSC SRE Automacao"
     }

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -1,18 +1,45 @@
 {
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
-  "component": "agent",
+  "component": "controller",
   "change_type": "multi-file",
-  "version": "2.3.3",
+  "version": "3.7.1",
   "changes": [
     {
+      "action": "search-replace",
+      "target_path": "package.json",
+      "search": "\"version\": \"3.7.0\"",
+      "replace": "\"version\": \"3.7.1\""
+    },
+    {
+      "action": "search-replace",
+      "target_path": "package-lock.json",
+      "search": "\"version\": \"3.7.0\"",
+      "replace": "\"version\": \"3.7.1\""
+    },
+    {
       "action": "replace-file",
-      "target_path": "src/__tests__/unit/cronjob-callback.test.ts",
-      "content_ref": "patches/cronjob-callback.test.ts"
+      "target_path": "src/swagger/swagger.json",
+      "content_ref": "patches/controller-swagger.json"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/controllers/cronjob-result.controller.ts",
+      "content_ref": "patches/cronjob-result.controller.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/__tests__/unit/cronjob-result.controller.test.ts",
+      "content_ref": "patches/cronjob-result.controller.test.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/routes/agentsRouter.ts",
+      "content_ref": "patches/agentsRouter.ts"
     }
   ],
-  "commit_message": "fix(agent): fix body-parser strict mode in test (#930188)",
+  "commit_message": "feat(controller): add cronjob result endpoint (#930188)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 76
+  "run": 77
 }


### PR DESCRIPTION
## Controller 3.7.1 — Historia #930188

### Changes
- `src/controllers/cronjob-result.controller.ts` — new endpoint: receives cronjob result from agent, stores in execution log
- `src/__tests__/unit/cronjob-result.controller.test.ts` — unit tests
- `src/routes/agentsRouter.ts` — registers `/api/cronjob/result` and `/api/cronjob/status/:execId`
- `src/swagger/swagger.json` — version 3.7.1

### Trigger
- run: #77, component: controller, version: 3.7.1, promote: true