### PR TITLE
perf: reduce sweeper frequency + concurrency groups for 18 workflows

### DIFF
--- a/.github/workflows/alert-notify.yml
+++ b/.github/workflows/alert-notify.yml
@@ -31,6 +31,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: alert-notify-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   REPO: lucassfreiree/autopilot
 

--- a/.github/workflows/auto-merge-sweeper.yml
+++ b/.github/workflows/auto-merge-sweeper.yml
@@ -1,7 +1,7 @@
 name: "[Core] Auto-Merge Sweeper"
 run-name: "${{ github.workflow }} • sweep open agent PRs"
 
-# DEFINITIVE auto-merge solution. Runs every minute.
+# DEFINITIVE auto-merge solution. Runs every 5 minutes.
 # Handles EVERYTHING automatically:
 # - Draft PRs → mark as ready
 # - Conflict PRs → update branch (rebase from main)
@@ -12,7 +12,7 @@ run-name: "${{ github.workflow }} • sweep open agent PRs"
 
 on:
   schedule:
-    - cron: '* * * * *'
+    - cron: '*/5 * * * *'
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}

--- a/.github/workflows/check-repo-access.yml
+++ b/.github/workflows/check-repo-access.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - '.github/workflows/check-repo-access.yml'
 
+concurrency:
+  group: check-repo-access-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   check-access:
     name: "Validate Token Access"

--- a/.github/workflows/ci-diagnose.yml
+++ b/.github/workflows/ci-diagnose.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ci-diagnose-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ci-failure-analysis-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/ci-status-check.yml
+++ b/.github/workflows/ci-status-check.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ci-status-check-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/clone-corporate-repos.yml
+++ b/.github/workflows/clone-corporate-repos.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: clone-corporate-repos-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
 

--- a/.github/workflows/compliance-gate.yml
+++ b/.github/workflows/compliance-gate.yml
@@ -34,6 +34,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: compliance-gate-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   # ═══════════════════════════════════════════
   # STAGE 1: Static Analysis (no network needed)

--- a/.github/workflows/enqueue-agent-handoff.yml
+++ b/.github/workflows/enqueue-agent-handoff.yml
@@ -38,6 +38,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: enqueue-agent-handoff-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/fetch-files.yml
+++ b/.github/workflows/fetch-files.yml
@@ -18,6 +18,11 @@ on:
         required: true
 permissions:
   contents: write
+
+concurrency:
+  group: fetch-files-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/fix-and-validate.yml
+++ b/.github/workflows/fix-and-validate.yml
@@ -16,6 +16,10 @@ permissions:
   contents: write
   actions: write
 
+concurrency:
+  group: fix-and-validate-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/fix-corporate-ci.yml
+++ b/.github/workflows/fix-corporate-ci.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: fix-corporate-ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/post-deploy-validation.yml
+++ b/.github/workflows/post-deploy-validation.yml
@@ -23,6 +23,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: post-deploy-validation-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: "Post-Deploy Validation"

--- a/.github/workflows/promote-cap.yml
+++ b/.github/workflows/promote-cap.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: promote-cap-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/record-improvement.yml
+++ b/.github/workflows/record-improvement.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: record-improvement-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/release-approval.yml
+++ b/.github/workflows/release-approval.yml
@@ -27,6 +27,10 @@ permissions:
   contents: write
   issues: write
 
+concurrency:
+  group: release-approval-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
 env:
   REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-freeze-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
 env:
   REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/restore-state.yml
+++ b/.github/workflows/restore-state.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: restore-state-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
 env:
   REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state

--- a/.github/workflows/session-guard.yml
+++ b/.github/workflows/session-guard.yml
@@ -38,6 +38,10 @@ on:
         description: "Agent that blocked us (if any)"
         value: ${{ jobs.guard.outputs.blocked_by }}
 
+concurrency:
+  group: session-guard-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
 env:
   AUTOPILOT_REPO: lucassfreiree/autopilot
   STATE_BRANCH: autopilot-state


### PR DESCRIPTION
## Summary
- **auto-merge-sweeper**: `* * * * *` → `*/5 * * * *` (~1400 fewer runs/day)
- **18 workflows**: Added concurrency groups to prevent pile-up and wasted runs
- **Safety-aware**: session-guard, restore-state, release-approval, release-freeze use `cancel-in-progress: false`

## Test Plan
- [ ] Verify builds-validation-gate passes (YAML syntax)
- [ ] Confirm auto-merge-sweeper runs every 5 min instead of every 1 min

https://claude.ai/code/session_01W2fV29kcrkKJBFfvgWqYW5