### PR TITLE
chore: diagnose controller 3.8.0 CI state

### DIFF
--- a/trigger/ci-diagnose.json
+++ b/trigger/ci-diagnose.json
@@ -2,6 +2,7 @@
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
   "component": "controller",
-  "note": "Diagnose controller 3.7.9 CI — check if run90 fix (remove ignoreDeprecations) resolved TS5103",
-  "run": 29
+  "commit_sha": "efe4f2b08473c2dd24545e228c799052c0cb274c",
+  "note": "Diagnose controller 3.8.0 CI after tsconfig deprecation-guard restore",
+  "run": 30
 }


### PR DESCRIPTION
## Summary
- trigger `ci-diagnose.yml` for the latest controller corporate commit `efe4f2b08473c2dd24545e228c799052c0cb274c`
- capture whether `3.8.0` still fails in the corporate pipeline or whether the previous gate result was only inherited as pre-existing state

## Why
- `apply-source-change.yml` for `3.8.0` completed all stages and promoted CAP
- the saved release state still ended as `promoted-preexisting-ci-fail`
- we need a fresh diagnosis for the new corporate SHA before deciding on another source fix

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
