### PR TITLE
fix: auto-sync dashboard from live spark-dashboard source

### DIFF
--- a/panel/dashboard/index.html
+++ b/panel/dashboard/index.html
@@ -353,16 +353,25 @@
     mn.innerHTML=PAGES.map(p=>`<div class="mobile-nav-item${p==='overview'?' active':''}" data-page="${p}" onclick="go('${p}')">${p.charAt(0).toUpperCase()+p.slice(1)}</div>`).join('');
   })();
 
-  // Fetch state
+  // Fetch state — try live source first (spark-dashboard), fallback to local
+  const STATE_URLS=[
+    'https://raw.githubusercontent.com/lucassfreiree/spark-dashboard/main/public/state.json',
+    'state.json'
+  ];
   async function fetchState(){
-    try{
-      const r=await fetch('state.json?t='+Date.now());
-      if(!r.ok)throw new Error(r.status);
-      state=await r.json();
-      renderAll();
-    }catch(e){
-      document.getElementById('alertsBanner').innerHTML=`<div class="alert-bar alert-error">Failed to load state.json: ${esc(e.message)}</div>`;
+    let lastErr;
+    for(const url of STATE_URLS){
+      try{
+        const r=await fetch(url+(url.includes('?')?'&':'?')+'t='+Date.now());
+        if(!r.ok)throw new Error(r.status);
+        const data=await r.json();
+        if(!data.lastSync)throw new Error('invalid state');
+        state=data;
+        renderAll();
+        return;
+      }catch(e){lastErr=e}
     }
+    document.getElementById('alertsBanner').innerHTML=`<div class="alert-bar alert-error">Failed to load state.json: ${esc(lastErr.message)}</div>`;
   }
 
   function scheduleRefresh(){

--- a/scripts/dashboard/collect-state.sh
+++ b/scripts/dashboard/collect-state.sh
@@ -424,29 +424,9 @@ STATE_B64=$(base64 -w0 /tmp/state.json)
 echo "state_b64=$STATE_B64" >> "$GITHUB_OUTPUT"
 echo "state_ready=true" >> "$GITHUB_OUTPUT"
 
-# ── Update panel/dashboard/state.json directly (same step = same process) ──
-REPO="$GITHUB_REPOSITORY"
-FILE_PATH="panel/dashboard/state.json"
-
-if [ -n "$STATE_B64" ] && [ ${#STATE_B64} -gt 100 ]; then
-  for attempt in 1 2 3; do
-    EXISTING_SHA=$(gh api "repos/$REPO/contents/$FILE_PATH" --jq '.sha' 2>/dev/null || echo "")
-
-    PAYLOAD=$(jq -n \
-      --arg content "$STATE_B64" \
-      --arg sha "$EXISTING_SHA" \
-      --arg message "chore: sync dashboard state [auto]" \
-      '{message: $message, content: $content} + (if $sha != "" then {sha: $sha} else {} end)')
-
-    gh api "repos/$REPO/contents/$FILE_PATH" \
-      --method PUT --input - <<< "$PAYLOAD" > /dev/null 2>&1 && {
-      echo "::notice ::State synced to $FILE_PATH (attempt $attempt)"
-      break
-    } || {
-      echo "::warning ::Attempt $attempt failed"
-      [ "$attempt" -lt 3 ] && sleep 2
-    }
-  done
-else
-  echo "::warning ::state_b64 empty or too small — skipping panel update"
-fi
+# ── panel/dashboard/state.json update REMOVED ──
+# Branch protection blocks gh api PUT to main (403).
+# Dashboard now fetches state.json directly from spark-dashboard repo
+# (lucassfreiree/spark-dashboard/public/state.json) which IS updated
+# successfully by the "Push state to Spark repo" step above.
+echo "::notice ::Panel reads state from spark-dashboard repo (no local update needed)"


### PR DESCRIPTION
## Summary
- Dashboard now fetches state.json from spark-dashboard repo (live source updated every 5-15 min)
- Removed dead `gh api PUT` code from collect-state.sh (was always failing due to branch protection 403)
- No more manual state.json fixes needed — sync is fully automatic

## Root Cause
`collect-state.sh` tried to update `panel/dashboard/state.json` on main via GitHub Contents API, but branch protection blocks direct pushes (403). The spark-dashboard repo (`lucassfreiree/spark-dashboard/public/state.json`) was always being updated successfully — the dashboard just wasn't reading from it.

## Fix
`fetchState()` now tries the spark-dashboard raw URL first, falls back to local state.json.

https://claude.ai/code/session_01JSniZkhg621AoURbj8DjG3