### PR TITLE
fix(controller): remove explicit node types and restore valid tsconfig deprecation guard (v3.8.1)

### DIFF
--- a/contracts/codex-session-memory.json
+++ b/contracts/codex-session-memory.json
@@ -1,1 +1,92 @@
-{"schemaVersion":1,"lastUpdated":"2026-04-01T18:47:09Z","sessionCount":7,"currentState":{"controllerVersion":"3.6.6","agentVersion":"2.2.9","lastTriggerRun":69,"lastSuccessfulRun":66,"workspace":"ws-default","pipelineStatus":"success"},"sessionsLog":[{"timestamp":"2026-04-01T18:45:04Z","topic":"dashboard-sync-pages","action":"Promoted the GitHub Pages redeploy fix for spark-sync-state to main and used this memory update to trigger a cloud-side sync run without touching local-only automation or corporate deploy triggers."},{"timestamp":"2026-04-01T18:47:09Z","topic":"dashboard-sync-race","action":"Confirmed spark-sync-state synced spark-dashboard successfully but failed to publish panel/dashboard/state.json because a git push back to main hit a non-fast-forward race."}],"decisions":[{"timestamp":"2026-04-01T18:45:04Z","decision":"Use explicit deploy-panel dispatch after spark-sync-state updates panel/dashboard/state.json on main.","reason":"Workflow-token commits do not trigger downstream push workflows, so GitHub Pages stayed stale while main already had fresh dashboard state."},{"timestamp":"2026-04-01T18:47:09Z","decision":"Replace panel/dashboard/state.json updates via git push with the GitHub Contents API plus retries.","reason":"A long-running sync job can start from an older main SHA; using git push makes the dashboard publish path fail on concurrent commits and prevents deploy-panel dispatch."}],"lessonsLearned":[{"timestamp":"2026-04-01T18:45:04Z","lesson":"autonomous-merge-direct can wait on queued third-party check suites such as Claude or Devin; for low-risk workflow fixes, a fast-forward promotion on the upstream branch can be the safer unblock path."},{"timestamp":"2026-04-01T18:47:09Z","lesson":"spark-sync-state must not rely on a local git commit and git push back to main for panel/dashboard/state.json. Use the Contents API on main and dispatch deploy-panel only after that update succeeds."}],"errorPatterns":{"pages_sync_gap":"spark-sync-state.yml can update panel/dashboard/state.json on main while GitHub Pages stays stale unless deploy-panel.yml is dispatched explicitly after the workflow-token push.","panel_state_non_fast_forward":"spark-sync-state can sync spark-dashboard successfully but still leave GitHub Pages stale when its final git push of panel/dashboard/state.json is rejected as non-fast-forward."}}
+{
+  "schemaVersion": 1,
+  "lastUpdated": "2026-04-02T14:21:00Z",
+  "sessionCount": 8,
+  "currentState": {
+    "controllerVersion": "3.8.0-verifying",
+    "agentVersion": "2.2.9",
+    "lastTriggerRun": 93,
+    "lastSuccessfulRun": 66,
+    "workspace": "ws-default",
+    "pipelineStatus": "controller-run93-verification"
+  },
+  "sessionsLog": [
+    {
+      "timestamp": "2026-04-01T18:45:04Z",
+      "topic": "dashboard-sync-pages",
+      "action": "Promoted the GitHub Pages redeploy fix for spark-sync-state to main and used this memory update to trigger a cloud-side sync run without touching local-only automation or corporate deploy triggers."
+    },
+    {
+      "timestamp": "2026-04-01T18:47:09Z",
+      "topic": "dashboard-sync-race",
+      "action": "Confirmed spark-sync-state synced spark-dashboard successfully but failed to publish panel/dashboard/state.json because a git push back to main hit a non-fast-forward race."
+    },
+    {
+      "timestamp": "2026-04-02T14:21:00Z",
+      "topic": "controller-run93-verification",
+      "action": "Recorded that the valid mainline fix remains on controller 3.8.0 at autopilot commit 645f70c6, abandoned the 3.8.1 draft, and triggered fetch-files plus ci-diagnose to verify whether the corporate repo and pipeline actually moved after run 93."
+    }
+  ],
+  "decisions": [
+    {
+      "timestamp": "2026-04-01T18:45:04Z",
+      "decision": "Use explicit deploy-panel dispatch after spark-sync-state updates panel/dashboard/state.json on main.",
+      "reason": "Workflow-token commits do not trigger downstream push workflows, so GitHub Pages stayed stale while main already had fresh dashboard state."
+    },
+    {
+      "timestamp": "2026-04-01T18:47:09Z",
+      "decision": "Replace panel/dashboard/state.json updates via git push with the GitHub Contents API plus retries.",
+      "reason": "A long-running sync job can start from an older main SHA; using git push makes the dashboard publish path fail on concurrent commits and prevents deploy-panel dispatch."
+    },
+    {
+      "timestamp": "2026-04-02T14:21:00Z",
+      "decision": "Keep the controller follow-up on version 3.8.0 and do not open a new semver line while the mainline run93 fix is the authoritative path.",
+      "reason": "The user explicitly requires 3.8.0 without adding another version segment, and main already contains the corresponding source-change trigger."
+    }
+  ],
+  "lessonsLearned": [
+    {
+      "timestamp": "2026-04-01T18:45:04Z",
+      "lesson": "autonomous-merge-direct can wait on queued third-party check suites such as Claude or Devin; for low-risk workflow fixes, a fast-forward promotion on the upstream branch can be the safer unblock path."
+    },
+    {
+      "timestamp": "2026-04-01T18:47:09Z",
+      "lesson": "spark-sync-state must not rely on a local git commit and git push back to main for panel/dashboard/state.json. Use the Contents API on main and dispatch deploy-panel only after that update succeeds."
+    },
+    {
+      "timestamp": "2026-04-02T14:21:00Z",
+      "lesson": "Always fetch the current corporate file via fetch-files before preparing search-replace changes; whitespace differences in the search string can silently prevent the intended patch."
+    },
+    {
+      "timestamp": "2026-04-02T14:21:00Z",
+      "lesson": "For controller 3.8.0, removing explicit types:[\"node\"] is required both to avoid TS2688 when @types/node is absent and to restore Jest type auto-discovery for test compilation."
+    },
+    {
+      "timestamp": "2026-04-02T14:21:00Z",
+      "lesson": "If apply-source-change finishes with Setup and Apply success but skips CI Gate, Save State, and CI Monitor, do not trust release-state alone; immediately verify via fetch-files and a fresh ci-diagnose on the latest corporate head."
+    }
+  ],
+  "errorPatterns": {
+    "pages_sync_gap": "spark-sync-state.yml can update panel/dashboard/state.json on main while GitHub Pages stays stale unless deploy-panel.yml is dispatched explicitly after the workflow-token push.",
+    "panel_state_non_fast_forward": "spark-sync-state can sync spark-dashboard successfully but still leave GitHub Pages stale when its final git push of panel/dashboard/state.json is rejected as non-fast-forward.",
+    "controller_tsconfig_spacing_mismatch": {
+      "observedAt": "2026-04-02T14:03:00Z",
+      "symptoms": [
+        "apply-source-change completes and promotes, but ci-diagnose still shows the same tsconfig error",
+        "fetched-controller-tsconfig.json still contains types:[\"node\"]"
+      ],
+      "rootCause": "The tsconfig search string did not match the live corporate file because there are two spaces after \"compilerOptions\": {.",
+      "fix": "Use the exact search string \"compilerOptions\": {  \"types\": [\"node\"],"
+    },
+    "controller_apply_success_state_skipped": {
+      "observedAt": "2026-04-02T14:15:04Z",
+      "symptoms": [
+        "apply-source-change run 93 completes with success",
+        "CI Gate, Save State, and CI Monitor are skipped",
+        "controller-release-state.json remains on the previous SHA"
+      ],
+      "rootCause": "The workflow completed the source apply path but did not publish a tracked commit/output for the downstream state and monitoring stages.",
+      "fix": "Trigger fetch-files and ci-diagnose immediately to confirm the live corporate file contents and latest commit health."
+    }
+  }
+}

--- a/panel/dashboard/state.json
+++ b/panel/dashboard/state.json
@@ -1,13 +1,13 @@
 {
-  "lastSync": "2026-04-02T13:55:14Z",
+  "lastSync": "2026-04-02T14:22:38Z",
   "syncSource": "autopilot/spark-sync-state.yml",
   "controller": {
-    "version": "3.7.9",
-    "status": "ci-failed-preexisting",
+    "version": "3.8.0",
+    "status": "promoted-preexisting-ci-fail",
     "ciResult": "failure",
-    "promoted": false,
-    "lastSha": "3d6557c3d2283942f0840a9e7a24df2307a9a9ed",
-    "updatedAt": "2026-04-02T13:26:51Z",
+    "promoted": true,
+    "lastSha": "efe4f2b08473c2dd24545e228c799052c0cb274c",
+    "updatedAt": "2026-04-02T13:58:55Z",
     "repo": "bbvinet/psc-sre-automacao-controller",
     "capRepo": "bbvinet/psc_releases_cap_sre-aut-controller",
     "stack": "Node 22, TypeScript, Express, Jest, SQLite, S3"
@@ -25,14 +25,14 @@
   },
   "pipeline": {
     "status": "success",
-    "lastRun": 92,
+    "lastRun": 93,
     "component": "controller",
     "version": "3.8.0",
     "promote": true,
     "workspace": "GETRONICS | ws-default | BBVINET_TOKEN",
     "changeType": "multi-file",
-    "commitMessage": "fix(controller): restore valid tsconfig deprecation guard (v3.8.0)",
-    "changesCount": 4
+    "commitMessage": "fix(controller): remove types restriction from tsconfig — restore jest type discovery (v3.8.0)",
+    "changesCount": 1
   },
   "agents": {
     "claude": {
@@ -76,11 +76,16 @@
       ]
     },
     "codex": {
-      "sessionCount": 7,
+      "sessionCount": 8,
       "lastSession": "none",
-      "lessonsCount": 2,
-      "lastUpdated": "2026-04-01T18:47:09Z",
+      "lessonsCount": 5,
+      "lastUpdated": "2026-04-02T14:21:00Z",
       "sessions": [
+        {
+          "date": null,
+          "summary": null,
+          "actions": 0
+        },
         {
           "date": null,
           "summary": null,
@@ -96,8 +101,8 @@
   },
   "sessionLock": {
     "agentId": "none",
-    "expiresAt": "2026-04-02T13:26:58Z",
-    "acquiredAt": "2026-04-02T13:26:58Z",
+    "expiresAt": "2026-04-02T14:15:00Z",
+    "acquiredAt": "2026-04-02T14:15:00Z",
     "operation": "none"
   },
   "health": {
@@ -138,18 +143,18 @@
   "ciMonitor": {
     "workspaceId": "ws-default",
     "component": "controller",
-    "commitSha": "3d6557c3d2283942f0840a9e7a24df2307a9a9ed",
+    "commitSha": "efe4f2b08473c2dd24545e228c799052c0cb274c",
     "version": "",
-    "monitoredAt": "2026-04-02T13:27:17Z",
+    "monitoredAt": "2026-04-02T14:01:21Z",
     "ciOutcome": "failure",
-    "monitorRunId": "23902740958",
-    "failedRunUrl": "https://github.com/bbvinet/psc-sre-automacao-controller/actions/runs/23902557096"
+    "monitorRunId": "23904161044",
+    "failedRunUrl": "https://github.com/bbvinet/psc-sre-automacao-controller/actions/runs/23903995535"
   },
   "pipelineStatus": {
-    "updatedAt": "2026-04-02T12:39:19Z",
+    "updatedAt": "2026-04-02T14:07:13Z",
     "workspaceId": "ws-default",
     "overallHealth": "degraded",
-    "monitorRunId": "23900783709",
+    "monitorRunId": "23904518190",
     "triggerEvent": "schedule",
     "autoDispatched": "",
     "components": {
@@ -164,20 +169,20 @@
         "stage": "idle",
         "health": "ok",
         "actionTaken": "none",
-        "deployAge": "4076min"
+        "deployAge": "4164min"
       },
       "controller": {
-        "version": "source-change",
-        "deployedAt": "2026-04-02T12:33:09Z",
-        "deployRunId": "23900355588",
+        "version": "3.8.0",
+        "deployedAt": "2026-04-02T13:58:55Z",
+        "deployRunId": "23903973104",
         "ciGateResult": "failure",
         "gateDecision": "pass-preexisting",
         "ciMonitorResult": "failure",
-        "ciMonitorAt": "2026-04-02T12:35:42Z",
+        "ciMonitorAt": "2026-04-02T14:01:21Z",
         "stage": "ci-failed",
         "health": "error",
         "actionTaken": "none",
-        "deployAge": "6min"
+        "deployAge": "8min"
       }
     }
   },
@@ -188,7 +193,7 @@
       "status": "active",
       "stack": "Node/TypeScript (NestJS, Jest, ESLint)",
       "token": "BBVINET_TOKEN",
-      "controllerVersion": "3.7.9",
+      "controllerVersion": "3.8.0",
       "agentVersion": "2.3.3",
       "pipelineStatus": "success",
       "repos": [
@@ -213,206 +218,222 @@
   "recentWorkflows": [
     {
       "conclusion": null,
-      "created": "2026-04-02T13:54:58Z",
-      "event": "push",
-      "head_branch": "main",
-      "name": "[Corp] Deploy: Apply Source Change • push • ws=n/a • ref=main",
-      "run_number": 92,
-      "status": "in_progress",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903973104"
-    },
-    {
-      "conclusion": null,
-      "created": "2026-04-02T13:54:58Z",
-      "event": "push",
-      "head_branch": "main",
-      "name": "[Infra] Spark Dashboard Sync • sync state to Spark dashboard",
-      "run_number": 209,
-      "status": "in_progress",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903973103"
-    },
-    {
-      "conclusion": null,
-      "created": "2026-04-02T13:54:58Z",
-      "event": "pull_request",
-      "head_branch": "codex/fix-controller-3-8-0-tsconfig",
-      "name": "[Infra] Cleanup: Stale Branches • pull_request • ws=n/a • ref=main",
-      "run_number": 369,
-      "status": "queued",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903973054"
-    },
-    {
-      "conclusion": null,
-      "created": "2026-04-02T13:54:58Z",
-      "event": "pull_request_target",
-      "head_branch": "codex/fix-controller-3-8-0-tsconfig",
-      "name": "[Core] Post-Merge Monitor • PR #453 • codex/fix-controller-3-8-0-tsconfig",
-      "run_number": 195,
-      "status": "queued",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903973043"
-    },
-    {
-      "conclusion": "skipped",
-      "created": "2026-04-02T13:54:51Z",
-      "event": "issue_comment",
-      "head_branch": "main",
-      "name": "Claude responding to @claude mention",
-      "run_number": 99,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903967153"
-    },
-    {
-      "conclusion": "skipped",
-      "created": "2026-04-02T13:54:46Z",
-      "event": "issue_comment",
-      "head_branch": "main",
-      "name": "Claude responding to @claude mention",
-      "run_number": 98,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903963772"
-    },
-    {
-      "conclusion": "success",
-      "created": "2026-04-02T13:54:41Z",
-      "event": "pull_request",
-      "head_branch": "codex/fix-controller-3-8-0-tsconfig",
-      "name": "[Core] PR Auto-Review • PR #453",
-      "run_number": 45,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903959636"
-    },
-    {
-      "conclusion": "success",
-      "created": "2026-04-02T13:54:41Z",
-      "event": "pull_request_target",
-      "head_branch": "codex/fix-controller-3-8-0-tsconfig",
-      "name": "[Core] Auto-Merge Sweeper • sweep open agent PRs",
-      "run_number": 300,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903959631"
-    },
-    {
-      "conclusion": null,
-      "created": "2026-04-02T13:54:41Z",
-      "event": "pull_request",
-      "head_branch": "codex/fix-controller-3-8-0-tsconfig",
-      "name": "[Core] Compliance Gate • auto",
-      "run_number": 33,
-      "status": "in_progress",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903959625"
-    },
-    {
-      "conclusion": null,
-      "created": "2026-04-02T13:54:41Z",
-      "event": "pull_request_target",
-      "head_branch": "codex/fix-controller-3-8-0-tsconfig",
-      "name": "[Core] Autonomous Direct Merge • PR #453 • codex/fix-controller-3-8-0-tsconfig → main",
-      "run_number": 261,
-      "status": "in_progress",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903959595"
-    },
-    {
-      "conclusion": "success",
-      "created": "2026-04-02T13:52:44Z",
+      "created": "2026-04-02T14:22:23Z",
       "event": "schedule",
       "head_branch": "main",
-      "name": "[Core] Health Check • schedule • ws=n/a • ref=main",
-      "run_number": 160,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23903873083"
-    },
-    {
-      "conclusion": "skipped",
-      "created": "2026-04-02T13:27:20Z",
-      "event": "issues",
-      "head_branch": "main",
-      "name": "[Core] Auto-Dispatch Task • Issue #452",
-      "run_number": 81,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902750264"
-    },
-    {
-      "conclusion": "skipped",
-      "created": "2026-04-02T13:27:19Z",
-      "event": "issues",
-      "head_branch": "main",
-      "name": "Claude responding to @claude mention",
-      "run_number": 97,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902750216"
-    },
-    {
-      "conclusion": "skipped",
-      "created": "2026-04-02T13:27:19Z",
-      "event": "issues",
-      "head_branch": "main",
-      "name": "[Core] Security Intake Dispatch • Issue #452",
-      "run_number": 7,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902750166"
-    },
-    {
-      "conclusion": "failure",
-      "created": "2026-04-02T13:27:16Z",
-      "event": "workflow_dispatch",
-      "head_branch": "main",
-      "name": "[Corp] Fix: CI Lint Errors • workflow_dispatch • ws=ws-default • ref=main",
-      "run_number": 15,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902747355"
+      "name": "[Infra] Spark Dashboard Sync • sync state to Spark dashboard",
+      "run_number": 212,
+      "status": "in_progress",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23905210786"
     },
     {
       "conclusion": "success",
-      "created": "2026-04-02T13:27:15Z",
-      "event": "workflow_dispatch",
-      "head_branch": "main",
-      "name": "[Corp] CI: Diagnose Error Logs • workflow_dispatch • ws=ws-default • ref=main",
-      "run_number": 35,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902746488"
-    },
-    {
-      "conclusion": "success",
-      "created": "2026-04-02T13:27:07Z",
-      "event": "workflow_dispatch",
-      "head_branch": "main",
-      "name": "[Core] CI Monitor Loop • workflow_dispatch • manual • ref=main",
-      "run_number": 17,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902740958"
-    },
-    {
-      "conclusion": "skipped",
-      "created": "2026-04-02T13:25:40Z",
-      "event": "pull_request_review_comment",
-      "head_branch": "claude/fix-cronjob-callback-route-6qr6E",
-      "name": "Claude responding to @claude mention",
-      "run_number": 96,
-      "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902678511"
-    },
-    {
-      "conclusion": "success",
-      "created": "2026-04-02T13:22:33Z",
+      "created": "2026-04-02T14:21:41Z",
       "event": "workflow_dispatch",
       "head_branch": "main",
       "name": "[Infra] Deploy Panel (GitHub Pages) • workflow_dispatch • ws=n/a • ref=main",
-      "run_number": 74,
+      "run_number": 77,
       "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902548628"
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23905177995"
+    },
+    {
+      "conclusion": null,
+      "created": "2026-04-02T14:21:20Z",
+      "event": "push",
+      "head_branch": "main",
+      "name": "[Corp] CI: Diagnose Error Logs • push • ws=n/a • ref=main",
+      "run_number": 38,
+      "status": "in_progress",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23905162875"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:21:20Z",
+      "event": "push",
+      "head_branch": "main",
+      "name": "[Infra] Spark Dashboard Sync • sync state to Spark dashboard",
+      "run_number": 211,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23905162871"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:21:20Z",
+      "event": "push",
+      "head_branch": "main",
+      "name": "[Corp] Fetch: Source Files • push • ws=n/a • ref=main",
+      "run_number": 28,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23905162828"
     },
     {
       "conclusion": "skipped",
-      "created": "2026-04-02T13:22:25Z",
+      "created": "2026-04-02T14:20:21Z",
+      "event": "pull_request_review_comment",
+      "head_branch": "claude/fix-cronjob-callback-route-6qr6E",
+      "name": "Claude responding to @claude mention",
+      "run_number": 111,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23905118311"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:17:15Z",
+      "event": "schedule",
+      "head_branch": "main",
+      "name": "[Core] Workflow Health Monitor • monitor all workflows",
+      "run_number": 59,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904979444"
+    },
+    {
+      "conclusion": "skipped",
+      "created": "2026-04-02T14:17:06Z",
       "event": "issue_comment",
       "head_branch": "main",
       "name": "Claude responding to @claude mention",
-      "run_number": 95,
+      "run_number": 110,
       "status": "completed",
-      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23902542094"
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904972691"
+    },
+    {
+      "conclusion": null,
+      "created": "2026-04-02T14:16:59Z",
+      "event": "pull_request_target",
+      "head_branch": "codex/fix-controller-3-8-1-tsconfig-memory",
+      "name": "[Core] Autonomous Direct Merge • PR #460 • codex/fix-controller-3-8-1-tsconfig-memory → main",
+      "run_number": 266,
+      "status": "in_progress",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904966476"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:16:59Z",
+      "event": "pull_request_target",
+      "head_branch": "codex/fix-controller-3-8-1-tsconfig-memory",
+      "name": "[Core] Auto-Merge Sweeper • sweep open agent PRs",
+      "run_number": 306,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904966452"
+    },
+    {
+      "conclusion": "skipped",
+      "created": "2026-04-02T14:14:57Z",
+      "event": "issue_comment",
+      "head_branch": "main",
+      "name": "Claude responding to @claude mention",
+      "run_number": 109,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904873576"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:14:52Z",
+      "event": "pull_request_target",
+      "head_branch": "codex/fix-controller-3-8-1-tsconfig-20260402",
+      "name": "[Core] Auto-Merge Sweeper • sweep open agent PRs",
+      "run_number": 305,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904870202"
+    },
+    {
+      "conclusion": null,
+      "created": "2026-04-02T14:14:52Z",
+      "event": "pull_request_target",
+      "head_branch": "codex/fix-controller-3-8-1-tsconfig-20260402",
+      "name": "[Core] Autonomous Direct Merge • PR #459 • codex/fix-controller-3-8-1-tsconfig-20260402 → main",
+      "run_number": 265,
+      "status": "in_progress",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904870187"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:14:49Z",
+      "event": "workflow_dispatch",
+      "head_branch": "main",
+      "name": "[Infra] Deploy Panel (GitHub Pages) • workflow_dispatch • ws=n/a • ref=main",
+      "run_number": 76,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904867752"
+    },
+    {
+      "conclusion": "skipped",
+      "created": "2026-04-02T14:14:34Z",
+      "event": "issue_comment",
+      "head_branch": "main",
+      "name": "Claude responding to @claude mention",
+      "run_number": 108,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904856474"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:14:28Z",
+      "event": "push",
+      "head_branch": "main",
+      "name": "[Infra] Spark Dashboard Sync • sync state to Spark dashboard",
+      "run_number": 210,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904852238"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:14:28Z",
+      "event": "push",
+      "head_branch": "main",
+      "name": "[Corp] Deploy: Apply Source Change • push • ws=n/a • ref=main",
+      "run_number": 93,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904852164"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:14:27Z",
+      "event": "pull_request",
+      "head_branch": "claude/fix-cronjob-callback-route-6qr6E",
+      "name": "[Infra] Cleanup: Stale Branches • pull_request • ws=n/a • ref=main",
+      "run_number": 372,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904851228"
+    },
+    {
+      "conclusion": "skipped",
+      "created": "2026-04-02T14:14:27Z",
+      "event": "issue_comment",
+      "head_branch": "main",
+      "name": "Claude responding to @claude mention",
+      "run_number": 107,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904851188"
+    },
+    {
+      "conclusion": "success",
+      "created": "2026-04-02T14:14:27Z",
+      "event": "pull_request_target",
+      "head_branch": "claude/fix-cronjob-callback-route-6qr6E",
+      "name": "[Core] Post-Merge Monitor • PR #458 • claude/fix-cronjob-callback-route-6qr6E",
+      "run_number": 198,
+      "status": "completed",
+      "url": "https://github.com/lucassfreiree/autopilot/actions/runs/23904851166"
     }
   ],
   "openPRs": [
+    {
+      "author": "lucassfreiree",
+      "branch": "codex/fix-controller-3-8-1-tsconfig-memory",
+      "created": "2026-04-02T14:16:54Z",
+      "draft": false,
+      "number": 460,
+      "title": "fix(controller): repair 3.8.1 tsconfig follow-up and persist memory"
+    },
+    {
+      "author": "lucassfreiree",
+      "branch": "codex/fix-controller-3-8-1-tsconfig-20260402",
+      "created": "2026-04-02T14:14:48Z",
+      "draft": false,
+      "number": 459,
+      "title": "fix(controller): remove explicit node types and restore valid tsconfig deprecation guard (v3.8.1)"
+    },
     {
       "author": "lucassfreiree3-maker",
       "branch": "codex/fix-dashboard-sync",
@@ -476,17 +497,11 @@
       "draft": false,
       "number": 412,
       "title": "ci(deps): bump google-github-actions/auth from 2 to 3"
-    },
-    {
-      "author": "dependabot[bot]",
-      "branch": "dependabot/github_actions/actions/setup-python-6",
-      "created": "2026-03-31T12:49:02Z",
-      "draft": false,
-      "number": 410,
-      "title": "ci(deps): bump actions/setup-python from 5 to 6"
     }
   ],
   "deployHistory": [
+    "state/workspaces/ws-default/audit/source-change-2026-04-02T14-15-01Z.json",
+    "state/workspaces/ws-default/audit/source-change-2026-04-02T13-59-03Z.json",
     "state/workspaces/ws-default/audit/source-change-2026-04-02T13-26-58Z.json",
     "state/workspaces/ws-default/audit/source-change-2026-04-02T12-45-55Z.json",
     "state/workspaces/ws-default/audit/source-change-2026-04-02T12-33-20Z.json",
@@ -504,14 +519,12 @@
     "state/workspaces/ws-default/audit/source-change-2026-03-30T17-08-54Z.json",
     "state/workspaces/ws-default/audit/source-change-2026-03-30T16-42-51Z.json",
     "state/workspaces/ws-default/audit/source-change-2026-03-30T14-45-16Z.json",
-    "state/workspaces/ws-default/audit/source-change-2026-03-30T14-33-49Z.json",
-    "state/workspaces/ws-default/audit/source-change-2026-03-30T13-30-52Z.json",
-    "state/workspaces/ws-default/audit/source-change-2026-03-30T13-10-52Z.json"
+    "state/workspaces/ws-default/audit/source-change-2026-03-30T14-33-49Z.json"
   ],
   "lessonsLearned": {
-    "total": 41,
+    "total": 44,
     "copilot": 39,
-    "codex": 2,
+    "codex": 5,
     "copilotLessons": [
       {
         "lesson": "NUNCA usar validateTrustedUrl dentro de fetch/postJson — quebra testes mock",
@@ -674,6 +687,21 @@
         "lesson": "spark-sync-state must not rely on a local git commit and git push back to main for panel/dashboard/state.json. Use the Contents API on main and dispatch deploy-panel only after that update succeeds.",
         "fix": null,
         "source": null
+      },
+      {
+        "lesson": "Always fetch the current corporate file via fetch-files before preparing search-replace changes; whitespace differences in the search string can silently prevent the intended patch.",
+        "fix": null,
+        "source": null
+      },
+      {
+        "lesson": "For controller 3.8.0, removing explicit types:[\"node\"] is required both to avoid TS2688 when @types/node is absent and to restore Jest type auto-discovery for test compilation.",
+        "fix": null,
+        "source": null
+      },
+      {
+        "lesson": "If apply-source-change finishes with Setup and Apply success but skips CI Gate, Save State, and CI Monitor, do not trust release-state alone; immediately verify via fetch-files and a fresh ci-diagnose on the latest corporate head.",
+        "fix": null,
+        "source": null
       }
     ]
   },
@@ -811,9 +839,15 @@
   "corporateReal": {
     "description": "REAL versions from corporate repos — source of truth. Other people may deploy independently.",
     "controller": {
-      "sourceVersion": "3.7.9",
-      "capTag": "3.7.9",
+      "sourceVersion": "3.8.0",
+      "capTag": "3.8.0",
       "recentCommits": [
+        {
+          "author": "github-actions",
+          "date": "2026-04-02T13:55:24Z",
+          "message": "fix(controller): restore valid tsconfig deprecation guard (v3.8.0)",
+          "sha": "efe4f2b0"
+        },
         {
           "author": "github-actions",
           "date": "2026-04-02T13:22:40Z",
@@ -837,15 +871,40 @@
           "date": "2026-04-02T11:45:08Z",
           "message": "refactor(controller): padroniza rotas cronjob para /agent/cronjob/* + version 3.",
           "sha": "ab85e1c5"
-        },
-        {
-          "author": "github-actions",
-          "date": "2026-04-01T20:36:50Z",
-          "message": "fix(security): Checkmarx XSS/SSRF/DoS — encodeURIComponent on output, ALLOWED_AG",
-          "sha": "0e8dc891"
         }
       ],
       "builds": [
+        {
+          "checks": [
+            {
+              "conclusion": "skipped",
+              "name": "CD (desenvolvimento)",
+              "status": "completed"
+            },
+            {
+              "conclusion": "skipped",
+              "name": "CI / Análise Motor Liberação",
+              "status": "completed"
+            },
+            {
+              "conclusion": "skipped",
+              "name": "CI / checkmarx",
+              "status": "completed"
+            },
+            {
+              "conclusion": "skipped",
+              "name": "CI / xRay",
+              "status": "completed"
+            },
+            {
+              "conclusion": "skipped",
+              "name": "CI / sonarQube",
+              "status": "completed"
+            }
+          ],
+          "sha": "efe4f2b0",
+          "total": 8
+        },
         {
           "checks": [
             {
@@ -907,41 +966,10 @@
           ],
           "sha": "39236c40",
           "total": 8
-        },
-        {
-          "checks": [
-            {
-              "conclusion": "skipped",
-              "name": "CD (desenvolvimento)",
-              "status": "completed"
-            },
-            {
-              "conclusion": "skipped",
-              "name": "CI / xRay",
-              "status": "completed"
-            },
-            {
-              "conclusion": "skipped",
-              "name": "CI / sonarQube",
-              "status": "completed"
-            },
-            {
-              "conclusion": "skipped",
-              "name": "CI / Análise Motor Liberação",
-              "status": "completed"
-            },
-            {
-              "conclusion": "skipped",
-              "name": "CI / checkmarx",
-              "status": "completed"
-            }
-          ],
-          "sha": "d90e0158",
-          "total": 8
         }
       ],
-      "drift": true,
-      "driftDetail": "autopilot=source-change real=3.7.9"
+      "drift": false,
+      "driftDetail": null
     },
     "agent": {
       "sourceVersion": "2.3.3",
@@ -1076,7 +1104,7 @@
       "drift": true,
       "driftDetail": "autopilot=source-change real=2.3.3"
     },
-    "lastChecked": "2026-04-02T13:55:14Z"
+    "lastChecked": "2026-04-02T14:22:38Z"
   },
   "corporateActivity": {
     "description": "Real-time activity from corporate repos — branches, PRs, external commits by other devs",
@@ -1140,7 +1168,7 @@
         {
           "name": "main",
           "protected": true,
-          "sha": "3d6557c3"
+          "sha": "efe4f2b0"
         }
       ],
       "branchCount": 12,

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -3,7 +3,7 @@
 # Source: bbvinet/psc_releases_cap_sre-aut-controller (GitHub)
 # Path: releases/openshift/hml/deploy/values.yaml
 # Image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller
-# Current tag: 3.8.1
+# Current tag: 3.8.0
 # Secret: psc-sre-automacao-controller-runtime
 # Auto-promote: Stage 4 of apply-source-change.yml updates tag
 #   after corporate CI passes (Esteira de Build NPM green)
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.8.1
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.8.0
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/ci-diagnose.json
+++ b/trigger/ci-diagnose.json
@@ -2,7 +2,6 @@
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
   "component": "controller",
-  "commit_sha": "efe4f2b08473c2dd24545e228c799052c0cb274c",
-  "note": "Diagnose controller 3.8.0 CI after tsconfig deprecation-guard restore",
-  "run": 30
+  "note": "Diagnose latest controller commit after run93 tsconfig types removal on 3.8.0",
+  "run": 29
 }

--- a/trigger/fetch-files.json
+++ b/trigger/fetch-files.json
@@ -2,6 +2,6 @@
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
   "workspace_id": "ws-default",
   "component": "controller",
-  "files": "tsconfig.json,package.json,package-lock.json",
+  "files": "tsconfig.json,package.json",
   "run": 25
 }

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,34 +3,16 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.8.1",
+  "version": "3.8.0",
   "changes": [
     {
       "action": "search-replace",
-      "target_path": "package.json",
-      "search": "\"version\": \"3.8.0\"",
-      "replace": "\"version\": \"3.8.1\""
-    },
-    {
-      "action": "search-replace",
-      "target_path": "package-lock.json",
-      "search": "\"version\": \"3.8.0\"",
-      "replace": "\"version\": \"3.8.1\""
-    },
-    {
-      "action": "search-replace",
-      "target_path": "src/swagger/swagger.json",
-      "search": "\"version\": \"3.8.0\"",
-      "replace": "\"version\": \"3.8.1\""
-    },
-    {
-      "action": "search-replace",
       "target_path": "tsconfig.json",
-      "search": "\"compilerOptions\": {  \"types\": [\"node\"],",
-      "replace": "\"compilerOptions\": {  \"ignoreDeprecations\": \"5.0\","
+      "search": "\"ignoreDeprecations\": \"5.0\", \"types\": [\"node\"],",
+      "replace": "\"ignoreDeprecations\": \"5.0\","
     }
   ],
-  "commit_message": "fix(controller): remove explicit node types and restore valid tsconfig deprecation guard (v3.8.1)",
+  "commit_message": "fix(controller): remove types restriction from tsconfig — restore jest type discovery (v3.8.0)",
   "skip_ci_wait": false,
   "promote": true,
   "run": 93


### PR DESCRIPTION
## Summary
- bump controller follow-up trigger to `3.8.1`
- replace the exact `tsconfig.json` prefix found in the fetched corporate file
- remove explicit `types: ["node"]` while adding `ignoreDeprecations: "5.0"`
- update CAP reference tag to `3.8.1`

## Why
The 3.8.0 trigger used a `tsconfig.json` search string that did not match the real file because of spacing, so the controller build kept failing with `TS2688` and `TS5107`.

## Validation
- confirmed the fetched remote `tsconfig.json` starts with `"compilerOptions": {  "types": ["node"],`
- verified the branch contents contain the exact replacement string before opening this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
