### PR TITLE
fix: update state.json lastSync to current time

### DIFF
--- a/panel/dashboard/state.json
+++ b/panel/dashboard/state.json
@@ -1,5 +1,5 @@
 {
-  "lastSync": "2026-03-30T19:45:00Z",
+  "lastSync": "2026-03-31T12:05:00Z",
   "syncSource": "autopilot/claude-code",
   "controller": {
     "version": "3.7.3",


### PR DESCRIPTION
Fix stale lastSync timestamp. The spark-sync-state git push step will keep it fresh going forward.

https://claude.ai/code/session_01JSniZkhg621AoURbj8DjG3