### PR TITLE
fix(ci-loop): close autonomous loop + failure notifications

### DIFF
--- a/.github/workflows/ci-monitor-loop.yml
+++ b/.github/workflows/ci-monitor-loop.yml
@@ -277,6 +277,47 @@ jobs:
 
           echo "fix-corporate-ci dispatched for $COMPONENT."
 
+      # ── 3c. Create failure notification issue ─────────────────────────────────
+      - name: "Create CI failure notification issue"
+        if: >
+          steps.poll.outputs.overall == 'failure' ||
+          steps.poll.outputs.overall == 'timeout'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          COMPONENT="${{ steps.inputs.outputs.component }}"
+          VERSION="${{ steps.inputs.outputs.version }}"
+          COMMIT_SHA="${{ steps.inputs.outputs.commit_sha }}"
+          FAILED_URL="${{ steps.poll.outputs.failed_run_url }}"
+          OVERALL="${{ steps.poll.outputs.overall }}"
+          SOURCE_REPO="${{ steps.inputs.outputs.source_repo }}"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          TITLE="[AutoPilot] Corporate CI $OVERALL: $COMPONENT $VERSION @ $NOW"
+          BODY="Corporate CI failed and auto-fix has been dispatched.
+
+          Component: $COMPONENT
+          Version: $VERSION
+          Commit SHA: $COMMIT_SHA
+          Source repo: $SOURCE_REPO
+          Outcome: $OVERALL
+          Failed run: $FAILED_URL
+
+          Actions taken:
+          - ci-diagnose dispatched (logs saved to autopilot-state)
+          - fix-corporate-ci dispatched (will attempt lint/build auto-fix)
+          - ci-monitor-loop will be re-dispatched by fix-corporate-ci with the fix SHA
+
+          If this issue persists after auto-fix, manual intervention is needed.
+          Check: state/workspaces/ws-default/ci-logs-${COMPONENT}-*.txt on autopilot-state branch."
+
+          gh issue create \
+            --repo "$AUTOPILOT_REPO" \
+            --title "$TITLE" \
+            --body "$BODY" \
+            2>/dev/null || echo "::warning ::Could not create failure notification issue"
+          echo "::notice ::CI failure issue created for $COMPONENT"
+
       # ── 4. Save result to autopilot-state ────────────────────────────────────
       - name: "Save monitor result to state"
         if: always()

--- a/.github/workflows/fix-corporate-ci.yml
+++ b/.github/workflows/fix-corporate-ci.yml
@@ -165,50 +165,54 @@ jobs:
           # ── 7. Commit and push ─────────────────────────────
           git add -A
           if git diff --cached --quiet; then
-            echo "No changes to commit"
+            echo "::warning ::Auto-fix could not apply any changes — lint errors may need manual code fix"
+            # Create notification issue since auto-fix couldn't fix the problem
+            GH_TOKEN="$RELEASE_TOKEN" gh issue create \
+              --repo "$AUTOPILOT_REPO" \
+              --title "[AutoPilot] CI auto-fix blocked: $COMPONENT — no auto-fixable errors found" \
+              --body "fix-corporate-ci ran for component \`$COMPONENT\` (workspace \`$WS_ID\`) but could not apply any automatic fixes. The ESLint error may require a code-level patch update in autopilot. Check the CI logs on autopilot-state branch (ci-logs-${COMPONENT}-*.txt) for the specific error." \
+              2>/dev/null || echo "::warning ::Could not create issue"
             exit 0
           fi
           git commit -m "fix: resolve CI errors (lint + build)"
           git push origin main
           echo "Fix pushed to main"
 
-          # ── 7. Wait for CI ─────────────────────────────────
+          # ── 8. Close the autonomous loop ──────────────────────────────────────
           NEW_SHA=$(git rev-parse HEAD)
-          echo "=== Waiting for CI on $NEW_SHA ==="
-          FOUND=false
-          for i in $(seq 1 36); do
-            sleep 5
-            COUNT=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$SOURCE_REPO/commits/$NEW_SHA/check-runs" --jq '.total_count' 2>/dev/null || echo "0")
-            if [ "$COUNT" -gt 0 ]; then FOUND=true; break; fi
-            echo "  Waiting... ($i)"
-          done
-          if [ "$FOUND" = "false" ]; then
-            echo "No CI checks found. Done."
-            exit 0
-          fi
-          for i in $(seq 1 120); do
-            sleep 10
-            DATA=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$SOURCE_REPO/commits/$NEW_SHA/check-runs" \
-              --jq '{t:.total_count, c:[.check_runs[]|select(.status=="completed")]|length, s:[.check_runs[]|select(.conclusion=="success")]|length, f:[.check_runs[]|select(.conclusion=="failure")]|length}' 2>/dev/null || echo '{}')
-            if ! echo "$DATA" | jq empty 2>/dev/null; then
-              echo "  Warning: invalid JSON from API, using safe defaults"
-              DATA='{"t":0,"c":0,"s":0,"f":0}'
-            fi
-            T=$(echo "$DATA"|jq -r '.t//0' 2>/dev/null || echo "0"); C=$(echo "$DATA"|jq -r '.c//0' 2>/dev/null || echo "0")
-            S=$(echo "$DATA"|jq -r '.s//0' 2>/dev/null || echo "0"); F=$(echo "$DATA"|jq -r '.f//0' 2>/dev/null || echo "0")
-            echo "  CI: $C/$T done (ok=$S fail=$F) [$i]"
-            if [ "$T" -gt 0 ] && [ "$C" -eq "$T" ]; then
-              if [ "$F" -gt 0 ]; then
-                echo "::error ::CI still failing after fix"
-              else
-                echo "CI passed!"
-              fi
-              break
-            fi
-          done
+          echo "Fix SHA: $NEW_SHA"
 
-          echo "---" >> "$GITHUB_STEP_SUMMARY"
-          echo "## CI Fix Result" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Errors found: $ERROR_COUNT" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Remaining: $REMAINING" >> "$GITHUB_STEP_SUMMARY"
-          echo "- CI: $S/$T passed" >> "$GITHUB_STEP_SUMMARY"
+          # Update release state with the new SHA so ci-monitor-loop tracks the right commit
+          STATE_FILE="state/workspaces/${WS_ID}/${COMPONENT}-release-state.json"
+          EXISTING_FILE_SHA=$(GH_TOKEN="$RELEASE_TOKEN" gh api \
+            "repos/$AUTOPILOT_REPO/contents/${STATE_FILE}?ref=$STATE_BRANCH" \
+            --jq '.sha' 2>/dev/null || echo "")
+          EXISTING_CONTENT=$(GH_TOKEN="$RELEASE_TOKEN" gh api \
+            "repos/$AUTOPILOT_REPO/contents/${STATE_FILE}?ref=$STATE_BRANCH" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+          UPDATED_CONTENT=$(echo "$EXISTING_CONTENT" | jq \
+            --arg sha "$NEW_SHA" \
+            --arg status "ci-fix-applied" \
+            '.lastReleasedSha = $sha | .status = $status' 2>/dev/null || echo "$EXISTING_CONTENT")
+
+          FIX_ARGS=(-f "branch=$STATE_BRANCH" \
+            -f "message=ci-fix: update SHA to $NEW_SHA [skip ci]" \
+            -f "content=$(echo "$UPDATED_CONTENT" | base64 -w0)")
+          [ -n "$EXISTING_FILE_SHA" ] && FIX_ARGS+=(-f "sha=$EXISTING_FILE_SHA")
+          GH_TOKEN="$RELEASE_TOKEN" gh api "repos/$AUTOPILOT_REPO/contents/${STATE_FILE}" \
+            --method PUT "${FIX_ARGS[@]}" > /dev/null 2>&1 || echo "::warning ::Could not update release state"
+
+          # Re-dispatch ci-monitor-loop for the fix commit — closes the autonomous loop
+          GH_TOKEN="$RELEASE_TOKEN" gh workflow run ci-monitor-loop.yml \
+            --repo "$AUTOPILOT_REPO" \
+            --ref main \
+            --field workspace_id="$WS_ID" \
+            --field component="$COMPONENT" \
+            --field commit_sha="$NEW_SHA"
+
+          echo "::notice ::Autonomous loop closed — ci-monitor-loop dispatched for fix SHA $NEW_SHA"
+
+          echo "## CI Fix Applied" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Fix SHA: \`$NEW_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Lint errors fixed: $ERROR_COUNT" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ci-monitor-loop dispatched to verify fix" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problema resolvido

O loop autônomo estava **incompleto**. Quando a esteira corporativa falhava:
1. `ci-monitor-loop` detectava ✅
2. Disparava `fix-corporate-ci` ✅
3. `fix-corporate-ci` empurrava o fix para o repo corporativo... mas **ninguém monitorava esse novo commit** ❌
4. Nenhuma notificação era criada ❌

## Fluxo anterior (quebrado)
```
apply-source-change → ci-monitor(SHA-A fail) → fix-corporate-ci → PARA AQUI
```

## Fluxo novo (completo)
```
apply-source-change → ci-monitor(SHA-A fail) → fix-corporate-ci
  → salva SHA-B no release-state
  → ci-monitor(SHA-B) → pass→promote-cap
                      → fail→Issue criada
```

## Mudanças

### `fix-corporate-ci.yml`
- Após push do fix: atualiza `release-state.json` com o novo SHA
- Re-despacha `ci-monitor-loop` com `commit_sha=NEW_SHA` — fecha o loop
- Path "sem mudanças": cria Issue explicando que o auto-fix não conseguiu corrigir

### `ci-monitor-loop.yml`
- Em `failure`/`timeout`: cria GitHub Issue com componente, versão, SHA, URL da run falha, e ações tomadas
- Torna falhas imediatamente visíveis na aba Issues

https://claude.ai/code/session_01YWFtCYyuoeM3egcNVpC9R9