### PR TITLE
fix(controller): remove ignoreDeprecations + types node [run 91]

### DIFF
--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -8,12 +8,18 @@
     {
       "action": "search-replace",
       "target_path": "tsconfig.json",
-      "search": "\"ignoreDeprecations\": \"6.0\", \"types\": [\"node\"],",
-      "replace": "\"types\": [\"node\"],"
+      "search": "\"ignoreDeprecations\": \"6.0\",",
+      "replace": ""
+    },
+    {
+      "action": "search-replace",
+      "target_path": "tsconfig.json",
+      "search": " \"types\": [\"node\"],",
+      "replace": ""
     }
   ],
-  "commit_message": "fix(controller): remove invalid ignoreDeprecations from tsconfig (v3.7.9)",
+  "commit_message": "fix(controller): remove ignoreDeprecations + types node from tsconfig (v3.7.9)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 90
+  "run": 91
 }


### PR DESCRIPTION
## Summary\n- Remove `\"ignoreDeprecations\": \"6.0\"` from tsconfig (TS5103)\n- Remove `\"types\": [\"node\"]` from tsconfig (TS2688 - @types/node not installed)\n- Trigger run 91 for controller v3.7.9\n\n## Root cause\nRun 89 added both entries. ignoreDeprecations is invalid for current TS version. types requires @types/node which isn't a project dependency.\n\n## Test plan\n- [ ] apply-source-change passes\n- [ ] Corporate CI passes (tsc + eslint + jest)\n- [ ] CAP promoted with 3.7.9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
