### PR TITLE
feat(pipeline): add pre-push validation step to apply-source-change

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -462,6 +462,43 @@ jobs:
           FINAL_ERRORS=$(echo "$LINT_FINAL" | jq '[.[] | .errorCount] | add // 0' 2>/dev/null || echo "0")
           echo "=== Final: $FINAL_ERRORS errors remaining ==="
 
+      - name: "Pre-push validation (npm ci + tsc + eslint + jest)"
+        id: validate
+        working-directory: /tmp/source
+        timeout-minutes: 15
+        run: |
+          set -euo pipefail
+          echo "=== Pre-push validation: full build & test ==="
+
+          # 1. Install dependencies
+          echo "--- npm ci ---"
+          npm ci
+          echo "npm ci: OK"
+
+          # 2. TypeScript compilation check
+          echo "--- tsc --noEmit ---"
+          npx tsc --noEmit
+          echo "tsc: OK"
+
+          # 3. ESLint (non-blocking — warnings only)
+          echo "--- eslint ---"
+          npx eslint . --quiet 2>&1 | tail -30 || echo "::warning ::ESLint has warnings/errors (non-blocking)"
+
+          # 4. Jest tests
+          echo "--- jest --ci ---"
+          npx jest --ci --forceExit --passWithNoTests
+          echo "jest: OK"
+
+          # 5. Build check (tsc compile)
+          echo "--- npm run build (if available) ---"
+          if npm run build --if-present 2>&1; then
+            echo "build: OK"
+          else
+            echo "::warning ::Build step failed (non-blocking)"
+          fi
+
+          echo "=== All validations passed ==="
+
       - name: "Push"
         id: push
         working-directory: /tmp/source


### PR DESCRIPTION
## Summary\n- Adds mandatory **pre-push validation gate** in Stage 2 of `apply-source-change.yml`\n- Runs `npm ci` → `tsc --noEmit` → `eslint` → `jest --ci` → `npm run build` **BEFORE** pushing to corporate repos\n- Applies to **both controller and agent** via matrix strategy\n- Prevents broken patches from reaching corporate CI (eliminates repeated CI failures like runs 89-93)\n\n## What changed\n- New step \"Pre-push validation\" between \"Fix pre-existing lint errors\" and \"Push\"\n- Uses `set -euo pipefail` — any failure in npm ci, tsc, or jest **blocks the push**\n- ESLint and build are non-blocking (warnings only)\n- 15-minute timeout to handle full test suites\n\n## Test plan\n- [ ] Merge and trigger a deploy (bump `trigger/source-change.json` run field)\n- [ ] Verify validation step runs before push in workflow logs\n- [ ] Verify a broken patch (e.g., TS error) blocks the push\n\nhttps://claude.ai/code/session_01YC9RyjbGfw471NTB928HcA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
