### PR TITLE
fix(controller 3.7.2): replace for...of with Object.fromEntries — ESLint no-restricted-syntax

### DIFF
--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -85,14 +85,14 @@ function sanitizeForOutput(value: unknown): string {
 }
 
 function sanitizeEnvValues(envs: JsonRecord): JsonRecord {
-  const result: JsonRecord = {};
-  for (const [key, value] of Object.entries(envs)) {
-    result[key] =
+  return Object.fromEntries(
+    Object.entries(envs).map(([key, value]) => [
+      key,
       typeof value === "string"
         ? value.replace(/[<>"'&]/g, "").replace(/[\r\n\t]+/g, " ").trim()
-        : value;
-  }
-  return result;
+        : value,
+    ]),
+  ) as JsonRecord;
 }
 
 function safeLogValue(value: unknown): string {

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -51,5 +51,5 @@
   "commit_message": "fix(controller): security fixes — XSS, SSRF, DoS-by-loop (#930188)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 78
+  "run": 79
 }


### PR DESCRIPTION
## Summary
- Fix ESLint `no-restricted-syntax` failure in `oas-sre-controller.controller.ts`
- `sanitizeEnvValues` used `for...of Object.entries()` which is forbidden by this codebase's ESLint config
- Replaced with `Object.fromEntries(Object.entries(envs).map(...))` — equivalent logic, no loop syntax
- Bump trigger run 78 → 79 to re-deploy controller 3.7.2

## Root Cause
Corporate CI log:
```
89:3  error  iterators/generators require regenerator-runtime, which is too heavyweight
       for this guide to allow them. Separately, loops should be avoided in favor of
       array iterations  no-restricted-syntax
```

## Lesson Added
`no-restricted-syntax` blocks `for...of` in this codebase. Always use array iterations (`.map`, `.reduce`, `.filter`, `Object.fromEntries`) instead.

https://claude.ai/code/session_01YWFtCYyuoeM3egcNVpC9R9