### PR TITLE
[codex] fix: redeploy Pages after dashboard state sync

### DIFF
--- a/.github/workflows/spark-sync-state.yml
+++ b/.github/workflows/spark-sync-state.yml
@@ -27,6 +27,7 @@ on:
   # v2: script extracted to scripts/dashboard/collect-state.sh (fix 21000 char limit)
 
 permissions:
+  actions: write
   contents: write
   pages: write
   id-token: write
@@ -182,4 +183,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add panel/dashboard/state.json
           git commit -m "chore: sync dashboard state [skip ci]"
-          git push origin HEAD:main || echo "::warning ::Push to main failed — branch protection may block workflow token"
+          if git push origin HEAD:main; then
+            gh workflow run deploy-panel.yml --repo "$GITHUB_REPOSITORY" --ref main
+            echo "::notice ::Dispatched deploy-panel.yml after dashboard state sync"
+          else
+            echo "::warning ::Push to main failed — branch protection may block workflow token"
+          fi


### PR DESCRIPTION
## Summary
- dispatch `deploy-panel.yml` explicitly after `spark-sync-state.yml` updates `panel/dashboard/state.json` on `main`
- add `actions: write` permission so the workflow can trigger the Pages deployment

## Root cause
- `spark-sync-state.yml` was successfully committing fresh `panel/dashboard/state.json` to `main`
- those commits were created by the workflow token, so `deploy-panel.yml` was not being triggered by the resulting push event
- GitHub Pages therefore kept serving the stale dashboard artifact from March 31 even though `main` had fresh state data from April 1

## Validation
- confirmed `main` had fresh `panel/dashboard/state.json` (`lastSync=2026-04-01T18:06:10Z`)
- confirmed GitHub Pages still served stale `state.json` (`lastSync=2026-03-31T12:05:00Z`)
- confirmed `spark-sync-state.yml` pushed commit `chore: sync dashboard state [skip ci]` successfully
- parsed the modified workflow with PyYAML

## Risk
- low: workflow-only change
- behavior stays the same except Pages deploy is now triggered explicitly after successful panel sync