### PR TITLE
[codex] docs: codify operating doctrine and GitHub MCP path

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -37,6 +37,61 @@ Zero dependencias locais. 100% GitHub-native. Operavel por Claude, ChatGPT e Cod
 
 ---
 
+## Doutrina operacional canonica
+
+Diretriz obrigatoria para operacao, evolucao e automacao do projeto:
+
+**CLOUD FIRST, GITHUB FIRST, LOCAL LAST**
+
+### Interpretacao pratica
+
+1. **Cloud first**
+   - Priorizar execucao, storage, estado, logs, schedules, artefatos, filas, runners e automacoes em cloud.
+   - Evitar depender desta maquina para memoria operacional, estado persistente, execucao continua, backups e segredos.
+2. **GitHub first**
+   - GitHub e a fonte principal de verdade do projeto.
+   - Tudo que for estruturalmente relevante deve ser refletido em codigo, docs, workflows, issues, PRs, handoffs, runbooks, checklists, changelogs ou trilhas de auditoria no proprio GitHub.
+3. **Local last**
+   - A maquina local e apenas terminal de controle, desenvolvimento eventual ou ponto temporario de operacao.
+   - Conhecimento critico, automacao critica e estado critico nao podem ficar presos ao ambiente local.
+
+### Regras obrigatorias desta doutrina
+
+- Toda mudanca relevante deve deixar rastro versionado, auditavel e reutilizavel no GitHub.
+- Se uma dependencia local for inevitavel, tratar como excecao: documentar, justificar, reduzir impacto, criar fallback e planejar migracao para cloud.
+- Toda automacao importante deve nascer com observabilidade minima: logs, status, sinais de erro, diagnostico e evidencia de sucesso.
+- Toda entrega deve considerar rollback, retry, timeout, validacao pos-acao e trilha de troubleshooting.
+- Todo aprendizado util deve virar ativo persistente do projeto: runbook, contrato, doc, workflow, template, issue comentada, handoff ou memoria operacional explicita.
+- Antes de criar algo novo, entender e fortalecer o fluxo existente; evitar duplicacao e preservar compatibilidade.
+
+### Ordem de analise e execucao
+
+1. Entender o estado atual
+2. Localizar workflows, automacoes, docs e padroes existentes
+3. Identificar dependencias locais e pontos de fragilidade
+4. Identificar o que pode ser movido para cloud/GitHub
+5. Avaliar riscos, seguranca, rollback e observabilidade
+6. Aplicar a evolucao minima segura
+7. Registrar rastreabilidade e memoria persistente
+8. Sugerir o proximo nivel de automacao
+
+### Gate minimo de qualidade
+
+Uma entrega so e considerada boa se:
+
+- reduz dependencia local
+- aumenta padronizacao
+- melhora rastreabilidade
+- melhora observabilidade
+- melhora manutencao e troubleshooting
+- aumenta reutilizacao em sessoes futuras
+- fica registrada no GitHub
+- nao quebra o fluxo atual
+- possui caminho de reversao
+- deixa o projeto mais autonomo do que antes
+
+---
+
 ## Estrutura de Arquivos
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Este repositório centraliza:
 4. `ops/docs/agent-operational-parity.md` — checklist prático para operar com o mesmo fluxo do Claude
    - inclui o loop de estabilização de PR (checks/builds/correções até verde) e template de reporte final
 
+## GitHub MCP no Codex local
+
+O operador local do Codex pode expor o servidor MCP oficial do GitHub para ampliar a autonomia em tarefas repo-native do `autopilot`.
+
+- Registro global do Codex: `~/.codex/config.toml` em `[mcp_servers.github]`
+- Launcher local: `~/.local/bin/codex-github-mcp`
+- Autenticacao: reutiliza o token do `gh auth` local, evitando PAT hardcoded no repo
+- Uso ideal: triagem de repositorio, leitura de PR/issues, metadados de workflows e outras operacoes GitHub nativas
+- Limite real: permissao continua vindo da conta/token autenticado; MCP nao concede write onde a conta nao tem acesso
+
+Validacao feita em 2026-04-01:
+
+- `codex exec ... --json` mostrou `mcp_tool_call` no servidor `github`
+- ferramentas observadas no runtime: `search_repositories`, `list_pull_requests`, `search_pull_requests`
+- resposta curta validada: `SOURCE=github:lucassfreiree/autopilot default=main lang=TypeScript updated=2026-04-01T17:54:00Z`
+
 ## Segurança e isolamento
 
 - Nunca misturar contextos entre workspaces.

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -10,6 +10,7 @@
     "bulk-changes",
     "test-execution",
     "ci-monitoring",
+    "github-mcp-repo-ops",
     "handoff-consumption",
     "pre-deploy-validation",
     "security-patching",
@@ -17,12 +18,35 @@
   ],
   "tools": {
     "primary": "codex-web",
-    "github": "gh-cli",
+    "github": "github-mcp + gh-cli",
+    "mcp": "GitHub MCP server `github` via /home/jfreire/.local/bin/codex-github-mcp",
     "editor": "github.dev",
     "api": "GitHub REST API via gh api or curl with GITHUB_TOKEN"
   },
   "githubConnection": {
     "description": "Como Codex se conecta ao GitHub para operacoes do autopilot",
+    "mcp": {
+      "description": "Canal MCP local para operacoes GitHub dentro do runtime do Codex",
+      "serverName": "github",
+      "launcher": "/home/jfreire/.local/bin/codex-github-mcp",
+      "authSource": "Token herdado do gh auth local (~/.config/gh/hosts.yml) ou GITHUB_PERSONAL_ACCESS_TOKEN",
+      "validatedAt": "2026-04-01T18:00:24Z",
+      "validatedBy": [
+        "codex exec com mcp_tool_call search_repositories em lucassfreiree/autopilot",
+        "codex exec com mcp_tool_call list_pull_requests/search_pull_requests em lucassfreiree/autopilot"
+      ],
+      "bestFor": [
+        "triagem de repositorio",
+        "leitura de PR/issues",
+        "metadados de workflows e repos",
+        "operacoes GitHub nativas sem depender de checkout local"
+      ],
+      "limits": [
+        "Permissoes continuam vindo da conta/token autenticado",
+        "Write ops so funcionam onde a conta tiver permissao real",
+        "gh CLI continua como fallback e para fluxos nao cobertos pelo MCP"
+      ]
+    },
     "authentication": {
       "autopilotRepo": "GITHUB_TOKEN (disponivel automaticamente no Codex quando rodando no repo lucassfreiree/autopilot)",
       "corporateRepo": "BBVINET_TOKEN (secret do repo — so acessivel dentro de workflows GitHub Actions, NAO diretamente pelo Codex)",
@@ -144,7 +168,7 @@
   "collaborationWithClaude": {
     "description": "Como Codex e Claude trabalham juntos",
     "sessionMemory": "contracts/claude-session-memory.json — ler SEMPRE no inicio da sessao. Contem estado atual, versoes, licoes aprendidas.",
-    "handoffProtocol": "Se precisa de algo que nao consegue fazer (ex: acesso MCP GitHub, WebFetch): criar handoff para Claude via enqueue-agent-handoff.yml",
+    "handoffProtocol": "Se precisa de algo que nao consegue fazer localmente (ex: credencial ausente, sistema externo sem token, bloqueio de permissao): criar handoff para Claude via enqueue-agent-handoff.yml",
     "sharedState": "autopilot-state branch e a fonte de verdade. Ambos leem/escrevem la.",
     "lockProtocol": "Se Claude tem session lock: NAO forcar. Criar handoff e esperar.",
     "prReview": "Codex pode revisar PRs do Claude e vice-versa via gh pr review"

--- a/contracts/codex-session-memory.json
+++ b/contracts/codex-session-memory.json
@@ -1,1 +1,84 @@
-{"schemaVersion":1,"lastUpdated":"2026-03-29T12:50:00Z","sessionCount":5,"currentState":{"controllerVersion":"3.6.6","agentVersion":"2.2.9","lastTriggerRun":69,"lastSuccessfulRun":66,"workspace":"ws-default","pipelineStatus":"success"},"sessionsLog":[],"decisions":[],"lessonsLearned":[],"errorPatterns":{}}
+{
+  "schemaVersion": 1,
+  "lastUpdated": "2026-04-01T18:00:24Z",
+  "sessionCount": 7,
+  "currentState": {
+    "controllerVersion": "3.6.6",
+    "agentVersion": "2.2.9",
+    "lastTriggerRun": 69,
+    "lastSuccessfulRun": 66,
+    "workspace": "ws-default",
+    "pipelineStatus": "success",
+    "githubMcp": "configured and validated locally via server github on 2026-04-01",
+    "operatingDoctrine": "cloud-first, github-first, local-last persisted in HANDOFF.md and shared-agent-contract.json"
+  },
+  "sessionsLog": [
+    {
+      "date": "2026-04-01",
+      "summary": "Diretriz operacional do proprietario institucionalizada no Autopilot: Cloud First, GitHub First, Local Last. HANDOFF.md passou a carregar a doutrina canonica, shared-agent-contract.json passou a exigir source-of-truth em GitHub, observabilidade, memoria persistente e gate minimo de qualidade.",
+      "actions": [
+        "persisted-operating-doctrine-in-handoff",
+        "persisted-operating-doctrine-in-shared-contract",
+        "updated-codex-memory-with-doctrine"
+      ],
+      "triggeredBy": "Lucas — definiu a diretriz oficial de operacao do projeto",
+      "lessonsLearned": [
+        "Diretrizes estruturais do projeto nao podem ficar apenas na conversa; devem virar contrato e handoff canonico",
+        "HANDOFF.md e o documento principal para continuidade operacional entre sessoes e agentes",
+        "A maquina local deve ser tratada como terminal temporario, nunca como fonte primaria de verdade"
+      ]
+    },
+    {
+      "date": "2026-04-01",
+      "summary": "GitHub MCP oficial configurado no Codex via launcher local reutilizando gh auth. Validado em runtime com mcp_tool_call no servidor github para search_repositories, list_pull_requests e search_pull_requests no repo lucassfreiree/autopilot.",
+      "actions": [
+        "configured-github-mcp-launcher",
+        "validated-codex-exec-mcp-repo-metadata",
+        "validated-codex-exec-mcp-open-prs",
+        "mapped-github-mcp-in-autopilot-docs-and-contract"
+      ],
+      "triggeredBy": "Lucas — pediu para configurar o MCP do GitHub e mapear a capacidade no autopilot",
+      "lessonsLearned": [
+        "Codex local consegue usar o servidor MCP oficial do GitHub quando ele esta registrado em [mcp_servers.github] e apontando para um launcher stdio",
+        "O launcher pode reutilizar o token do gh auth local, evitando PAT hardcoded no config.toml",
+        "Validacao real deve observar eventos mcp_tool_call no codex exec; smoke test de stdio isolado nao prova integracao completa com o runtime",
+        "Escopo e permissao continuam limitando write ops; MCP aumenta cobertura operacional, nao privilegios"
+      ]
+    }
+  ],
+  "decisions": [
+    {
+      "date": "2026-04-01",
+      "decision": "Operar o projeto segundo a doutrina Cloud First, GitHub First, Local Last",
+      "context": "Diretriz explicita do proprietario. Toda entrega deve reduzir dependencia local e aumentar automacao, auditabilidade, memoria persistente e continuidade operacional no GitHub/cloud."
+    },
+    {
+      "date": "2026-04-01",
+      "decision": "GitHub MCP passa a ser caminho de primeira classe para triagem repo/PR/issues no autopilot quando disponivel localmente",
+      "context": "Teste real do codex exec mostrou mcp_tool_call no servidor github com search_repositories, list_pull_requests e search_pull_requests"
+    }
+  ],
+  "lessonsLearned": [
+    {
+      "lesson": "GitHub MCP oficial do Codex foi validado em runtime no repo lucassfreiree/autopilot",
+      "source": "session 2026-04-01",
+      "fix": "Usar servidor github para leituras de repo/PR/issues e manter gh CLI como fallback ou para fluxos fora do MCP"
+    },
+    {
+      "lesson": "O token pode ser herdado do gh auth local por um launcher stdio sem gravar segredo no config.toml",
+      "source": "session 2026-04-01",
+      "fix": "Manter ~/.local/bin/codex-github-mcp lendo ~/.config/gh/hosts.yml ou GITHUB_PERSONAL_ACCESS_TOKEN"
+    },
+    {
+      "lesson": "Permissao do repo continua sendo o limitador real de autonomia",
+      "source": "session 2026-04-01",
+      "fix": "Para write real no repo alvo, garantir que a conta/token autenticado tenha permissao de escrita"
+    },
+    {
+      "lesson": "Toda regra operacional relevante deve ser persistida no GitHub do projeto, preferencialmente em HANDOFF.md ou contratos compartilhados",
+      "source": "session 2026-04-01",
+      "fix": "Registrar novas doutrinas, runbooks e padroes como ativos canonicos do Autopilot em vez de depender de memoria conversacional"
+    }
+  ],
+  "errorPatterns": {}
+}

--- a/contracts/shared-agent-contract.json
+++ b/contracts/shared-agent-contract.json
@@ -11,6 +11,55 @@
     "repo": "lucassfreiree/autopilot",
     "branch": "autopilot-backups"
   },
+  "operatingDoctrine": {
+    "priority": "cloud-first, github-first, local-last",
+    "objective": "Operate Autopilot with maximum autonomy, reliability, traceability, security, observability, and continuity while minimizing local-machine dependency.",
+    "sourceOfTruth": {
+      "project": "GitHub repository lucassfreiree/autopilot",
+      "runtimeState": "autopilot-state branch",
+      "backups": "autopilot-backups branch",
+      "handoffCanonicalDoc": "HANDOFF.md"
+    },
+    "localMachineRole": "Control terminal only. Never the canonical source of memory, state, scheduling, logs, backups, or critical automation.",
+    "mandatoryPrinciples": [
+      "Prefer cloud execution, scheduling, storage, logs, automation, and integrations whenever viable",
+      "Persist structural knowledge in GitHub, not in ephemeral local context",
+      "Treat local-only dependency as an exception that must be documented, justified, and reduced over time",
+      "Every important automation must be observable, auditable, and debuggable",
+      "Every meaningful change must consider rollback, retry, timeout, validation, and evidence of success",
+      "Every useful lesson must be institutionalized as documentation, workflow, template, contract, runbook, or explicit memory"
+    ],
+    "analysisOrder": [
+      "Understand current state",
+      "Locate existing workflows, docs, automation, and conventions",
+      "Identify local dependencies and fragility points",
+      "Identify what can move to cloud/GitHub",
+      "Assess risks, security, rollback, and observability",
+      "Apply the minimum safe evolution",
+      "Record traceability and persistent memory",
+      "Suggest the next automation layer"
+    ],
+    "operationalLayers": [
+      "execution",
+      "observability",
+      "validation",
+      "governance",
+      "memory-and-learning",
+      "self-improvement"
+    ],
+    "qualityGate": [
+      "Reduce local dependency",
+      "Increase standardization",
+      "Improve traceability",
+      "Improve observability",
+      "Improve maintainability and troubleshooting",
+      "Improve reuse in future sessions",
+      "Persist the result in GitHub",
+      "Preserve compatibility with the current flow",
+      "Provide a reversal or rollback path",
+      "Leave the project more autonomous than before"
+    ]
+  },
   "schemas": {
     "workspace": "schemas/workspace.schema.json",
     "releaseState": "schemas/release-state.schema.json",
@@ -105,6 +154,7 @@
     "separationGuide": "ops/docs/workspace-separation.md"
   },
   "rules": [
+    "Cloud First, GitHub First, Local Last",
     "NEVER assume a default workspace — always identify from conversation context or ask the user",
     "Never store corporate secrets in the autopilot repo",
     "Never store corporate code in the autopilot repo",
@@ -115,6 +165,8 @@
     "Never use regex to edit YAML - use structured tooling",
     "Never hardcode branch names - read from workspace.json",
     "State is the source of truth, not agent memory",
+    "GitHub is the primary source of truth for project structure, workflows, docs, handoffs, and reusable operational knowledge",
+    "Never leave critical knowledge only on the local machine or only in session context",
     "Always validate jq output with fallbacks (2>/dev/null || echo fallback)",
     "Use base64 encoding when passing content between workflow jobs",
     "Never silently swallow errors - always log before continuing",
@@ -127,6 +179,12 @@
     "auditWrite": "Retry once if audit write fails, then log error"
   },
   "governance": {
+    "changeRequirements": [
+      "Document relevant operational changes in GitHub",
+      "Keep auditability and rollback in mind for every risky change",
+      "Prefer reusable workflows, templates, and runbooks over ad-hoc manual steps",
+      "Never introduce critical local-only automation if a GitHub/cloud path exists"
+    ],
     "personalRepo": {
       "allowed": ["state", "audit", "schemas", "contracts", "templates", "docs", "workflows", "panel", "trigger", "compliance"],
       "forbidden": ["corporate-code", "secrets", "kubeconfig", "internal-urls", "customer-data"]


### PR DESCRIPTION
## Summary
- codify the project operating doctrine in `HANDOFF.md` as the canonical continuity document
- add shared contract rules for cloud-first, GitHub-first, local-last execution
- persist Codex memory about the doctrine and the validated GitHub MCP path
- publish the previously local-only GitHub MCP mapping into repo docs/contracts

## Why
- the project owner defined Cloud First, GitHub First, Local Last as the mandatory operating model
- this should live in GitHub as reusable project memory, not only in session context or on one machine
- the GitHub MCP setup and validation were still only local and needed to be institutionalized

## Validation
- validated JSON syntax with `jq empty`
- reviewed patch isolation in a clean worktree based on `origin/main`
- no product/runtime logic changed; docs/contracts only

## Risk
- low: documentation and contract updates only
- rollback: revert this PR or specific files if the doctrine wording needs adjustment