### PR TITLE
chore: fetch controller tsconfig for 3.8.0 follow-up

### DIFF
--- a/trigger/fetch-files.json
+++ b/trigger/fetch-files.json
@@ -1,7 +1,7 @@
 {
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
-  "component": "agent",
-  "files": "src/routes/apis.ts,src/controllers/execute.controller.ts,src/util/jwt.ts,src/routes/index.ts,package.json,src/app.ts",
-  "run": 24
+  "component": "controller",
+  "files": "tsconfig.json,package.json,package-lock.json",
+  "run": 25
 }


### PR DESCRIPTION
## Summary
- trigger `fetch-files.yml` for the controller
- fetch `tsconfig.json`, `package.json`, and `package-lock.json` from the current corporate repo state

## Why
- the fresh diagnosis for controller `3.8.0` still reproduces the same `TS2688` and `TS5107`
- before making another source change, we need the exact current `tsconfig` and package files from the corporate repo to patch against the real content rather than guessing search/replace patterns

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
