### PR TITLE
fix(security): address Checkmarx controller vulnerabilities

### DIFF
--- a/patches/agents-execute-logs.controller.ts
+++ b/patches/agents-execute-logs.controller.ts
@@ -20,6 +20,7 @@ import { readSyncPollIntervalMs } from "../util/sync-poll-interval";
 export type ExecStatus = "RUNNING" | "PENDING" | "DONE" | "ERROR";
 
 const MAX_ENTRIES_PER_EXEC = 500;
+const SAFE_EXEC_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 
 export type LogEntry = {
   ts: string;
@@ -620,13 +621,13 @@ export async function pushAgentExecutionLogs(
   const fromBody = typeof body.from === "string" ? body.from : undefined;
   const from = fromBody || queryFrom || headerXFrom || headerFrom || "agent";
 
-  if (!execId || entries.length < 1) {
+  if (!execId || !SAFE_EXEC_ID_PATTERN.test(execId) || entries.length < 1) {
     res.status(400).json({
       ok: false,
       title: "Bad Request",
       status: 400,
       detail:
-        "Provide execId (string) and entries (array) with at least one item.",
+        "Provide execId (string matching safe pattern) and entries (array) with at least one item.",
     });
     return;
   }
@@ -718,12 +719,12 @@ export async function getAgentExecutionLogs(
     return;
   }
 
-  if (!execId) {
+  if (!execId || !SAFE_EXEC_ID_PATTERN.test(execId)) {
     res.status(400).json({
       ok: false,
       title: "Bad Request",
       status: 400,
-      detail: "Provide uuid (recommended) or execId (query string).",
+      detail: "Provide uuid (recommended) or execId (query string) matching safe pattern.",
     });
     return;
   }

--- a/patches/cronjob-result.controller.ts
+++ b/patches/cronjob-result.controller.ts
@@ -72,6 +72,8 @@ const VALID_COMPLIANCE_STATUSES: CronjobComplianceStatus[] = [
   "error",
 ];
 
+const SAFE_EXEC_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+
 // ── Validation ─────────────────────────────────────────────────
 
 function validateCronjobResult(body: unknown): ValidationResult {
@@ -357,10 +359,10 @@ export async function getCronjobStatus(
 ): Promise<void> {
   const execId = safeString(req.params.execId);
 
-  if (!execId) {
+  if (!execId || !SAFE_EXEC_ID_PATTERN.test(execId)) {
     res.status(400).json({
       ok: false,
-      error: "Parameter 'execId' is required.",
+      error: "Parameter 'execId' is required and must match safe pattern.",
     });
     return;
   }

--- a/patches/oas-execute.controller.ts
+++ b/patches/oas-execute.controller.ts
@@ -27,8 +27,27 @@ const DEFAULT_AGENT_CALL_TIMEOUT_MS = 30_000;
 const TRUSTED_AGENT_URL_PATTERN =
   /^https?:\/\/(?!.*@)[a-zA-Z0-9._-]+(?::[0-9]{1,5})?(?:\/[^\s<>"']*)?$/;
 
+const BLOCKED_SSRF_HOSTS = [
+  "169.254.169.254",
+  "metadata.google.internal",
+  "metadata.goog",
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+  "0.0.0.0",
+];
+
 function validateTrustedUrl(url: string): boolean {
-  return Boolean(url) && TRUSTED_AGENT_URL_PATTERN.test(url);
+  if (!url || !TRUSTED_AGENT_URL_PATTERN.test(url)) return false;
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    if (BLOCKED_SSRF_HOSTS.includes(host)) return false;
+    if (host.startsWith("169.254.")) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function sanitizeForOutput(value: unknown): string {
@@ -287,10 +306,6 @@ export async function postOasAutomation(
     const timeoutMs = readAgentCallTimeoutMs();
     const abort = new AbortController();
     const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
-    if (!validateTrustedUrl(trustedAgentUrl)) {
-      res.status(500).json({ ok: false, error: "Resolved agent URL is not trusted" });
-      return;
-    }
 
     let resp: Awaited<ReturnType<typeof fetch>>;
     try {

--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -63,8 +63,27 @@ const DEFAULT_AGENT_CALL_TIMEOUT_MS = 35_000;
 const TRUSTED_AGENT_URL_PATTERN =
   /^https?:\/\/(?!.*@)[a-zA-Z0-9._-]+(?::[0-9]{1,5})?(?:\/[^\s<>"']*)?$/;
 
+const BLOCKED_SSRF_HOSTS = [
+  "169.254.169.254",
+  "metadata.google.internal",
+  "metadata.goog",
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+  "0.0.0.0",
+];
+
 function validateTrustedUrl(url: string): boolean {
-  return Boolean(url) && TRUSTED_AGENT_URL_PATTERN.test(url);
+  if (!url || !TRUSTED_AGENT_URL_PATTERN.test(url)) return false;
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    if (BLOCKED_SSRF_HOSTS.includes(host)) return false;
+    if (host.startsWith("169.254.")) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function asRecord(value: unknown): JsonRecord | null {
@@ -474,12 +493,9 @@ export async function postOasSreController(
         ok: false,
         error: "Failed to call Agent",
         execId,
-        cluster: failedDispatch.cluster,
+        cluster: sanitizeForOutput(failedDispatch.cluster),
         agentStatus: failedDispatch.status,
-        dispatches: dispatches.map((item) => ({
-          cluster: item.cluster,
-          agentStatus: item.status,
-        })),
+        dispatches: summarizeDispatches(dispatches),
       });
       return;
     }


### PR DESCRIPTION
## Summary
- **XSS (High)**: Sanitize `cluster` field in 502 error response with `sanitizeForOutput()` and use `summarizeDispatches()` instead of raw inline map in `oas-sre-controller.controller.ts`
- **SSRF**: Add cloud metadata endpoint blocking (169.254.x.x, localhost, 127.0.0.1, [::1], 0.0.0.0) to `validateTrustedUrl()` in both `oas-sre-controller` and `oas-execute` controllers
- **DoS Loop**: Add `SAFE_EXEC_ID_PATTERN` validation for user-supplied `execId` in `agents-execute-logs.controller.ts` and `cronjob-result.controller.ts`
- Remove duplicate `validateTrustedUrl` check in `oas-execute.controller.ts`

## Checkmarx Findings Addressed
| ID | Type | Severity | File |
|---|---|---|---|
| -1420982817 | Reflected_XSS | High | oas-sre-controller.controller.ts |
| -1733319352 | SSRF | Medium | oas-sre-controller.controller.ts |
| -700191064 | SSRF | Medium | oas-execute.controller.ts |
| -2083612934 | DoS Loop | Medium | agents-execute-logs.controller.ts |
| -406362239 | DoS Loop | Medium | agents-execute-logs.controller.ts |

## Test plan
- [ ] Existing tests pass (execId values like `exec-123` match safe pattern)
- [ ] 502 error response now sanitizes cluster output
- [ ] validateTrustedUrl blocks metadata service IPs
- [ ] Invalid execId patterns rejected with 400

https://claude.ai/code/session_01Vs9WQXXbECXV81qDpGdfdn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
