### PR TITLE
feat: map Checkmarx SAST patterns into compliance gate

### DIFF
--- a/.github/workflows/compliance-gate.yml
+++ b/.github/workflows/compliance-gate.yml
@@ -189,40 +189,67 @@ jobs:
             viol "blocked-workspace" "Workspace $WS_ID is LOCKED (third-party)" "error"
           fi
 
-          # ══ RULE 10: SECURITY — XSS (Reflected) ══
+          # ══ RULE 10: SECURITY — XSS (Reflected) [Checkmarx Reflected_XSS] ══
+          # Checkmarx traces: req.body → ... → res.json(). Even indirect flows trigger.
+          # Fix: every file with res.json AND req.body/query/params MUST import sanitizeForOutput
           for f in $PATCH_TS; do
-            # Check if req.body/req.query flows to res.json without sanitization
-            if grep -n "res\.json.*req\.\(body\|query\|params\)" "$f" > /dev/null 2>&1; then
+            HAS_REQ_INPUT=$(grep -c "req\.\(body\|query\|params\)" "$f" 2>/dev/null || echo "0")
+            HAS_RES_JSON=$(grep -c "res\.\(json\|send\|status\)" "$f" 2>/dev/null || echo "0")
+            if [ "$HAS_REQ_INPUT" -gt 0 ] && [ "$HAS_RES_JSON" -gt 0 ]; then
               if ! grep -q "sanitizeForOutput" "$f"; then
-                viol "security-xss" "$f: req input flows to res.json without sanitizeForOutput()" "error"
+                viol "security-xss" "$f: file reads req input AND writes response — MUST import sanitizeForOutput (Checkmarx Reflected_XSS)" "error"
               fi
             fi
-            # Check error messages reflecting input
+            # Check error messages reflecting unsanitized details
             if grep -nP "res\.(status|json).*error.*\b(message|detail|desc)" "$f" | grep -v "sanitize" > /dev/null 2>&1; then
               warn "security-error-leak" "$f: error response may leak details — use sanitizeForOutput()"
             fi
           done
 
-          # ══ RULE 11: SECURITY — SSRF ══
+          # ══ RULE 11: SECURITY — SSRF [Checkmarx SSRF] ══
+          # Checkmarx traces: req.body → body.cluster/namespace → URL resolve → fetch()
+          # Fix: every file with fetch() MUST have validateTrustedUrl before the call
           for f in $PATCH_TS; do
-            if grep -nP "fetch\(.*req\.|http\.request\(.*req\." "$f" > /dev/null 2>&1; then
-              if ! grep -q "parseSafeIdentifier\|validateTrustedUrl" "$f"; then
-                viol "security-ssrf" "$f: user input used in fetch/http without validation" "error"
+            HAS_FETCH=$(grep -cP "fetch\(|http\.request\(|postJson\(|callAgent\(" "$f" 2>/dev/null || echo "0")
+            if [ "$HAS_FETCH" -gt 0 ]; then
+              if ! grep -q "validateTrustedUrl" "$f"; then
+                viol "security-ssrf" "$f: uses fetch/http/postJson/callAgent without validateTrustedUrl (Checkmarx SSRF)" "error"
+              fi
+              # Also verify URL is NOT built directly from req.body
+              if grep -nP "fetch\(\s*req\.|fetch\(\s*body\." "$f" > /dev/null 2>&1; then
+                viol "security-ssrf" "$f: req/body input used DIRECTLY in fetch URL — use resolveTrustedRegisteredAgentExecuteUrl + validateTrustedUrl" "error"
+              fi
+            fi
+            # Files that resolve URLs from user input MUST validate
+            if grep -q "resolveTrustedRegisteredAgentExecuteUrl\|resolveTrustedRegisteredAgentExecuteUrlByCluster" "$f"; then
+              if ! grep -q "validateTrustedUrl" "$f"; then
+                viol "security-ssrf" "$f: resolves agent URL from input but missing validateTrustedUrl guard (Checkmarx SSRF)" "error"
               fi
             fi
           done
 
-          # ══ RULE 12: SECURITY — DoS by loop ══
+          # ══ RULE 12: SECURITY — DoS by loop [Checkmarx Server_DoS_by_Loop] ══
+          # Checkmarx traces: req.query/params → function arg → array.length → for-loop bound
+          # Fix: ANY for-loop bounded by .length MUST use Math.min(x, MAX_CONSTANT)
           for f in $PATCH_TS; do
+            # Direct: loop driven by req input
             if grep -nP "for\s*\(.*req\.(body|query)|\.forEach.*req\." "$f" > /dev/null 2>&1; then
               if ! grep -q "MAX_RESULTS\|MAX_ENTRIES\|\.slice(0," "$f"; then
                 viol "security-dos-loop" "$f: loop driven by user input without MAX_RESULTS limit" "error"
               fi
             fi
-            # Also catch indirect DoS: for-loops bounded by .length without Math.min cap
+            # Indirect: ANY for-loop bounded by .length (Checkmarx can trace user input to .length)
             if grep -nP 'for\s*\([^;]*<\s*\w+\.length' "$f" > /dev/null 2>&1; then
-              if ! grep -q "Math\.min\|MAX_RESULTS\|MAX_ENTRIES\|MAX_SCORE" "$f"; then
+              if ! grep -q "Math\.min\|MAX_RESULTS\|MAX_ENTRIES\|MAX_SCORE\|MAX_STATUS\|MAX_SYNC\|MAX_LOG" "$f"; then
                 viol "security-dos-loop" "$f: for-loop bounded by .length without explicit Math.min cap (Checkmarx Server_DoS_by_Loop)" "error"
+              fi
+            fi
+            # Array iteration without bounds (forEach/map on unbounded arrays)
+            if grep -nP "\.\(forEach\|map\|reduce\)\(" "$f" > /dev/null 2>&1; then
+              if grep -q "req\.\(body\|query\|params\)" "$f"; then
+                if ! grep -q "\.slice(0,\|MAX_RESULTS\|MAX_ENTRIES\|boundedEntries" "$f"; then
+                  warn "security-dos-iteration" "$f: iterates array from request without .slice() bound"
+                fi
               fi
             fi
           done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Zero local dependencies. 100% GitHub-native.
 | `release-freeze.schema.json` | Release freeze state |
 | `release-state.schema.json` | Release state (agent/controller) |
 | `workspace.schema.json` | Workspace configuration |
+| `checkmarx-patterns.json` | Checkmarx SAST finding patterns → compliance gate rules + fix patterns |
 
 ## Integrations (all zero-cost, open-source)
 

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -1375,7 +1375,12 @@
       "yaml_table_pipe_in_run_block": "NUNCA usar | no inicio de linha em blocos run: | — YAML interpreta como block scalar indicator. Tabelas markdown com | devem ser escritas via echo para arquivo temporario.",
       "checkmarx_dos_loop_fix_pattern": "Para Checkmarx Server_DoS_by_Loop: adicionar const MAX_X = N; e Math.min(array.length, MAX_X) no bound do for-loop. Mesmo que o loop tenha tamanho fixo, Checkmarx nao consegue verificar estaticamente.",
       "xray_known_npm_vulns_374": "XRay scan do build 3.7.4: Critical ejs@3.1.10 CVE-2023-29827, High braces@3.0.2 CVE-2024-4068. RPM High: nodejs CVE-2025-23166/3277/6965, libxml2 CVE-2025-49795/49796/49794, libarchive CVE-2025-5914, zlib CVE-2025-4638. RPM sao do base image (nao fixavel por nos).",
-      "ci_gate_stuck_corporate_runner_offline": "CI Gate pode ficar stuck por horas quando corporate runner esta offline (fds/feriado). O ci-monitor-loop e deploy-pipeline-monitor compensam — verificam e reportam sucesso/falha independentemente. Se CI Gate stuck > 30min, verificar release-state no autopilot-state (pode ja ter sido promovido)."
+      "ci_gate_stuck_corporate_runner_offline": "CI Gate pode ficar stuck por horas quando corporate runner esta offline (fds/feriado). O ci-monitor-loop e deploy-pipeline-monitor compensam — verificam e reportam sucesso/falha independentemente. Se CI Gate stuck > 30min, verificar release-state no autopilot-state (pode ja ter sido promovido).",
+      "checkmarx_patterns_mapped": "CRITICO: Todos os patterns Checkmarx (Reflected_XSS, SSRF, Server_DoS_by_Loop, Information_Exposure) estao mapeados em schemas/checkmarx-patterns.json com: dataFlow, affectedFiles, fixPattern, preventionCheck. Compliance gate Rules 10-12 foram reforçadas para detectar esses patterns automaticamente. ANTES de criar qualquer patch de controller: consultar schemas/checkmarx-patterns.json para verificar se o codigo segue os fix patterns.",
+      "checkmarx_scan_dates_vs_deploy": "CRITICO: Checkmarx scan dates sao do build ANTERIOR. Scan de 17/03/2026 e PRE-3.7.3 (deployed 30/03). Scan de 31/03/2026 (Server_DoS_by_Loop New) e PRE-3.7.4 (deployed 31/03). Sempre verificar se o finding ja foi corrigido no deploy mais recente antes de criar novo patch.",
+      "checkmarx_indirect_data_flow": "Checkmarx faz TAINT ANALYSIS em profundidade. Mesmo que validacao exista, se o taint flow cruza funcoes sem verificacao explicita no ponto de entrada, ele reporta. Ex: req.params.execId → getExecutionSnapshot(execId) → pickPreferredSnapshot → for-loop. O fix Math.min no for-loop resolve porque Checkmarx ve o bound explicito.",
+      "security_scanner_completed": "security-vuln-scanner.yml completou primeiro scan com sucesso em 27s. Encontrou 64 CVEs do build 3.7.4. Report salvo em autopilot-state: security-scan-controller-3.7.4.json. Script: scripts/security/scan-corporate-vulns.sh. Triggers: workflow_run (apply-source-change + ci-monitor-loop), push, dispatch.",
+      "vuln_scanner_timeout_fix": "CRITICO: scan-corporate-vulns.sh original travava porque: (1) gh api .../logs download sem timeout, (2) jq dentro de while-loop (O(n^2)), (3) declare -A nao portavel. FIX: timeout 60s no download, batch npm/rpm parsing com sed+jq -s, limit 20 CVEs com timeout 10s cada. PR #424."
     },
     "gha_yaml_markdown_bold": "CRITICO: NUNCA usar **texto**: (markdown bold seguido de dois-pontos) dentro de blocos run: | em workflows GitHub Actions. O parser YAML do GHA interpreta ** como alias syntax e : como mapping key, quebrando o YAML ANTES de avaliar o shell. Fix: remover ** ou usar variaveis. Corrigido em 6 workflows: emergency-watchdog, auto-dispatch-task, continuous-improvement, dashboard-auto-improve, deploy-auto-learn, workflow-sentinel.",
     "gha_no_heredoc_in_run": "CRITICO: NUNCA usar heredoc (cat <<EOF / cat <<'EOF') dentro de blocos run: | em GitHub Actions. O GHA parser le TODO o bloco run: como YAML literal ANTES de avaliar como shell. Qualquer linha com dois-pontos (ex: 'Workspace: $WS') e interpretada como YAML key-value e quebra. FIX: usar variavel simples com string inline. Ex: BODY='texto sem colon' e depois gh issue comment --body \"$BODY\". NUNCA heredoc.",
@@ -1403,7 +1408,12 @@
         "SEMPRE verificar imports/paths no test match a estrutura do repo corporativo",
         "SEMPRE verificar se JWTService.generateCallbackToken existe antes de referenciar",
         "SEMPRE incluir swagger atualizado com novos endpoints",
-        "SEMPRE registrar novas rotas no roteador (apis.ts / agentsRouter.ts)"
+        "SEMPRE registrar novas rotas no roteador (apis.ts / agentsRouter.ts)",
+        "SEMPRE verificar Checkmarx patterns: XSS (sanitizeForOutput), SSRF (validateTrustedUrl), DoS (Math.min). Ref: schemas/checkmarx-patterns.json",
+        "SEMPRE: arquivo com fetch/postJson/callAgent DEVE ter validateTrustedUrl",
+        "SEMPRE: arquivo com req.body/query/params + res.json DEVE ter sanitizeForOutput",
+        "SEMPRE: for-loop com .length DEVE ter Math.min(x, MAX_CONSTANT)",
+        "SEMPRE: arrays em response DEVEM usar .slice(0, MAX_ENTRIES)"
       ],
       "autonomous_operation": [
         "NUNCA perguntar ao usuario se deve continuar — SEMPRE continuar autonomamente",

--- a/schemas/checkmarx-patterns.json
+++ b/schemas/checkmarx-patterns.json
@@ -1,0 +1,112 @@
+{
+  "schemaVersion": 1,
+  "description": "Checkmarx SAST finding patterns mapped to compliance gate rules and fix patterns. Used by compliance-gate.yml and security-vuln-scanner.yml to prevent recurring vulnerabilities.",
+  "lastUpdated": "2026-03-31T23:00:00Z",
+  "patterns": [
+    {
+      "id": "Reflected_XSS",
+      "checkmarxQueryName": "Reflected_XSS_All_Clients",
+      "severity": "high",
+      "complianceRule": "security-xss",
+      "description": "User input from req.body/req.query/req.params flows to res.json() without sanitization",
+      "dataFlow": "req.body → variable → res.json(variable)",
+      "affectedFiles": [
+        "src/controllers/oas-sre-controller.controller.ts",
+        "src/controllers/oas-execute.controller.ts",
+        "src/controllers/execute.controller.ts"
+      ],
+      "fixPattern": "Import and apply sanitizeForOutput() to any user-derived data before including in response. For error objects, use sanitizeForOutput(msg) instead of raw error.message.",
+      "codeExample": {
+        "vulnerable": "res.json({ error: error.message })",
+        "fixed": "res.json({ error: sanitizeForOutput(error.message) })"
+      },
+      "preventionCheck": "Every .ts file that reads req.body/query/params AND calls res.json/send MUST import sanitizeForOutput from util/security"
+    },
+    {
+      "id": "SSRF",
+      "checkmarxQueryName": "Server_Side_Request_Forgery",
+      "severity": "high",
+      "complianceRule": "security-ssrf",
+      "description": "User input from req.body influences the target URL of a server-side HTTP request",
+      "dataFlow": "req.body → body.cluster/namespace → resolveTrustedRegisteredAgentExecuteUrl() → fetch(url)",
+      "affectedFiles": [
+        "src/controllers/oas-sre-controller.controller.ts",
+        "src/controllers/oas-execute.controller.ts",
+        "src/controllers/execute.controller.ts"
+      ],
+      "fixPattern": "Always validate URLs with validateTrustedUrl() before fetch(). Use resolveTrustedRegisteredAgentExecuteUrl() to build URLs from a trusted registry (never concatenate user input into URLs). Parse input with parseSafeIdentifier() to strip injection chars.",
+      "codeExample": {
+        "vulnerable": "const url = body.agentUrl; const resp = await fetch(url, ...)",
+        "fixed": "const url = resolveTrustedRegisteredAgentExecuteUrl({ cluster }); if (!validateTrustedUrl(url)) return; const resp = await fetch(url, ...)"
+      },
+      "preventionCheck": "Every file using fetch()/postJson()/callAgent() MUST have validateTrustedUrl(). Every file resolving URLs from user input MUST use resolveTrustedRegisteredAgentExecuteUrl()."
+    },
+    {
+      "id": "Server_DoS_by_Loop",
+      "checkmarxQueryName": "Server_DoS_by_Loop",
+      "severity": "high",
+      "complianceRule": "security-dos-loop",
+      "description": "A loop's iteration count is influenced by user input, potentially causing denial of service",
+      "dataFlow": "req.query/req.params → execId → getExecutionSnapshot(execId) → snapshot.entries → loop/iteration",
+      "affectedFiles": [
+        "src/controllers/agents-execute-logs.controller.ts",
+        "src/controllers/cronjob-result.controller.ts"
+      ],
+      "fixPattern": "Add explicit Math.min(array.length, MAX_CONSTANT) to ALL for-loop bounds. For array responses, use .slice(0, MAX_ENTRIES) before iteration. Define MAX_* constants at module scope.",
+      "codeExample": {
+        "vulnerable": "for (let i = 0; i < scores.length; i++) { ... }",
+        "fixed": "const MAX_SCORE_FIELDS = 4; for (let i = 0; i < Math.min(scores.length, MAX_SCORE_FIELDS); i++) { ... }"
+      },
+      "preventionCheck": "ANY for-loop with .length in the bound MUST use Math.min(x, MAX_CONSTANT). Arrays returned in responses MUST use .slice(0, MAX_ENTRIES). Compliance gate Rule 12 enforces this.",
+      "indirectFlows": [
+        "req.query.uuid → getAgentExecutionLogs → getExecutionSnapshot → pickPreferredSnapshot → for-loop on currentScore.length",
+        "req.params.execId → getCronjobStatus → getExecutionSnapshot → snapshot.entries iteration",
+        "req.body → callAgent/postJson → response entries → iteration"
+      ]
+    },
+    {
+      "id": "Information_Exposure",
+      "checkmarxQueryName": "Information_Exposure_Through_an_Error_Message",
+      "severity": "medium",
+      "complianceRule": "security-error-leak",
+      "description": "Internal error details (stack traces, error messages) exposed in HTTP responses",
+      "fixPattern": "Always wrap error.message with sanitizeForOutput(msg) which strips dangerous chars and limits to 256 chars",
+      "preventionCheck": "Compliance gate Rule 10 warns when error responses contain unsanitized message/detail fields"
+    }
+  ],
+  "securityImports": {
+    "description": "Required security utility imports for controller files",
+    "sanitizeForOutput": {
+      "from": "../util/security",
+      "usage": "Sanitize any user-derived data before including in HTTP response",
+      "requiredWhen": "File reads req.body/query/params AND writes res.json/send"
+    },
+    "validateTrustedUrl": {
+      "from": "../util/trusted-agent",
+      "usage": "Validate URL against trusted domain pattern before fetch()",
+      "requiredWhen": "File uses fetch()/postJson()/callAgent()"
+    },
+    "parseSafeIdentifier": {
+      "from": "../util/security",
+      "usage": "Parse and sanitize identifier strings (cluster, namespace, etc.)",
+      "requiredWhen": "File uses user input to resolve URLs or build identifiers"
+    },
+    "safeString": {
+      "from": "../util/security",
+      "usage": "Trim and limit string input from request",
+      "requiredWhen": "File reads string values from req.query/params"
+    },
+    "resolveTrustedRegisteredAgentExecuteUrl": {
+      "from": "../util/trusted-agent",
+      "usage": "Resolve agent URL from trusted registry (never build URLs from user input)",
+      "requiredWhen": "File needs to call an agent endpoint"
+    }
+  },
+  "complianceGateRules": {
+    "rule10_xss": "File with req input + res output MUST have sanitizeForOutput",
+    "rule11_ssrf": "File with fetch/postJson/callAgent MUST have validateTrustedUrl. File resolving URLs MUST validate.",
+    "rule12_dos": "for-loop with .length MUST use Math.min. Arrays from DB/external MUST .slice(0, MAX). forEach/map on req-derived arrays MUST have .slice bound.",
+    "rule13_secrets": "No hardcoded secrets in patches",
+    "rule14_order": "No use-before-define"
+  }
+}


### PR DESCRIPTION
## Summary
- Enhanced compliance gate Rules 10-12 to match exact Checkmarx SAST data flows (Reflected_XSS, SSRF, Server_DoS_by_Loop)
- New `schemas/checkmarx-patterns.json` mapping all Checkmarx finding types to compliance rules, fix patterns, and affected files
- Updated session memory with before_any_deploy prevention rules

## Checkmarx Prevention (automatic)
| Finding | Compliance Rule | Auto-Detection |
|---------|----------------|----------------|
| Reflected_XSS | Rule 10 | File with req input + res output MUST have sanitizeForOutput |
| SSRF | Rule 11 | File with fetch/postJson/callAgent MUST have validateTrustedUrl |
| Server_DoS_by_Loop | Rule 12 | ANY for-loop with .length MUST use Math.min(x, MAX_CONSTANT) |
| Information_Exposure | Rule 10 warn | Error response with unsanitized message/detail |

## Test plan
- [ ] Verify compliance gate passes on existing patches (no false positives on already-fixed code)
- [ ] Verify new rules catch intentionally vulnerable code patterns

https://claude.ai/code/session_019QnwcZ8wnNUty7fk6PRwHd