### PR TITLE
fix: enable auto-learning mechanisms + fix heredoc bugs

### DIFF
--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -156,6 +156,10 @@ jobs:
                   add_issue "medium" "$F" "Silent error suppression (|| true without logging): $((SILENT_COUNT - LOGGED_COUNT)) occurrences" "true"
                 fi
               fi
+              # Check for heredoc in run blocks (causes exit 127 in GHA)
+              if grep -qE 'cat <<|<<EOF|<<BODY|<<ISSUE' "$F" 2>/dev/null; then
+                add_issue "critical" "$F" "Heredoc (cat <<EOF) in run: block causes exit 127 in GHA" "false"
+              fi
               # Check for missing set -e
               if grep -q 'run: |' "$F" && ! grep -q 'set -e' "$F"; then
                 add_issue "low" "$F" "Missing 'set -e' in shell scripts" "false"
@@ -545,48 +549,22 @@ jobs:
           [ "$CRIT" != "0" ] && TITLE="[CI Alert] ${CRIT} critical issues found (score: ${SCORE})"
           [ "$TREND" = "degrading" ] && TITLE="[CI Alert] Project health degrading (score: ${SCORE})"
 
-          BODY=$(cat <<ISSUE_EOF
-          ## Continuous Improvement Alert
-
-          | Metric | Value |
-          |--------|-------|
-          | Health Score | **${SCORE}/100** |
-          | Trend | ${TREND} |
-          | Total Issues | ${TOTAL} |
-          | Critical | ${CRIT} |
-          | High | ${HIGH} |
-
-          Run: ${RUN_URL}
-
-          ### Action Required
-          - Review the workflow run for detailed issue list
-          - Fix critical issues immediately
-          - Schedule high-severity fixes for next sprint
-          ISSUE_EOF
-          )
+          BODY="## Continuous Improvement Alert\n\n| Metric | Value |\n|--------|-------|\n| Health Score | ${SCORE}/100 |\n| Trend | ${TREND} |\n| Total Issues | ${TOTAL} |\n| Critical | ${CRIT} |\n| High | ${HIGH} |\n\nRun: ${RUN_URL}\n\n### Action Required\n- Review the workflow run for detailed issue list\n- Fix critical issues immediately\n- Schedule high-severity fixes for next sprint"
 
           # Check if similar issue already exists
           EXISTING=$(gh api "repos/$AUTOPILOT_REPO/issues?state=open&labels=continuous-improvement&per_page=1" \
             --jq '.[0].number' 2>/dev/null || echo "")
 
           if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
-            # Update existing issue
-            gh api "repos/$AUTOPILOT_REPO/issues/$EXISTING/comments" \
-              --method POST \
-              -f "body=$BODY" > /dev/null 2>&1
+            printf '%b' "$BODY" | gh api "repos/$AUTOPILOT_REPO/issues/$EXISTING/comments" \
+              --method POST -F body=@- > /dev/null 2>&1
             echo "Updated existing issue #$EXISTING"
           else
-            # Create new issue
-            gh api "repos/$AUTOPILOT_REPO/issues" \
-              --method POST \
-              -f "title=$TITLE" \
-              -f "body=$BODY" \
+            printf '%b' "$BODY" | gh api "repos/$AUTOPILOT_REPO/issues" \
+              --method POST -f "title=$TITLE" -F body=@- \
               -f "labels=[\"continuous-improvement\",\"automated\"]" > /dev/null 2>&1 || {
-              # Labels might not exist, try without
-              gh api "repos/$AUTOPILOT_REPO/issues" \
-                --method POST \
-                -f "title=$TITLE" \
-                -f "body=$BODY" > /dev/null 2>&1
+              printf '%b' "$BODY" | gh api "repos/$AUTOPILOT_REPO/issues" \
+                --method POST -f "title=$TITLE" -F body=@- > /dev/null 2>&1
             }
             echo "Created new alert issue"
           fi

--- a/.github/workflows/deploy-auto-learn.yml
+++ b/.github/workflows/deploy-auto-learn.yml
@@ -2,7 +2,12 @@ name: "[Core] Deploy Auto-Learn"
 run-name: "${{ github.workflow }} • learn from ${{ inputs.source || 'auto' }}"
 
 # Runs after ANY deploy-related workflow completes — learns from results
+# Also runs on push to its own file (ensures GitHub indexes the workflow)
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/deploy-auto-learn.yml'
   workflow_run:
     workflows:
       - "[Corp] Deploy: Apply Source Change"


### PR DESCRIPTION
## Summary
- **deploy-auto-learn.yml**: Add `push` trigger on own file path to force GitHub workflow indexing (had 0 runs ever — never indexed)
- **continuous-improvement.yml**: Replace heredoc with inline string in alert step (same exit 127 bug as compliance-gate)
- **continuous-improvement.yml**: Add heredoc anti-pattern detection to workflow scan (detects `cat <<EOF` in `run:` blocks as critical issue)

## Why
The user asked why auto-learning/improvement didn't catch the compliance-gate exit 127 failure. Investigation revealed:
1. `deploy-auto-learn.yml` had **0 runs ever** — GitHub never indexed it because it only had `workflow_run` + `workflow_dispatch` triggers
2. `continuous-improvement.yml` had the same heredoc bug in its alert step
3. Neither mechanism detected heredoc patterns in workflow files

## Test plan
- [ ] After merge, verify deploy-auto-learn.yml triggers on push (self-indexing)
- [ ] Verify continuous-improvement.yml YAML is valid (validated locally)
- [ ] Next weekly run of continuous-improvement should detect any remaining heredoc patterns

https://claude.ai/code/session_019QnwcZ8wnNUty7fk6PRwHd