### PR TITLE
fix(controller): validate 3.8.0 tsconfig restore via compliance gate

### DIFF
--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -3,7 +3,7 @@
 # Source: bbvinet/psc_releases_cap_sre-aut-controller (GitHub)
 # Path: releases/openshift/hml/deploy/values.yaml
 # Image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller
-# Current tag: 3.7.8
+# Current tag: 3.8.0
 # Secret: psc-sre-automacao-controller-runtime
 # Auto-promote: Stage 4 of apply-source-change.yml updates tag
 #   after corporate CI passes (Esteira de Build NPM green)
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.7.8
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.8.0
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,23 +3,35 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.7.9",
+  "version": "3.8.0",
   "changes": [
     {
       "action": "search-replace",
-      "target_path": "tsconfig.json",
-      "search": "\"ignoreDeprecations\": \"6.0\",",
-      "replace": ""
+      "target_path": "package.json",
+      "search": "\"version\": \"3.7.9\"",
+      "replace": "\"version\": \"3.8.0\""
+    },
+    {
+      "action": "search-replace",
+      "target_path": "package-lock.json",
+      "search": "\"version\": \"3.7.9\"",
+      "replace": "\"version\": \"3.8.0\""
+    },
+    {
+      "action": "search-replace",
+      "target_path": "src/swagger/swagger.json",
+      "search": "\"version\": \"3.7.9\"",
+      "replace": "\"version\": \"3.8.0\""
     },
     {
       "action": "search-replace",
       "target_path": "tsconfig.json",
-      "search": " \"types\": [\"node\"],",
-      "replace": ""
+      "search": "\"compilerOptions\": { \"types\": [\"node\"],",
+      "replace": "\"compilerOptions\": { \"ignoreDeprecations\": \"5.0\", \"types\": [\"node\"],"
     }
   ],
-  "commit_message": "fix(controller): remove ignoreDeprecations + types node from tsconfig (v3.7.9)",
+  "commit_message": "fix(controller): restore valid tsconfig deprecation guard (v3.8.0)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 91
+  "run": 92
 }


### PR DESCRIPTION
## Summary
- bump the controller deploy target from `3.7.9` to `3.8.0`
- restore a valid `ignoreDeprecations` guard in `tsconfig.json` while keeping `types: ["node"]`
- bump the required source version references in `package.json`, `package-lock.json`, `swagger.json`, and `references/controller-cap/values.yaml`

## Why
- the latest `controller 3.7.9` flow still fails in the saved diagnosis with `TS2688` for `node` and `TS5107` for `moduleResolution=node10`
- `3.7.9` is already the active source version, so the next valid release must be `3.8.0`
- this PR exists specifically to use the existing `Compliance Gate` on the autopilot PR as the pre-merge validator against the corporate repo

## Validation before PR
- reviewed the exact trigger history for runs 88-91
- confirmed the latest saved diagnosis in `autopilot-state`
- validated `trigger/source-change.json` structure with `jq`
- reviewed the final diff in a clean worktree

## What to watch
- `[Core] Compliance Gate`
- if green: squash merge and monitor `apply-source-change.yml`
- if red: inspect the gate result and iterate on the same branch

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
