### PR TITLE
feat: intelligent security scanner with dynamic corporate CI query

### DIFF
--- a/.github/workflows/security-vuln-scanner.yml
+++ b/.github/workflows/security-vuln-scanner.yml
@@ -22,12 +22,13 @@ on:
         type: boolean
         default: true
   workflow_run:
-    workflows: ["[Corp] Apply Source Change"]
+    workflows: ["[Corp] Apply Source Change", "[Corp] CI Monitor Loop"]
     types: [completed]
   push:
     branches: [main]
     paths:
       - '.github/workflows/security-vuln-scanner.yml'
+      - 'scripts/security/**'
 
 concurrency:
   group: security-vuln-scanner-${{ inputs.component || 'controller' }}
@@ -46,10 +47,10 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'push'
     outputs:
-      has_critical: ${{ steps.analyze.outputs.has_critical }}
-      has_high: ${{ steps.analyze.outputs.has_high }}
-      npm_fixable: ${{ steps.analyze.outputs.npm_fixable }}
-      report_json: ${{ steps.analyze.outputs.report_json }}
+      has_critical: ${{ steps.scan.outputs.has_critical }}
+      has_high: ${{ steps.scan.outputs.has_high }}
+      npm_fixable: ${{ steps.scan.outputs.npm_fixable }}
+      total_cves: ${{ steps.scan.outputs.total_cves }}
       component: ${{ steps.setup.outputs.component }}
       version: ${{ steps.setup.outputs.version }}
     steps:
@@ -61,16 +62,9 @@ jobs:
         run: |
           COMPONENT="${{ inputs.component || 'controller' }}"
           VERSION="${{ inputs.version || '' }}"
+          CI_RUN_ID="${{ inputs.ci_run_id || '' }}"
 
-          # If triggered by workflow_run, read from release state
-          if [ -z "$VERSION" ]; then
-            STATE_FILE="state/workspaces/ws-default/${COMPONENT}-release-state.json"
-            if [ -f "$STATE_FILE" ]; then
-              VERSION=$(jq -r '.lastTag // ""' "$STATE_FILE" 2>/dev/null || echo "")
-            fi
-          fi
-
-          # Fallback: read from autopilot-state branch
+          # If triggered by workflow_run, read from release state on autopilot-state
           if [ -z "$VERSION" ]; then
             VERSION=$(gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/${COMPONENT}-release-state.json?ref=autopilot-state" \
               --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | jq -r '.lastTag // ""' 2>/dev/null || echo "unknown")
@@ -85,186 +79,30 @@ jobs:
           echo "component=$COMPONENT" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "corp_repo=$CORP_REPO" >> "$GITHUB_OUTPUT"
+          echo "ci_run_id=$CI_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "::notice ::Scanning $COMPONENT v$VERSION from $CORP_REPO"
 
-      - name: "Fetch corporate CI run summary"
-        id: fetch_ci
-        shell: bash {0}
-        env:
-          CORP_REPO: ${{ steps.setup.outputs.corp_repo }}
-          CI_RUN_ID: ${{ inputs.ci_run_id || '' }}
-        run: |
-          if [ -z "$BBVINET_TOKEN" ]; then
-            echo "::warning ::BBVINET_TOKEN not available — cannot scan corporate CI"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Find the latest successful CI run
-          if [ -n "$CI_RUN_ID" ]; then
-            RUN_ID="$CI_RUN_ID"
-          else
-            # Get latest workflow runs from corporate repo
-            RUN_ID=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/actions/runs?status=completed&per_page=5" \
-              --jq '.workflow_runs[0].id' 2>/dev/null || echo "")
-          fi
-
-          if [ -z "$RUN_ID" ]; then
-            echo "::warning ::No CI run found for $CORP_REPO"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-          echo "::notice ::Found CI run: $RUN_ID"
-
-          # Fetch job summaries (xRay, Checkmarx, Motor de Liberacao)
-          JOBS=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/actions/runs/$RUN_ID/jobs?per_page=30" 2>/dev/null || echo '{"jobs":[]}')
-          echo "$JOBS" > /tmp/ci-jobs.json
-
-          # Extract job names and conclusions
-          echo "$JOBS" | jq -r '.jobs[] | "\(.name): \(.conclusion // "unknown")"' 2>/dev/null || true
-
-          # Try to get annotations (vulnerability findings appear here)
-          ANNOTATIONS=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/check-runs?head_sha=$(echo "$JOBS" | jq -r '.jobs[0].head_sha // ""')&per_page=50" \
-            --jq '.check_runs[] | select(.output.annotations_count > 0) | {name: .name, annotations: .output.annotations_count}' 2>/dev/null || echo "")
-          echo "Annotations: $ANNOTATIONS"
-
-      - name: "Fetch CI logs for vulnerability data"
-        id: fetch_logs
-        if: steps.fetch_ci.outputs.skip != 'true'
-        shell: bash {0}
-        env:
-          CORP_REPO: ${{ steps.setup.outputs.corp_repo }}
-          RUN_ID: ${{ steps.fetch_ci.outputs.run_id }}
-          COMPONENT: ${{ steps.setup.outputs.component }}
-        run: |
-          # Also check autopilot-state for ci-logs
-          echo "::group::Fetching CI logs from autopilot-state"
-          CI_LOGS=$(gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default?ref=autopilot-state" \
-            --jq '[.[] | select(.name | test("ci-logs-'$COMPONENT'-"))] | sort_by(.name) | reverse | .[0].name // ""' 2>/dev/null || echo "")
-
-          if [ -n "$CI_LOGS" ]; then
-            echo "::notice ::Latest CI log: $CI_LOGS"
-            gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/$CI_LOGS?ref=autopilot-state" \
-              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null > /tmp/ci-log.txt || true
-          fi
-          echo "::endgroup::"
-
-          # Fetch package.json and package-lock.json from corporate repo for dependency analysis
-          echo "::group::Fetching dependency files"
-          GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/contents/package.json" \
-            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null > /tmp/corp-package.json || true
-          GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/contents/package-lock.json" \
-            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null > /tmp/corp-package-lock.json || true
-          echo "::endgroup::"
-
-      - name: "Analyze vulnerabilities"
-        id: analyze
+      - name: "Run vulnerability scan"
+        id: scan
         shell: bash {0}
         env:
           COMPONENT: ${{ steps.setup.outputs.component }}
           VERSION: ${{ steps.setup.outputs.version }}
+          CORP_REPO: ${{ steps.setup.outputs.corp_repo }}
+          CI_RUN_ID: ${{ steps.setup.outputs.ci_run_id }}
+          OUTPUT_FILE: /tmp/vuln-report.json
         run: |
-          REPORT='{"component":"'"$COMPONENT"'","version":"'"$VERSION"'","scannedAt":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","vulnerabilities":[],"npmFixable":[],"summary":{}}'
-
-          # ── Parse known CVEs from CI logs and XRay ──
-          VULNS="[]"
-
-          # Known vulnerability patterns from XRay (parsed from CI summary)
-          # These are the common patterns found in the corporate pipeline
-          KNOWN_NPM_VULNS='[
-            {"package":"ejs","currentVersion":"3.1.10","cve":"CVE-2023-29827","severity":"critical","ghsa":"GHSA-j5pp-6f4w-r5r6","fixVersion":"3.1.11","type":"npm"},
-            {"package":"braces","currentVersion":"3.0.2","cve":"CVE-2024-4068","severity":"high","ghsa":"GHSA-grv7-fg5c-xmjg","fixVersion":"3.0.3","type":"npm"}
-          ]'
-
-          # ── Check GitHub Advisory Database for each CVE ──
-          echo "::group::Consulting GitHub Advisory Database"
-          ADVISORY_RESULTS="[]"
-          for GHSA in $(echo "$KNOWN_NPM_VULNS" | jq -r '.[].ghsa'); do
-            echo "Checking advisory: $GHSA"
-            ADVISORY=$(gh api "repos/advisories/$GHSA" 2>/dev/null || \
-                       gh api "advisories/$GHSA" 2>/dev/null || echo '{}')
-            if [ -n "$ADVISORY" ] && [ "$ADVISORY" != "{}" ]; then
-              SEVERITY=$(echo "$ADVISORY" | jq -r '.severity // "unknown"' 2>/dev/null || echo "unknown")
-              SUMMARY=$(echo "$ADVISORY" | jq -r '.summary // ""' 2>/dev/null || echo "")
-              echo "  Severity: $SEVERITY — $SUMMARY"
-              ADVISORY_RESULTS=$(echo "$ADVISORY_RESULTS" | jq --arg g "$GHSA" --arg s "$SEVERITY" --arg sum "$SUMMARY" \
-                '. + [{"ghsa": $g, "severity": $s, "summary": $sum}]')
-            fi
-          done
-          echo "::endgroup::"
-
-          # ── Scan package.json for vulnerable versions ──
-          echo "::group::Scanning dependencies"
-          NPM_FIXABLE="[]"
-          if [ -f /tmp/corp-package.json ]; then
-            # Check each known vulnerable package
-            for row in $(echo "$KNOWN_NPM_VULNS" | jq -c '.[]'); do
-              PKG=$(echo "$row" | jq -r '.package')
-              CURRENT=$(echo "$row" | jq -r '.currentVersion')
-              FIX=$(echo "$row" | jq -r '.fixVersion')
-              CVE=$(echo "$row" | jq -r '.cve')
-              SEV=$(echo "$row" | jq -r '.severity')
-
-              # Check if package exists in dependencies
-              DEP_VER=$(jq -r ".dependencies.\"$PKG\" // .devDependencies.\"$PKG\" // \"\"" /tmp/corp-package.json 2>/dev/null || echo "")
-              if [ -n "$DEP_VER" ]; then
-                echo "  Found $PKG@$DEP_VER (vulnerable: $CURRENT, fix: $FIX) — $CVE ($SEV)"
-                NPM_FIXABLE=$(echo "$NPM_FIXABLE" | jq --arg p "$PKG" --arg c "$CURRENT" --arg f "$FIX" --arg cve "$CVE" --arg sev "$SEV" \
-                  '. + [{"package": $p, "current": $c, "fix": $f, "cve": $cve, "severity": $sev, "isDirect": true}]')
-              else
-                # Check if it's a transitive dependency in package-lock
-                if [ -f /tmp/corp-package-lock.json ]; then
-                  LOCK_VER=$(jq -r ".packages.\"node_modules/$PKG\".version // .dependencies.\"$PKG\".version // \"\"" /tmp/corp-package-lock.json 2>/dev/null || echo "")
-                  if [ -n "$LOCK_VER" ]; then
-                    echo "  Found $PKG@$LOCK_VER (transitive, vulnerable: $CURRENT, fix: $FIX) — $CVE ($SEV)"
-                    NPM_FIXABLE=$(echo "$NPM_FIXABLE" | jq --arg p "$PKG" --arg c "$LOCK_VER" --arg f "$FIX" --arg cve "$CVE" --arg sev "$SEV" \
-                      '. + [{"package": $p, "current": $c, "fix": $f, "cve": $cve, "severity": $sev, "isDirect": false}]')
-                  fi
-                fi
-              fi
-            done
-          fi
-          echo "::endgroup::"
-
-          # ── Build final report ──
-          CRITICAL_COUNT=$(echo "$KNOWN_NPM_VULNS" | jq '[.[] | select(.severity == "critical")] | length')
-          HIGH_COUNT=$(echo "$KNOWN_NPM_VULNS" | jq '[.[] | select(.severity == "high")] | length')
-          FIXABLE_COUNT=$(echo "$NPM_FIXABLE" | jq 'length')
-
-          REPORT=$(echo "$REPORT" | jq \
-            --argjson vulns "$KNOWN_NPM_VULNS" \
-            --argjson fixable "$NPM_FIXABLE" \
-            --argjson advisories "$ADVISORY_RESULTS" \
-            --argjson cc "$CRITICAL_COUNT" \
-            --argjson hc "$HIGH_COUNT" \
-            --argjson fc "$FIXABLE_COUNT" \
-            '.vulnerabilities = $vulns | .npmFixable = $fixable | .advisories = $advisories | .summary = {critical: $cc, high: $hc, fixable: $fc}')
-
-          echo "$REPORT" | jq . > /tmp/vuln-report.json
-          cat /tmp/vuln-report.json
-
-          # Outputs
-          HAS_CRITICAL="false"
-          HAS_HIGH="false"
-          [ "$CRITICAL_COUNT" -gt 0 ] && HAS_CRITICAL="true"
-          [ "$HIGH_COUNT" -gt 0 ] && HAS_HIGH="true"
-
-          echo "has_critical=$HAS_CRITICAL" >> "$GITHUB_OUTPUT"
-          echo "has_high=$HAS_HIGH" >> "$GITHUB_OUTPUT"
-          echo "npm_fixable=$FIXABLE_COUNT" >> "$GITHUB_OUTPUT"
-          REPORT_B64=$(echo "$REPORT" | jq -c . | base64 -w0)
-          echo "report_json=$REPORT_B64" >> "$GITHUB_OUTPUT"
+          chmod +x scripts/security/scan-corporate-vulns.sh
+          bash scripts/security/scan-corporate-vulns.sh
 
       - name: "Save report to autopilot-state"
+        if: always()
         shell: bash {0}
         env:
           COMPONENT: ${{ steps.setup.outputs.component }}
           VERSION: ${{ steps.setup.outputs.version }}
         run: |
-          if [ ! -f /tmp/vuln-report.json ]; then
+          if [ ! -f /tmp/vuln-report.json ] || [ ! -s /tmp/vuln-report.json ]; then
             echo "::warning ::No report to save"
             exit 0
           fi
@@ -272,7 +110,6 @@ jobs:
           REPORT_B64=$(base64 -w0 /tmp/vuln-report.json)
           DEST="state/workspaces/ws-default/security-scan-${COMPONENT}-${VERSION}.json"
 
-          # Check if file exists on autopilot-state
           EXISTING_SHA=$(gh api "repos/lucassfreiree/autopilot/contents/$DEST?ref=autopilot-state" \
             --jq '.sha' 2>/dev/null || echo "")
 
@@ -289,6 +126,14 @@ jobs:
               -f branch="autopilot-state" 2>/dev/null || echo "::warning ::Failed to save report"
           fi
 
+      - name: "Upload report artifact"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vuln-report-${{ steps.setup.outputs.component }}-${{ steps.setup.outputs.version }}
+          path: /tmp/vuln-report.json
+          retention-days: 30
+
   # ═══════════════════════════════════════════
   # Auto-fix npm vulnerabilities
   # ═══════════════════════════════════════════
@@ -298,22 +143,32 @@ jobs:
     needs: scan-vulnerabilities
     if: >-
       needs.scan-vulnerabilities.outputs.npm_fixable != '0' &&
-      (inputs.auto_fix == true || github.event_name == 'workflow_run')
+      needs.scan-vulnerabilities.outputs.npm_fixable != '' &&
+      (inputs.auto_fix != false || github.event_name == 'workflow_run')
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Generate npm audit fix recommendation"
+      - name: "Download vulnerability report"
+        uses: actions/download-artifact@v4
+        with:
+          name: vuln-report-${{ needs.scan-vulnerabilities.outputs.component }}-${{ needs.scan-vulnerabilities.outputs.version }}
+          path: /tmp/
+
+      - name: "Generate fix recommendations"
         id: fix
         shell: bash {0}
         env:
           COMPONENT: ${{ needs.scan-vulnerabilities.outputs.component }}
           VERSION: ${{ needs.scan-vulnerabilities.outputs.version }}
-          REPORT_B64: ${{ needs.scan-vulnerabilities.outputs.report_json }}
         run: |
-          REPORT=$(echo "$REPORT_B64" | base64 -d 2>/dev/null || echo '{}')
-          FIXABLE=$(echo "$REPORT" | jq -c '.npmFixable // []')
-          COUNT=$(echo "$FIXABLE" | jq 'length')
+          if [ ! -f /tmp/vuln-report.json ]; then
+            echo "::warning ::No report found"
+            echo "action=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
+          FIXABLE=$(jq -c '.npmFixable // []' /tmp/vuln-report.json)
+          COUNT=$(echo "$FIXABLE" | jq 'length')
           echo "::notice ::Found $COUNT fixable npm vulnerabilities"
 
           if [ "$COUNT" -eq 0 ]; then
@@ -321,30 +176,17 @@ jobs:
             exit 0
           fi
 
-          # Generate fix summary
-          echo "## NPM Vulnerability Fixes Available" > /tmp/fix-summary.md
-          echo "" >> /tmp/fix-summary.md
-          echo "| Package | Current | Fix | CVE | Severity | Direct? |" >> /tmp/fix-summary.md
-          echo "|---------|---------|-----|-----|----------|---------|" >> /tmp/fix-summary.md
-          echo "$FIXABLE" | jq -r '.[] | "| \(.package) | \(.current) | \(.fix) | \(.cve) | \(.severity) | \(.isDirect) |"' >> /tmp/fix-summary.md
-          echo "" >> /tmp/fix-summary.md
-          echo "### Recommended Actions" >> /tmp/fix-summary.md
+          # Log each fixable vulnerability
+          echo "$FIXABLE" | jq -r '.[] | "  FIX: \(.package) — \(.cve) — upgrade to \(.fixVersion)"' 2>/dev/null || true
 
-          # For direct dependencies: update package.json
-          DIRECT=$(echo "$FIXABLE" | jq '[.[] | select(.isDirect == true)]')
-          TRANSITIVE=$(echo "$FIXABLE" | jq '[.[] | select(.isDirect == false)]')
+          # Save fix plan for potential auto-deploy
+          echo "$FIXABLE" | jq '{
+            component: env.COMPONENT,
+            version: env.VERSION,
+            fixes: .,
+            generatedAt: (now | todate)
+          }' > /tmp/fix-plan.json 2>/dev/null || true
 
-          if [ "$(echo "$DIRECT" | jq 'length')" -gt 0 ]; then
-            echo "#### Direct Dependencies (update package.json)" >> /tmp/fix-summary.md
-            echo "$DIRECT" | jq -r '.[] | "- `\(.package)`: \(.current) → \(.fix) (\(.cve))"' >> /tmp/fix-summary.md
-          fi
-
-          if [ "$(echo "$TRANSITIVE" | jq 'length')" -gt 0 ]; then
-            echo "#### Transitive Dependencies (npm audit fix / overrides)" >> /tmp/fix-summary.md
-            echo "$TRANSITIVE" | jq -r '.[] | "- `\(.package)`: \(.current) → \(.fix) (\(.cve)) — add to `overrides` in package.json"' >> /tmp/fix-summary.md
-          fi
-
-          cat /tmp/fix-summary.md
           echo "action=fix" >> "$GITHUB_OUTPUT"
 
   # ═══════════════════════════════════════════
@@ -356,73 +198,85 @@ jobs:
     needs: [scan-vulnerabilities, auto-fix]
     if: >-
       always() &&
+      needs.scan-vulnerabilities.result == 'success' &&
       (needs.scan-vulnerabilities.outputs.has_critical == 'true' ||
        needs.scan-vulnerabilities.outputs.has_high == 'true')
     steps:
-      - name: "Create tracking issue"
+      - name: "Download vulnerability report"
+        uses: actions/download-artifact@v4
+        with:
+          name: vuln-report-${{ needs.scan-vulnerabilities.outputs.component }}-${{ needs.scan-vulnerabilities.outputs.version }}
+          path: /tmp/
+
+      - name: "Create or update tracking issue"
         shell: bash {0}
         env:
           COMPONENT: ${{ needs.scan-vulnerabilities.outputs.component }}
           VERSION: ${{ needs.scan-vulnerabilities.outputs.version }}
-          HAS_CRITICAL: ${{ needs.scan-vulnerabilities.outputs.has_critical }}
-          NPM_FIXABLE: ${{ needs.scan-vulnerabilities.outputs.npm_fixable }}
-          REPORT_B64: ${{ needs.scan-vulnerabilities.outputs.report_json }}
+          TOTAL_CVES: ${{ needs.scan-vulnerabilities.outputs.total_cves }}
         run: |
-          REPORT=$(echo "$REPORT_B64" | base64 -d 2>/dev/null || echo '{}')
-          CRITICAL=$(echo "$REPORT" | jq '.summary.critical // 0')
-          HIGH=$(echo "$REPORT" | jq '.summary.high // 0')
+          if [ ! -f /tmp/vuln-report.json ]; then
+            echo "::warning ::No report to create issue from"
+            exit 0
+          fi
 
-          # Check if issue already exists for this version
+          CRITICAL=$(jq '.summary.critical // 0' /tmp/vuln-report.json)
+          HIGH=$(jq '.summary.high // 0' /tmp/vuln-report.json)
+          MEDIUM=$(jq '.summary.medium // 0' /tmp/vuln-report.json)
+          NPM_FIX=$(jq '.summary.npmFixable // 0' /tmp/vuln-report.json)
+          SCAN_DATE=$(jq -r '.scannedAt // "unknown"' /tmp/vuln-report.json)
+
+          # Check if issue already exists
           EXISTING=$(gh issue list --repo lucassfreiree/autopilot \
             --search "Security Scan: $COMPONENT v$VERSION" \
             --state open --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
 
           if [ -n "$EXISTING" ]; then
-            echo "::notice ::Issue #$EXISTING already exists — updating"
-            gh issue comment "$EXISTING" --repo lucassfreiree/autopilot \
-              --body "Updated scan at $(date -u +%Y-%m-%dT%H:%M:%SZ). Critical: $CRITICAL, High: $HIGH, NPM fixable: $NPM_FIXABLE" 2>/dev/null || true
+            echo "::notice ::Issue #$EXISTING already exists — adding comment"
+            COMMENT="Re-scan at $SCAN_DATE. Critical: $CRITICAL, High: $HIGH, Medium: $MEDIUM, NPM fixable: $NPM_FIX"
+            gh issue comment "$EXISTING" --repo lucassfreiree/autopilot --body "$COMMENT" 2>/dev/null || true
             exit 0
           fi
 
-          # Build issue body
-          SEVERITY_LABEL="priority-medium"
-          [ "$HAS_CRITICAL" = "true" ] && SEVERITY_LABEL="priority-critical"
+          # Build vulnerability list
+          VULN_LIST=$(jq -r '.vulnerabilities[] | select(.severity == "critical" or .severity == "high") |
+            "- **\(.severity | ascii_upcase)**: \(.cve) — \(.package // "OS-level") — \(.summary[:100] // "See advisory")\(if .ghsa != "" then " ([Advisory](https://github.com/advisories/\(.ghsa)))" else "" end)\(if .fixVersion != "" and .fixVersion != null then " — Fix: \(.fixVersion)" else "" end)"' \
+            /tmp/vuln-report.json 2>/dev/null || echo "See scan report on autopilot-state branch")
 
-          VULN_LIST=$(echo "$REPORT" | jq -r '.vulnerabilities[] | "- \(.severity | ascii_upcase): \(.package)@\(.currentVersion) — \(.cve) (https://github.com/advisories/\(.ghsa)) — Fix: \(.fixVersion // "N/A")"' 2>/dev/null || echo "See scan report on autopilot-state branch")
-          ADVISORY_LINKS=$(echo "$REPORT" | jq -r '.vulnerabilities[] | "- https://github.com/advisories/\(.ghsa)"' 2>/dev/null || echo "N/A")
-          SCAN_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # Build npm fixable list
+          FIXABLE_LIST=$(jq -r '.npmFixable[] | "- `\(.package)`: \(.cve) — upgrade to \(.fixVersion)"' /tmp/vuln-report.json 2>/dev/null || echo "None")
 
+          # Build issue body via temp file (avoids YAML colon conflicts)
           {
             echo "## Security Vulnerability Scan Results"
-            echo "Component: $COMPONENT v$VERSION"
-            echo "Scan date: $SCAN_DATE"
-            echo "Source: Corporate CI (Esteira de Build NPM) + XRay + Checkmarx"
+            echo ""
+            echo "- Component = $COMPONENT v$VERSION"
+            echo "- Scan date = $SCAN_DATE"
+            echo "- Source = Corporate CI (Esteira de Build NPM) XRay + Checkmarx"
             echo ""
             echo "### Summary"
-            echo "Critical: $CRITICAL / High: $HIGH / NPM Fixable: $NPM_FIXABLE"
+            echo "- Total CVEs = ${TOTAL_CVES:-0}"
+            echo "- Critical = $CRITICAL / High = $HIGH / Medium = $MEDIUM / NPM Fixable = $NPM_FIX"
             echo ""
-            echo "### Vulnerabilities Found"
+            echo "### Critical and High Vulnerabilities"
             echo "$VULN_LIST"
             echo ""
-            echo "### Advisory Links"
-            echo "$ADVISORY_LINKS"
+            echo "### NPM Fixable (auto-upgrade available)"
+            echo "$FIXABLE_LIST"
             echo ""
             echo "### Recommended Actions"
-            echo "1. Direct npm deps: Update version in package.json + package-lock.json"
-            echo "2. Transitive deps: Add to overrides field in package.json"
-            echo "3. OS-level (rpm): Update base Docker image or ignore if no fix available"
-            echo "4. Re-deploy via apply-source-change pipeline"
+            echo "1. NPM direct deps - Update version in package.json + package-lock.json"
+            echo "2. NPM transitive deps - Add to overrides in package.json or run npm audit fix"
+            echo "3. OS-level (rpm) - Update base Docker image or request infra team update"
+            echo "4. Re-deploy via apply-source-change pipeline after fixes"
             echo ""
             echo "---"
             echo "Auto-generated by security-vuln-scanner workflow"
           } > /tmp/issue-body.txt
 
-          BODY=$(cat /tmp/issue-body.txt)
+          TITLE="Security Scan $COMPONENT v$VERSION — $CRITICAL critical, $HIGH high vulnerabilities"
 
           gh issue create --repo lucassfreiree/autopilot \
-            --title "Security Scan: $COMPONENT v$VERSION — $CRITICAL critical, $HIGH high vulnerabilities" \
-            --body "$BODY" \
-            --label "security,$SEVERITY_LABEL" 2>/dev/null || \
-          gh issue create --repo lucassfreiree/autopilot \
-            --title "Security Scan: $COMPONENT v$VERSION — $CRITICAL critical, $HIGH high vulnerabilities" \
-            --body "$BODY" 2>/dev/null || echo "::error ::Failed to create issue"
+            --title "$TITLE" \
+            --body-file /tmp/issue-body.txt \
+            --label "security" 2>/dev/null || echo "::error ::Failed to create issue"

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractId": "claude-session-memory",
   "description": "Memoria cumulativa de TUDO que foi feito, decidido e aprendido. Cada sessao DEVE ler isso e aplicar automaticamente. O objetivo e reduzir tempo de execucao e melhorar qualidade a cada sessao.",
-  "lastUpdated": "2026-03-31T12:30:00Z",
+  "lastUpdated": "2026-03-31T23:30:00Z",
   "lastSessionId": "session_01N6wTVvkGd7Hs1zMtus8i5i",
   "multiCompanyModel": {
     "description": "Control plane centralizado gerenciando multiplas empresas. Cada empresa e um contexto COMPLETAMENTE ISOLADO.",
@@ -22,7 +22,7 @@
           "bbvinet/psc-sre-automacao-controller": {
             "role": "Controller — orquestra automacoes, despacha para agents, gerencia logs de execucao",
             "type": "source-code",
-            "currentVersion": "3.7.0",
+            "currentVersion": "3.7.4",
             "stack": "Node 22, TypeScript, Express, Jest, SQLite, S3",
             "ci": "Esteira de Build NPM (corporate runner)",
             "actionsUrl": "https://github.com/bbvinet/psc-sre-automacao-controller/actions",
@@ -33,7 +33,7 @@
           "bbvinet/psc-sre-automacao-agent": {
             "role": "Agent — executa automacoes nos clusters, recebe callbacks de cronjob, envia logs ao controller",
             "type": "source-code",
-            "currentVersion": "2.3.2",
+            "currentVersion": "2.3.3",
             "stack": "Node 22, TypeScript, Express, Jest, K8s client",
             "ci": "Esteira de Build NPM (corporate runner)",
             "actionsUrl": "https://github.com/bbvinet/psc-sre-automacao-agent/actions",
@@ -499,7 +499,7 @@
     ]
   },
   "versioningRules": {
-    "currentVersion": "3.7.3",
+    "currentVersion": "3.7.4",
     "previousVersion": "3.7.2",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versioningPattern": "CRITICO: Apos X.Y.9, a proxima versao e X.(Y+1).0 — NUNCA X.Y.10. Exemplos: 3.5.9 → 3.6.0, 3.6.9 → 3.7.0, 3.9.9 → 3.10.0. O terceiro digito (patch) vai de 0 a 9 apenas.",
@@ -1366,7 +1366,16 @@
       "deploy_auto_learn_zero_runs": "deploy-auto-learn.yml tinha 0 runs porque GitHub nao indexou (so tinha workflow_run + workflow_dispatch triggers). FIX: adicionar push trigger no proprio arquivo para forcar indexacao. PR #405.",
       "heredoc_exit_127_systematic": "CRITICO: $(cat <<EOF) dentro de run: | blocks em GHA causa exit 127. O GHA parser interpreta como YAML antes de avaliar como shell. Workflows corrigidos: compliance-gate (#403), continuous-improvement (#405), post-deploy-validation (#406), alert-notify (#406). FIX: usar inline string + printf. continuous-improvement agora detecta este pattern automaticamente.",
       "continuous_improvement_shallow": "continuous-improvement.yml faz analise ESTRUTURAL (YAML valido, schemas, locks expirados) mas NAO analisa falhas de RUNTIME. deploy-auto-learn.yml e o mecanismo que aprende de falhas de runtime. Ambos sao complementares.",
-      "cronjob_result_test_count_mismatch": "Mock tinha count:1 com entries:[] mas controller computa count = boundedEntries.length = 0. FIX: alinhar mock count com entries.length. PR #402."
+      "cronjob_result_test_count_mismatch": "Mock tinha count:1 com entries:[] mas controller computa count = boundedEntries.length = 0. FIX: alinhar mock count com entries.length. PR #402.",
+      "compliance_gate_patch_scope": "CRITICO: compliance-gate.yml escaneava TODOS os .ts em patches/ incluindo sobras de deploys anteriores. FIX: so escanear arquivos referenciados em trigger/source-change.json changes[].content_ref. Implementado no PR #420.",
+      "compliance_gate_rule5_false_positive": "Rule 5 (no-validate-in-fetch) usava grep -B5 que capturava nomes de funcao (callAgent/postJson) em linhas ANTES de validateTrustedUrl. FIX: mudar para grep same-line pattern (fetch|postJson|callAgent).*validateTrustedUrl. PR #420.",
+      "compliance_gate_rule6_regex_false_positive": "Rule 6 (no-nested-ternary) capturava patterns de regex URL como https?:// onde ? parecia operador ternario. FIX: excluir linhas que comecam com /^ (regex definition) e linhas com RegExp. PR #420.",
+      "compliance_gate_rule12_indirect_dos": "Rule 12 (security-dos-loop) agora tambem detecta for-loops bounded por .length sem Math.min cap. Verificacao indireta para Checkmarx Server_DoS_by_Loop. PR #420.",
+      "security_vuln_scanner_workflow": "security-vuln-scanner.yml — scanner pos-deploy que consulta esteira corporativa (XRay, Checkmarx) via BBVINET_TOKEN, baixa logs do run, parseia CVEs, consulta GitHub Advisory DB, cria Issue. Triggers: workflow_run (apply-source-change + ci-monitor-loop), workflow_dispatch, push. Script externo: scripts/security/scan-corporate-vulns.sh. PR #421.",
+      "yaml_table_pipe_in_run_block": "NUNCA usar | no inicio de linha em blocos run: | — YAML interpreta como block scalar indicator. Tabelas markdown com | devem ser escritas via echo para arquivo temporario.",
+      "checkmarx_dos_loop_fix_pattern": "Para Checkmarx Server_DoS_by_Loop: adicionar const MAX_X = N; e Math.min(array.length, MAX_X) no bound do for-loop. Mesmo que o loop tenha tamanho fixo, Checkmarx nao consegue verificar estaticamente.",
+      "xray_known_npm_vulns_374": "XRay scan do build 3.7.4: Critical ejs@3.1.10 CVE-2023-29827, High braces@3.0.2 CVE-2024-4068. RPM High: nodejs CVE-2025-23166/3277/6965, libxml2 CVE-2025-49795/49796/49794, libarchive CVE-2025-5914, zlib CVE-2025-4638. RPM sao do base image (nao fixavel por nos).",
+      "ci_gate_stuck_corporate_runner_offline": "CI Gate pode ficar stuck por horas quando corporate runner esta offline (fds/feriado). O ci-monitor-loop e deploy-pipeline-monitor compensam — verificam e reportam sucesso/falha independentemente. Se CI Gate stuck > 30min, verificar release-state no autopilot-state (pode ja ter sido promovido)."
     },
     "gha_yaml_markdown_bold": "CRITICO: NUNCA usar **texto**: (markdown bold seguido de dois-pontos) dentro de blocos run: | em workflows GitHub Actions. O parser YAML do GHA interpreta ** como alias syntax e : como mapping key, quebrando o YAML ANTES de avaliar o shell. Fix: remover ** ou usar variaveis. Corrigido em 6 workflows: emergency-watchdog, auto-dispatch-task, continuous-improvement, dashboard-auto-improve, deploy-auto-learn, workflow-sentinel.",
     "gha_no_heredoc_in_run": "CRITICO: NUNCA usar heredoc (cat <<EOF / cat <<'EOF') dentro de blocos run: | em GitHub Actions. O GHA parser le TODO o bloco run: como YAML literal ANTES de avaliar como shell. Qualquer linha com dois-pontos (ex: 'Workspace: $WS') e interpretada como YAML key-value e quebra. FIX: usar variavel simples com string inline. Ex: BODY='texto sem colon' e depois gh issue comment --body \"$BODY\". NUNCA heredoc.",
@@ -1442,17 +1451,17 @@
     "_note": "Externalized by token-auto-optimize. Read on demand."
   },
   "currentState": {
-    "controllerVersion": "3.7.3",
+    "controllerVersion": "3.7.4",
     "agentVersion": "2.3.3",
-    "lastTriggerRun": 81,
-    "lastSuccessfulRun": 80,
+    "lastTriggerRun": 82,
+    "lastSuccessfulRun": 82,
     "historia930217": "completed — all 4 deploys passed (3.6.5, 3.6.6, 2.2.8, 2.2.9)",
     "historia930188": "COMPLETED — controller 3.7.2 CI PASSED (run #80, 2026-03-30T19:03Z). ciOutcome=success. CAP tag=3.7.2. Security fixes: XSS sanitizeForOutput, SSRF validateTrustedUrl, DoS boundedEntries, no for...of. 3 iterations: run78(for...of ESLint), run79(count:1 test), run80(PASS).",
     "pendingDeploy": null,
     "nextDeploy": {
-      "note": "No pending deploy. Controller 3.7.2 and Agent 2.3.3 both deployed and promoted.",
+      "note": "No pending deploy. Controller 3.7.4 and Agent 2.3.3 both deployed and promoted. 3.7.4 = Checkmarx DoS fix + security-vuln-scanner.",
       "nextVersion": {
-        "controller": "3.7.3",
+        "controller": "3.7.5",
         "agent": "2.3.4"
       }
     }

--- a/scripts/security/scan-corporate-vulns.sh
+++ b/scripts/security/scan-corporate-vulns.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════
+# scan-corporate-vulns.sh — Dynamic vulnerability scanner
+# Queries corporate CI (Esteira de Build NPM) via BBVINET_TOKEN
+# Parses XRay, Checkmarx, and Motor de Liberacao data from run logs
+# ═══════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+COMPONENT="${COMPONENT:-controller}"
+VERSION="${VERSION:-unknown}"
+CORP_REPO="${CORP_REPO:-}"
+CI_RUN_ID="${CI_RUN_ID:-}"
+BBVINET_TOKEN="${BBVINET_TOKEN:-}"
+GH_TOKEN_VAL="${GH_TOKEN:-}"
+OUTPUT_FILE="${OUTPUT_FILE:-/tmp/vuln-report.json}"
+
+# ── Determine corporate repo ──
+if [ -z "$CORP_REPO" ]; then
+  if [ "$COMPONENT" = "controller" ]; then
+    CORP_REPO="bbvinet/psc-sre-automacao-controller"
+  else
+    CORP_REPO="bbvinet/psc-sre-automacao-agent"
+  fi
+fi
+
+echo "::notice ::Scanning $COMPONENT v$VERSION from $CORP_REPO"
+
+# ── Find the latest CI run ──
+find_ci_run() {
+  if [ -n "$CI_RUN_ID" ]; then
+    echo "$CI_RUN_ID"
+    return
+  fi
+
+  if [ -z "$BBVINET_TOKEN" ]; then
+    echo ""
+    return
+  fi
+
+  # Try to find runs — get latest completed or in_progress
+  local RUN_ID
+  RUN_ID=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/actions/runs?per_page=5" \
+    --jq '.workflow_runs | map(select(.conclusion == "success" or .status == "completed")) | .[0].id // ""' 2>/dev/null || echo "")
+
+  if [ -z "$RUN_ID" ]; then
+    # Fallback: get any recent run
+    RUN_ID=$(GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/actions/runs?per_page=3" \
+      --jq '.workflow_runs[0].id // ""' 2>/dev/null || echo "")
+  fi
+
+  echo "$RUN_ID"
+}
+
+# ── Download and parse CI run logs ──
+fetch_run_data() {
+  local RUN_ID="$1"
+  echo "::group::Fetching CI run $RUN_ID data"
+
+  # Get run details
+  GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/actions/runs/$RUN_ID" \
+    --jq '{id: .id, status: .status, conclusion: .conclusion, created_at: .created_at, head_sha: .head_sha, name: .name}' \
+    2>/dev/null > /tmp/run-info.json || echo '{}' > /tmp/run-info.json
+
+  cat /tmp/run-info.json
+  echo ""
+
+  # Get jobs for this run
+  GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/actions/runs/$RUN_ID/jobs?per_page=30" \
+    2>/dev/null > /tmp/run-jobs.json || echo '{"jobs":[]}' > /tmp/run-jobs.json
+
+  echo "Jobs found:"
+  jq -r '.jobs[] | "  \(.name): \(.conclusion // .status)"' /tmp/run-jobs.json 2>/dev/null || true
+
+  # Download logs archive
+  echo "Downloading logs archive..."
+  GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/actions/runs/$RUN_ID/logs" \
+    > /tmp/ci-logs.zip 2>/dev/null || true
+
+  if [ -s /tmp/ci-logs.zip ]; then
+    mkdir -p /tmp/ci-logs-extracted
+    unzip -o -q /tmp/ci-logs.zip -d /tmp/ci-logs-extracted 2>/dev/null || true
+    echo "Extracted $(find /tmp/ci-logs-extracted -type f | wc -l) log files"
+  fi
+
+  echo "::endgroup::"
+}
+
+# ── Parse XRay vulnerabilities from logs ──
+parse_xray_vulns() {
+  echo "::group::Parsing XRay vulnerability data"
+  local VULNS="[]"
+
+  # Search for CVE patterns in all log files
+  local CVE_LINES=""
+  if [ -d /tmp/ci-logs-extracted ]; then
+    CVE_LINES=$(grep -rihE "CVE-[0-9]{4}-[0-9]+" /tmp/ci-logs-extracted/ 2>/dev/null || true)
+  fi
+
+  # Also check autopilot-state ci-logs
+  local LATEST_LOG=""
+  LATEST_LOG=$(gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default?ref=autopilot-state" \
+    --jq "[.[] | select(.name | test(\"ci-logs-${COMPONENT}-\"))] | sort_by(.name) | reverse | .[0].name // \"\"" 2>/dev/null || echo "")
+
+  if [ -n "$LATEST_LOG" ]; then
+    echo "Latest autopilot CI log: $LATEST_LOG"
+    gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/$LATEST_LOG?ref=autopilot-state" \
+      --jq '.content' 2>/dev/null | base64 -d 2>/dev/null > /tmp/autopilot-ci-log.txt || true
+
+    if [ -s /tmp/autopilot-ci-log.txt ]; then
+      local EXTRA_CVES
+      EXTRA_CVES=$(grep -oE "CVE-[0-9]{4}-[0-9]+" /tmp/autopilot-ci-log.txt 2>/dev/null | sort -u || true)
+      if [ -n "$EXTRA_CVES" ]; then
+        CVE_LINES="$CVE_LINES
+$EXTRA_CVES"
+      fi
+    fi
+  fi
+
+  # Extract unique CVE IDs
+  local UNIQUE_CVES
+  UNIQUE_CVES=$(echo "$CVE_LINES" | grep -oE "CVE-[0-9]{4}-[0-9]+" 2>/dev/null | sort -u || true)
+  local CVE_COUNT
+  CVE_COUNT=$(echo "$UNIQUE_CVES" | grep -c "CVE" 2>/dev/null || echo "0")
+  echo "Found $CVE_COUNT unique CVEs in CI logs"
+
+  # Parse npm package + version associations from logs
+  # Pattern: npm://package:version or "package":"version"
+  local NPM_VULNS="[]"
+  if [ -d /tmp/ci-logs-extracted ]; then
+    # XRay format: npm://package:version
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      local PKG VER
+      PKG=$(echo "$line" | sed -E 's/npm:\/\/([^:]+):.*/\1/' 2>/dev/null || true)
+      VER=$(echo "$line" | sed -E 's/npm:\/\/[^:]+:(.*)/\1/' 2>/dev/null || true)
+      if [ -n "$PKG" ] && [ -n "$VER" ]; then
+        NPM_VULNS=$(echo "$NPM_VULNS" | jq --arg p "$PKG" --arg v "$VER" \
+          'if any(.[]; .package == $p and .version == $v) then . else . + [{"package": $p, "version": $v}] end')
+      fi
+    done < <(grep -rohE "npm://[a-zA-Z0-9@._-]+:[0-9.]+" /tmp/ci-logs-extracted/ 2>/dev/null | sort -u || true)
+  fi
+
+  # Parse rpm package + version associations
+  local RPM_VULNS="[]"
+  if [ -d /tmp/ci-logs-extracted ]; then
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      local PKG VER
+      PKG=$(echo "$line" | sed -E 's|rpm://[0-9]+:([^:]+):.*|\1|' 2>/dev/null || true)
+      VER=$(echo "$line" | sed -E 's|rpm://[0-9]+:[^:]+:([^+]+).*|\1|' 2>/dev/null || true)
+      if [ -n "$PKG" ] && [ -n "$VER" ]; then
+        RPM_VULNS=$(echo "$RPM_VULNS" | jq --arg p "$PKG" --arg v "$VER" \
+          'if any(.[]; .package == $p and .version == $v) then . else . + [{"package": $p, "version": $v, "type": "rpm"}] end')
+      fi
+    done < <(grep -rohE "rpm://[0-9]+:[a-zA-Z0-9._-]+:[0-9.]+" /tmp/ci-logs-extracted/ 2>/dev/null | sort -u || true)
+  fi
+
+  # ── Query GitHub Advisory DB for each CVE ──
+  echo "::group::Querying GitHub Advisory Database"
+  local ALL_VULNS="[]"
+
+  # Map known CVE → GHSA (built dynamically + hardcoded fallbacks)
+  declare -A CVE_TO_GHSA
+  CVE_TO_GHSA["CVE-2023-29827"]="GHSA-j5pp-6f4w-r5r6"
+  CVE_TO_GHSA["CVE-2024-4068"]="GHSA-grv7-fg5c-xmjg"
+
+  # Try to resolve each CVE via GitHub Advisory API
+  while IFS= read -r CVE; do
+    [ -z "$CVE" ] && continue
+    echo "Checking $CVE..."
+
+    local GHSA_ID=""
+    local SEVERITY="unknown"
+    local SUMMARY=""
+    local FIXED_VER=""
+    local AFFECTED_PKG=""
+
+    # Check hardcoded mapping first
+    if [ -n "${CVE_TO_GHSA[$CVE]+x}" ]; then
+      GHSA_ID="${CVE_TO_GHSA[$CVE]}"
+    fi
+
+    # Try GitHub Advisory search by CVE
+    if [ -z "$GHSA_ID" ]; then
+      GHSA_ID=$(gh api "advisories?cve_id=$CVE" \
+        --jq '.[0].ghsa_id // ""' 2>/dev/null || echo "")
+    fi
+
+    # If we have a GHSA, get full details
+    if [ -n "$GHSA_ID" ]; then
+      local ADVISORY
+      ADVISORY=$(gh api "advisories/$GHSA_ID" 2>/dev/null || echo '{}')
+      SEVERITY=$(echo "$ADVISORY" | jq -r '.severity // "unknown"' 2>/dev/null || echo "unknown")
+      SUMMARY=$(echo "$ADVISORY" | jq -r '.summary // ""' 2>/dev/null | head -c 200 || echo "")
+      FIXED_VER=$(echo "$ADVISORY" | jq -r '.vulnerabilities[0].patched_versions // ""' 2>/dev/null | head -c 50 || echo "")
+      AFFECTED_PKG=$(echo "$ADVISORY" | jq -r '.vulnerabilities[0].package.name // ""' 2>/dev/null || echo "")
+    fi
+
+    # Try NVD-style severity lookup if no GHSA
+    if [ "$SEVERITY" = "unknown" ] && [ -z "$GHSA_ID" ]; then
+      # Attempt to get severity from the advisory search
+      local SEARCH_RESULT
+      SEARCH_RESULT=$(gh api "advisories?type=reviewed&cve_id=$CVE" 2>/dev/null || echo "[]")
+      if [ "$SEARCH_RESULT" != "[]" ]; then
+        SEVERITY=$(echo "$SEARCH_RESULT" | jq -r '.[0].severity // "unknown"' 2>/dev/null || echo "unknown")
+        GHSA_ID=$(echo "$SEARCH_RESULT" | jq -r '.[0].ghsa_id // ""' 2>/dev/null || echo "")
+        SUMMARY=$(echo "$SEARCH_RESULT" | jq -r '.[0].summary // ""' 2>/dev/null | head -c 200 || echo "")
+      fi
+    fi
+
+    ALL_VULNS=$(echo "$ALL_VULNS" | jq \
+      --arg cve "$CVE" \
+      --arg ghsa "$GHSA_ID" \
+      --arg sev "$SEVERITY" \
+      --arg sum "$SUMMARY" \
+      --arg fix "$FIXED_VER" \
+      --arg pkg "$AFFECTED_PKG" \
+      '. + [{"cve": $cve, "ghsa": $ghsa, "severity": $sev, "summary": $sum, "fixVersion": $fix, "package": $pkg}]')
+  done <<< "$UNIQUE_CVES"
+  echo "::endgroup::"
+
+  # ── Classify vulnerabilities ──
+  local CRITICAL HIGH MEDIUM LOW
+  CRITICAL=$(echo "$ALL_VULNS" | jq '[.[] | select(.severity == "critical")] | length')
+  HIGH=$(echo "$ALL_VULNS" | jq '[.[] | select(.severity == "high")] | length')
+  MEDIUM=$(echo "$ALL_VULNS" | jq '[.[] | select(.severity == "medium")] | length')
+  LOW=$(echo "$ALL_VULNS" | jq '[.[] | select(.severity == "low" or .severity == "unknown")] | length')
+
+  # ── Identify npm-fixable vulnerabilities ──
+  local NPM_FIXABLE="[]"
+  # Check corporate package.json for fixable deps
+  if [ -f /tmp/corp-package.json ]; then
+    NPM_FIXABLE=$(echo "$ALL_VULNS" | jq -c '[.[] | select(.fixVersion != "" and .fixVersion != null and .package != "")]')
+  fi
+
+  # Build the final report
+  jq -n \
+    --arg comp "$COMPONENT" \
+    --arg ver "$VERSION" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg run_id "${CI_RUN_ID:-auto}" \
+    --argjson vulns "$ALL_VULNS" \
+    --argjson npm_vulns "$NPM_VULNS" \
+    --argjson rpm_vulns "$RPM_VULNS" \
+    --argjson fixable "$NPM_FIXABLE" \
+    --argjson critical "$CRITICAL" \
+    --argjson high "$HIGH" \
+    --argjson medium "$MEDIUM" \
+    --argjson low "$LOW" \
+    --argjson total "$CVE_COUNT" \
+    '{
+      component: $comp,
+      version: $ver,
+      scannedAt: $ts,
+      ciRunId: $run_id,
+      summary: {total: $total, critical: $critical, high: $high, medium: $medium, low: $low, npmFixable: ($fixable | length)},
+      vulnerabilities: $vulns,
+      npmPackages: $npm_vulns,
+      rpmPackages: $rpm_vulns,
+      npmFixable: $fixable
+    }' > "$OUTPUT_FILE"
+
+  echo ""
+  echo "=== VULNERABILITY REPORT ==="
+  jq '.summary' "$OUTPUT_FILE"
+  echo ""
+  echo "Critical/High vulnerabilities:"
+  jq -r '.vulnerabilities[] | select(.severity == "critical" or .severity == "high") | "  \(.severity | ascii_upcase): \(.cve) — \(.package) — \(.summary[:80])"' "$OUTPUT_FILE" 2>/dev/null || true
+  echo "::endgroup::"
+
+  # Output for GitHub Actions
+  echo "has_critical=$([ "$CRITICAL" -gt 0 ] && echo true || echo false)" >> "${GITHUB_OUTPUT:-/dev/null}"
+  echo "has_high=$([ "$HIGH" -gt 0 ] && echo true || echo false)" >> "${GITHUB_OUTPUT:-/dev/null}"
+  echo "npm_fixable=$(echo "$NPM_FIXABLE" | jq 'length')" >> "${GITHUB_OUTPUT:-/dev/null}"
+  echo "total_cves=$CVE_COUNT" >> "${GITHUB_OUTPUT:-/dev/null}"
+}
+
+# ── Fetch corporate package.json for dependency analysis ──
+fetch_dependencies() {
+  echo "::group::Fetching corporate dependencies"
+  if [ -n "$BBVINET_TOKEN" ]; then
+    GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/contents/package.json" \
+      --jq '.content' 2>/dev/null | base64 -d 2>/dev/null > /tmp/corp-package.json || true
+    GH_TOKEN="$BBVINET_TOKEN" gh api "repos/$CORP_REPO/contents/package-lock.json" \
+      --jq '.content' 2>/dev/null | base64 -d 2>/dev/null > /tmp/corp-package-lock.json || true
+
+    if [ -f /tmp/corp-package.json ]; then
+      echo "package.json fetched ($(wc -c < /tmp/corp-package.json) bytes)"
+    fi
+  fi
+  echo "::endgroup::"
+}
+
+# ── Main execution ──
+main() {
+  if [ -z "$BBVINET_TOKEN" ]; then
+    echo "::error ::BBVINET_TOKEN not available — cannot scan corporate CI"
+    jq -n --arg comp "$COMPONENT" --arg ver "$VERSION" \
+      '{component: $comp, version: $ver, error: "BBVINET_TOKEN not available", summary: {total: 0, critical: 0, high: 0}}' > "$OUTPUT_FILE"
+    exit 0
+  fi
+
+  # Step 1: Find CI run
+  local RUN_ID
+  RUN_ID=$(find_ci_run)
+  if [ -z "$RUN_ID" ]; then
+    echo "::warning ::No CI run found — using autopilot-state logs only"
+  else
+    echo "::notice ::Using CI run: $RUN_ID"
+    CI_RUN_ID="$RUN_ID"
+    # Step 2: Fetch run data and logs
+    fetch_run_data "$RUN_ID"
+  fi
+
+  # Step 3: Fetch dependencies
+  fetch_dependencies
+
+  # Step 4: Parse and analyze
+  parse_xray_vulns
+
+  echo ""
+  echo "Report saved to: $OUTPUT_FILE"
+  cat "$OUTPUT_FILE" | jq .
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Rewrite security-vuln-scanner to dynamically query corporate CI (Esteira de Build NPM) via BBVINET_TOKEN
- Extract external script `scripts/security/scan-corporate-vulns.sh` for log parsing
- Downloads CI run logs, parses XRay npm/rpm CVE data, queries GitHub Advisory DB
- Also triggers on ci-monitor-loop completion (faster than waiting for apply-source-change)
- Update session memory with 3.7.4 deploy success and 9 new error patterns

## Test plan
- [ ] Verify YAML valid (validated locally)
- [ ] Verify workflow triggers on push (self-path trigger)
- [ ] Manual dispatch with ci_run_id=23810579473 to test against 3.7.4 build

https://claude.ai/code/session_019QnwcZ8wnNUty7fk6PRwHd