### PR TITLE
[codex] fix: redeploy Pages after dashboard state sync

### DIFF
--- a/.github/workflows/spark-sync-state.yml
+++ b/.github/workflows/spark-sync-state.yml
@@ -28,6 +28,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
   pages: write
   id-token: write
 
@@ -182,4 +183,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add panel/dashboard/state.json
           git commit -m "chore: sync dashboard state [skip ci]"
-          git push origin HEAD:main || echo "::warning ::Push to main failed — branch protection may block workflow token"
+          if git push origin HEAD:main; then
+            gh workflow run deploy-panel.yml --repo "$GITHUB_REPOSITORY" --ref main
+            echo "::notice ::Triggered deploy-panel.yml after dashboard state sync"
+          else
+            echo "::warning ::Push to main failed — branch protection may block workflow token"
+          fi


### PR DESCRIPTION
## Summary
- dispatch `deploy-panel.yml` explicitly after `spark-sync-state.yml` updates `panel/dashboard/state.json` on `main`
- add `actions: write` permission so the workflow can trigger the Pages deployment

## Root cause
- `spark-sync-state.yml` commits fresh `panel/dashboard/state.json` to `main`
- those commits are created by the workflow token, so `deploy-panel.yml` is not triggered by that resulting `push`
- GitHub Pages therefore keeps serving a stale dashboard artifact even though `main` has fresh state data

## Validation
- confirmed `main` has fresh `panel/dashboard/state.json`
- confirmed `https://lucassfreiree.github.io/autopilot/dashboard/state.json` remains stale
- kept the change limited to the workflow path that publishes state to `main`

## Risk
- low: workflow-only change
- existing sync behavior remains intact; this only closes the gap between state sync and Pages publish
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
