### PR TITLE
chore: trigger ci-diagnose controller 3.7.9 [run 29]

### DIFF
--- a/trigger/ci-diagnose.json
+++ b/trigger/ci-diagnose.json
@@ -2,6 +2,6 @@
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
   "component": "controller",
-  "note": "Diagnose controller 3.7.2 CI failure — run80 sha f5ec64b840504117652a614df17f01a7b89a045e",
-  "run": 28
+  "note": "Diagnose controller 3.7.9 CI — check if run90 fix (remove ignoreDeprecations) resolved TS5103",
+  "run": 29
 }


### PR DESCRIPTION
Trigger ci-diagnose run 29 to check controller 3.7.9 corporate CI status after run 90 fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
