### PR TITLE
fix(controller): remove ignoreDeprecations TS5103 [run 90]

### DIFF
--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -8,32 +8,12 @@
     {
       "action": "search-replace",
       "target_path": "tsconfig.json",
-      "search": "\"ignoreDeprecations\": \"6.0\",",
-      "replace": "\"ignoreDeprecations\": \"6.0\", \"types\": [\"node\"],"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "src/routes/agentsRouter.ts",
-      "content_ref": "patches/agentsRouter.ts"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "src/controllers/cronjob-result.controller.ts",
-      "content_ref": "patches/cronjob-result.controller.ts"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "src/__tests__/unit/cronjob-result.controller.test.ts",
-      "content_ref": "patches/cronjob-result.controller.test.ts"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "src/swagger/swagger.json",
-      "content_ref": "patches/controller-swagger.json"
+      "search": "\"ignoreDeprecations\": \"6.0\", \"types\": [\"node\"],",
+      "replace": "\"types\": [\"node\"],"
     }
   ],
-  "commit_message": "fix(controller): tsconfig types node TS2591 + rotas cronjob /agent/* (v3.7.9)",
+  "commit_message": "fix(controller): remove invalid ignoreDeprecations from tsconfig (v3.7.9)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 89
+  "run": 90
 }


### PR DESCRIPTION
## Summary\n- Corporate CI failed with `TS5103: Invalid value for '--ignoreDeprecations'`\n- Remove `\"ignoreDeprecations\": \"6.0\"` from tsconfig.json (invalid for current TS version)\n- Keep `\"types\": [\"node\"]` fix from run 89\n- Trigger run 90 for controller v3.7.9\n\n## Context\n- Run 87: initial deploy (failed)\n- Run 88: fix TS5107 (failed - same TS5103)\n- Run 89: add types node (failed - same TS5103)\n- Run 90: remove ignoreDeprecations (this fix)\n\n## Test plan\n- [ ] apply-source-change succeeds\n- [ ] Corporate CI passes (tsc + eslint + jest)\n- [ ] CAP promoted with tag 3.7.9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
