### PR TITLE
feat: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+
+updates:
+  # GitHub Actions — keep actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  # Python (LangChain orchestrator)
+  - package-ecosystem: "pip"
+    directory: "/integrations/langchain"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # npm (n8n integration)
+  - package-ecosystem: "npm"
+    directory: "/integrations/n8n"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for 3 ecosystems: github-actions (weekly), pip (weekly), npm (monthly)
- `auto-merge-sweeper` already handles `dependabot/` branches — PRs will be auto-merged for patch/minor updates

Closes the last remaining automation gap identified in the analysis.

https://claude.ai/code/session_019QnwcZ8wnNUty7fk6PRwHd