### PR TITLE
fix(controller): remove types restriction from tsconfig [run 93]

### DIFF
--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -7,31 +7,13 @@
   "changes": [
     {
       "action": "search-replace",
-      "target_path": "package.json",
-      "search": "\"version\": \"3.7.9\"",
-      "replace": "\"version\": \"3.8.0\""
-    },
-    {
-      "action": "search-replace",
-      "target_path": "package-lock.json",
-      "search": "\"version\": \"3.7.9\"",
-      "replace": "\"version\": \"3.8.0\""
-    },
-    {
-      "action": "search-replace",
-      "target_path": "src/swagger/swagger.json",
-      "search": "\"version\": \"3.7.9\"",
-      "replace": "\"version\": \"3.8.0\""
-    },
-    {
-      "action": "search-replace",
       "target_path": "tsconfig.json",
-      "search": "\"compilerOptions\": { \"types\": [\"node\"],",
-      "replace": "\"compilerOptions\": { \"ignoreDeprecations\": \"5.0\", \"types\": [\"node\"],"
+      "search": "\"ignoreDeprecations\": \"5.0\", \"types\": [\"node\"],",
+      "replace": "\"ignoreDeprecations\": \"5.0\","
     }
   ],
-  "commit_message": "fix(controller): restore valid tsconfig deprecation guard (v3.8.0)",
+  "commit_message": "fix(controller): remove types restriction from tsconfig — restore jest type discovery (v3.8.0)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 92
+  "run": 93
 }


### PR DESCRIPTION
## Summary\n- Remove `\"types\": [\"node\"]` from tsconfig — it restricts TS to only `@types/node`, blocking `@types/jest` auto-discovery\n- All 25 test suites failed with TS2593 (Cannot find name 'describe')\n- Keep `\"ignoreDeprecations\": \"5.0\"` (valid value)\n\n## Root cause\n`types` field in tsconfig restricts which `@types/*` packages TypeScript sees. With `[\"node\"]`, it ignores `@types/jest`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
