### PR TITLE
fix(monitoring): fix 3 root-cause workflow failures + update dashboard

### DIFF
--- a/.github/workflows/builds-validation-gate.yml
+++ b/.github/workflows/builds-validation-gate.yml
@@ -121,7 +121,8 @@ jobs:
             fi
 
             # ── Check 7: Hardcoded secrets or tokens ──
-            if grep -qiE '(ghp_|github_pat_|sk-|AIza|AKIA)' "$WF_FILE" 2>/dev/null; then
+            # Skip self-scan to avoid false positive from the detection pattern itself
+            if [[ "$WF_FILE" != *"builds-validation-gate"* ]] && grep -qiE '(ghp_|github_pat_|sk-|AIza|AKIA)' "$WF_FILE" 2>/dev/null; then
               FILE_ERRORS="${FILE_ERRORS}\n  - Possible hardcoded secret/token detected"
               ERRORS=$((ERRORS + 1))
             fi

--- a/.github/workflows/compliance-gate.yml
+++ b/.github/workflows/compliance-gate.yml
@@ -295,6 +295,7 @@ jobs:
               replace-file)
                 CONTENT_REF=$(echo "$ch" | jq -r '.content_ref')
                 if [ -f "$CONTENT_REF" ]; then
+                  mkdir -p "/tmp/corporate/$(dirname "$TARGET")"
                   cp "$CONTENT_REF" "/tmp/corporate/$TARGET"
                   echo "✅ replace-file: $TARGET from $CONTENT_REF"
                 else

--- a/.github/workflows/intelligent-orchestrator.yml
+++ b/.github/workflows/intelligent-orchestrator.yml
@@ -198,9 +198,9 @@ jobs:
           echo "ecosystem_health=$HEALTH" >> "$GITHUB_OUTPUT"
           echo "failing_count=$FAILING_COUNT" >> "$GITHUB_OUTPUT"
           echo "failing_workflows=$(echo "$FAILING" | jq -c '.' 2>/dev/null || echo '[]')" >> "$GITHUB_OUTPUT"
-          echo "stale_monitors=$(echo -e "$STALE_MONITORS" | head -20)" >> "$GITHUB_OUTPUT"
+          echo "stale_monitors=$(echo -e "$STALE_MONITORS" | head -20 | tr '\n' '|')" >> "$GITHUB_OUTPUT"
           echo "dashboard_stale=$DASH_STALE" >> "$GITHUB_OUTPUT"
-          echo "trigger_anomalies=$(echo -e "$TRIGGER_ISSUES" | head -10)" >> "$GITHUB_OUTPUT"
+          echo "trigger_anomalies=$(echo -e "$TRIGGER_ISSUES" | head -10 | tr '\n' '|')" >> "$GITHUB_OUTPUT"
           echo "needs_action=$NEEDS_ACTION" >> "$GITHUB_OUTPUT"
           echo "knowledge_base=$(echo "$KB" | jq -c '.' 2>/dev/null || echo '{}')" >> "$GITHUB_OUTPUT"
 

--- a/panel/dashboard/state.json
+++ b/panel/dashboard/state.json
@@ -1,6 +1,6 @@
 {
-  "lastSync": "2026-03-30T13:18:11Z",
-  "syncSource": "manual-restore",
+  "lastSync": "2026-03-30T17:15:00Z",
+  "syncSource": "autopilot/manual-fix",
   "controller": {
     "version": "3.7.0",
     "status": "promoted",
@@ -8,41 +8,25 @@
     "promoted": true
   },
   "agent": {
-    "version": "2.3.2",
-    "status": "promoted",
+    "version": "2.3.3",
+    "status": "ci-passed",
     "ciResult": "success",
     "promoted": true
   },
   "pipeline": {
-    "status": "idle",
-    "lastRun": 72,
-    "component": "agent",
-    "version": "2.3.3"
+    "status": "deploying",
+    "lastRun": 77,
+    "component": "controller",
+    "version": "3.7.1"
   },
   "agents": {
-    "claude": {
-      "status": "active"
-    },
-    "copilot": {
-      "sessionCount": 0
-    },
-    "codex": {
-      "sessionCount": 0
-    }
+    "claude": { "status": "active" },
+    "copilot": { "sessionCount": 0 },
+    "codex": { "sessionCount": 0 }
   },
   "workspaces": [
-    {
-      "id": "ws-default",
-      "company": "Getronics",
-      "status": "active",
-      "stack": "Node/TypeScript (NestJS, Jest, ESLint)"
-    },
-    {
-      "id": "ws-cit",
-      "company": "CIT",
-      "status": "setup",
-      "stack": "DevOps"
-    }
+    { "id": "ws-default", "company": "Getronics", "status": "active", "stack": "Node/TypeScript (NestJS, Jest, ESLint)" },
+    { "id": "ws-cit", "company": "CIT", "status": "setup", "stack": "DevOps" }
   ],
   "recentWorkflows": [],
   "openPRs": [],


### PR DESCRIPTION
## Root causes found and fixed

### 1. `builds-validation-gate` (Layer 1) — self-referential false positive
The secret detection regex `ghp_|github_pat_|...` appeared in the file itself, causing the workflow to flag itself as having a hardcoded secret.
**Fix:** skip self when scanning (check `$WF_FILE != *builds-validation-gate*`).

### 2. `compliance-gate` (PRE-DEPLOY) — mkdir -p missing
`cp "$CONTENT_REF" "/tmp/corporate/$TARGET"` fails when the target directory doesn't exist (new files). With `set -e`, this causes `exit 1` which propagates through the pipe and fails the step. This cascaded to `autonomous-merge-direct` failing (it waits for all check suites — if compliance-gate fails, it sees a failed suite and calls `setFailed`).
**Fix:** `mkdir -p "/tmp/corporate/$(dirname "$TARGET")"` before cp.

### 3. `intelligent-orchestrator` (Layer 4) — echo -e multiline corruption
`echo -e "$STALE_MONITORS"` expands `\n` into real newlines. Writing this to `$GITHUB_OUTPUT` as `echo "key=$(echo -e ...)"` injects unencoded newlines into the output file, corrupting all subsequent output reads (`dashboard_stale`, `needs_action`, etc.).
**Fix:** pipe through `tr '\n' '|'` to keep output single-line.

### Dashboard
Updated `panel/dashboard/state.json` with correct current state: agent 2.3.3 promoted, controller 3.7.1 deploying (run #77).