### PR TITLE
fix: remove remaining heredoc bugs from 3 workflows

### DIFF
--- a/.github/workflows/alert-notify.yml
+++ b/.github/workflows/alert-notify.yml
@@ -119,27 +119,17 @@ jobs:
           LABELS="autopilot-alert,severity:${SEVERITY}"
 
           # Create issue
-          ISSUE_BODY=$(cat <<EOBODY
-          ## Alert: ${TITLE}
-          Severity: ${SEVERITY}
-          Timestamp: ${NOW}
-          Source: ${{ steps.eval.outputs.source }}
-          ---
-          ${BODY}
-          ---
-          This issue was automatically created by the Autopilot alert system.
-          Close this issue when the alert is resolved.
-          EOBODY
-          )
+          ALERT_SOURCE="${{ steps.eval.outputs.source }}"
+          ISSUE_BODY="## Alert: ${TITLE}\nSeverity: ${SEVERITY}\nTimestamp: ${NOW}\nSource: ${ALERT_SOURCE}\n---\n${BODY}\n---\nThis issue was automatically created by the Autopilot alert system.\nClose this issue when the alert is resolved."
 
-          gh api "repos/$REPO/issues" \
+          printf '%b' "$ISSUE_BODY" | gh api "repos/$REPO/issues" \
             --method POST \
             -f "title=[autopilot] ${TITLE}" \
-            -f "body=${ISSUE_BODY}" \
+            -F body=@- \
             -f "labels[]=${LABELS%%,*}" 2>/dev/null || \
-          gh issue create --repo "$REPO" \
+          printf '%b' "$ISSUE_BODY" | gh issue create --repo "$REPO" \
             --title "[autopilot] ${TITLE}" \
-            --body "$ISSUE_BODY" 2>/dev/null || true
+            --body-file - 2>/dev/null || true
 
           echo "## Alert Created" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Title:** $TITLE" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -156,9 +156,10 @@ jobs:
                   add_issue "medium" "$F" "Silent error suppression (|| true without logging): $((SILENT_COUNT - LOGGED_COUNT)) occurrences" "true"
                 fi
               fi
-              # Check for heredoc in run blocks (causes exit 127 in GHA)
-              if grep -qE 'cat <<|<<EOF|<<BODY|<<ISSUE' "$F" 2>/dev/null; then
-                add_issue "critical" "$F" "Heredoc (cat <<EOF) in run: block causes exit 127 in GHA" "false"
+              # Check for command-substitution heredoc in run blocks (causes exit 127 in GHA)
+              # Pattern: $(cat <<EOF) is dangerous. cat >> file <<EOF is safe (direct redirect).
+              if grep -qE '\$\(cat <<|BODY=\$\(cat <<|ISSUE_BODY=\$\(cat <<' "$F" 2>/dev/null; then
+                add_issue "critical" "$F" "Command-substitution heredoc causes exit 127 in GHA. Use inline string." "false"
               fi
               # Check for missing set -e
               if grep -q 'run: |' "$F" && ! grep -q 'set -e' "$F"; then

--- a/.github/workflows/post-deploy-validation.yml
+++ b/.github/workflows/post-deploy-validation.yml
@@ -207,19 +207,16 @@ jobs:
           COMP="${{ steps.info.outputs.component }}"
           VER="${{ steps.info.outputs.version }}"
 
-          BODY=$(cat <<EOFBODY
-          ## Post-Deploy Validation Failed
-          - Source version: ${{ steps.source.outputs.result }} (${{ steps.source.outputs.real }})
-          - CAP tag: ${{ steps.cap.outputs.result }} (${{ steps.cap.outputs.tag }})
-          - Autopilot state: ${{ steps.state.outputs.result }}
-          - Corporate CI: ${{ steps.ci.outputs.outcome }}
+          SRC_RESULT="${{ steps.source.outputs.result }}"
+          SRC_REAL="${{ steps.source.outputs.real }}"
+          CAP_RESULT="${{ steps.cap.outputs.result }}"
+          CAP_TAG="${{ steps.cap.outputs.tag }}"
+          STATE_RESULT="${{ steps.state.outputs.result }}"
+          CI_OUTCOME="${{ steps.ci.outputs.outcome }}"
+          BODY="## Post-Deploy Validation Failed\n- Source version: ${SRC_RESULT} (${SRC_REAL})\n- CAP tag: ${CAP_RESULT} (${CAP_TAG})\n- Autopilot state: ${STATE_RESULT}\n- Corporate CI: ${CI_OUTCOME}\n\nDeploy of ${COMP} v${VER} has issues. Investigate immediately."
 
-          Deploy of **${COMP} v${VER}** has issues. Investigate immediately.
-          EOFBODY
-          )
-
-          gh api "repos/${{ github.repository }}/issues" \
+          printf '%b' "$BODY" | gh api "repos/${{ github.repository }}/issues" \
             --method POST \
             -f title="[Alert] Post-deploy validation failed: $COMP v$VER" \
-            -f body="$BODY" \
+            -F body=@- \
             -f "labels[]=bug" -f "labels[]=deploy" 2>/dev/null || echo "::warning ::Failed to create issue"


### PR DESCRIPTION
## Summary
- **post-deploy-validation.yml**: Replace `$(cat <<EOFBODY)` with inline string + `printf '%b'`
- **alert-notify.yml**: Replace `$(cat <<EOBODY)` with inline string + `printf '%b'`
- **continuous-improvement.yml**: Refine heredoc detection to only flag dangerous `$(cat <<)` pattern, not safe `cat >> file <<` redirects

These are the remaining workflows with the same exit 127 heredoc bug fixed in compliance-gate (#403) and continuous-improvement (#405).

## Test plan
- [ ] YAML validated locally with python3 yaml.safe_load
- [ ] Workflows that create issues (post-deploy, alert-notify) will use printf for proper newline handling

https://claude.ai/code/session_019QnwcZ8wnNUty7fk6PRwHd