### PR TITLE
chore: update live status + trigger spark-sync

### DIFF
--- a/contracts/claude-live-status.json
+++ b/contracts/claude-live-status.json
@@ -1,19 +1,18 @@
 {
   "currentSession": {
     "status": "active",
-    "task": "Fix builds monitoring + intelligent automation",
-    "phase": "validating",
-    "sessionId": "claude_session_01UUEz9wrwdB57dxdkLXc5Kw"
+    "task": "Fix dashboard sync + UI cleanup",
+    "phase": "monitoring"
   },
-  "lastUpdated": "2026-03-30T02:05:00Z",
+  "lastUpdated": "2026-03-31T12:00:00Z",
   "lastUpdatedBy": "claude-code",
   "lastCompletedAction": {
-    "action": "fix-spark-sync-state-21000-char-limit",
-    "timestamp": "2026-03-30T01:48:00Z"
+    "action": "fix-dashboard-sync-git-push",
+    "timestamp": "2026-03-31T11:55:00Z"
   },
   "operationalState": {
-    "controllerVersion": "3.7.0",
-    "agentVersion": "2.3.2",
-    "lastTriggerRun": 71
+    "controllerVersion": "3.7.3",
+    "agentVersion": "2.3.3",
+    "lastTriggerRun": 81
   }
 }


### PR DESCRIPTION
Updates claude-live-status.json (watched path) to trigger spark-sync-state.yml which will test the new git push sync mechanism.

https://claude.ai/code/session_01JSniZkhg621AoURbj8DjG3