### PR TITLE
fix: correct cronjob-result test mock count for next deploy

### DIFF
--- a/patches/cronjob-result.controller.test.ts
+++ b/patches/cronjob-result.controller.test.ts
@@ -12,7 +12,7 @@ jest.mock("../../controllers/agents-execute-logs.controller", () => ({
     statusLabel: "Done",
     finished: true,
     lastUpdate: "2024-01-01T00:00:00.000Z",
-    count: 1,
+    count: 0,
     entries: [],
   }),
 }));
@@ -79,7 +79,7 @@ describe("cronjob-result.controller", () => {
       statusLabel: "Done",
       finished: true,
       lastUpdate: "2024-01-01T00:00:00.000Z",
-      count: 1,
+      count: 0,
       entries: [],
     });
   });


### PR DESCRIPTION
## Summary
- Fix pre-existing test failure in `cronjob-result.controller.test.ts`
- Mock provided `count: 1` with `entries: []`, but controller computes `count: boundedEntries.length` = `0`
- Changed mock to `count: 0` to match the actual controller behavior
- This eliminates 2 test failures (unit/ and controllers/) in next controller deploy

## Impact
- **Risk**: None — only changes test mock data to match actual implementation
- **Scope**: Controller only (patches/cronjob-result.controller.test.ts)
- **Will take effect**: On next controller deploy via apply-source-change

https://claude.ai/code/session_019QnwcZ8wnNUty7fk6PRwHd