### PR TITLE
fix(controller): generate outbound JWT for agent dispatch (run 101)

### DIFF
--- a/patches/execute.controller.ts
+++ b/patches/execute.controller.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { randomUUID } from "node:crypto";
+import jwt from "jsonwebtoken";
 import { initExecution } from "./agents-execute-logs.controller";
 import { timestampSP } from "../util/time";
 import { resolveTrustedRegisteredAgentExecuteUrl } from "../util/trusted-agent";
@@ -162,9 +163,36 @@ async function postJson(
   return { ok: false, status: resp.status, text };
 }
 
-function getIncomingAuthorization(req: Request): string | undefined {
-  const auth = String(req.headers.authorization || "").trim();
-  return auth || undefined;
+function generateOutboundAgentJwt(execId: string): string | undefined {
+  const secret = safeString(process.env.JWT_SECRET);
+  if (!secret) {
+    const fromEnv = safeString(process.env.AGENT_EXECUTE_AUTHORIZATION);
+    return fromEnv || undefined;
+  }
+
+  const issuer =
+    safeString(process.env.JWT_ISSUER) || "psc-sre-automacao-controller";
+  const audience =
+    safeString(process.env.JWT_AUDIENCE) || "psc-sre-automacao-agent";
+  const subject =
+    safeString(process.env.JWT_DEFAULT_SUBJECT) || "execute-controller";
+  const expiresIn = safeString(process.env.JWT_EXPIRES_IN) || "5m";
+  const algorithm = (safeString(process.env.JWT_SIGN_ALG) ||
+    "HS256") as jwt.Algorithm;
+
+  const scopeExecute = safeString(process.env.SCOPE_EXECUTE_AUTOMATION);
+
+  const token = jwt.sign(
+    {
+      sub: subject,
+      scope: scopeExecute ? [scopeExecute] : [],
+      execId,
+    },
+    secret,
+    { algorithm, expiresIn, issuer, audience },
+  );
+
+  return `Bearer ${token}`;
 }
 
 function setLocals(res: Response, locals: LocalsExec): void {
@@ -226,8 +254,8 @@ export async function executeAgent(
       "x-exec-id": execId,
     };
 
-    const incomingAuth = getIncomingAuthorization(req);
-    if (incomingAuth) headers.authorization = incomingAuth;
+    const outboundAuth = generateOutboundAgentJwt(execId);
+    if (outboundAuth) headers.authorization = outboundAuth;
 
     const forwardBody: AgentForwardBody = {
       execId,

--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import crypto from "node:crypto";
+import jwt from "jsonwebtoken";
 import {
   initExecution,
   type ExecutionSnapshot,
@@ -334,17 +335,36 @@ function validateSreControllerPayload(body: unknown): ValidationResult {
   };
 }
 
-function getIncomingAuthorization(req: Request): string | undefined {
-  const auth = safeString(req.headers.authorization);
-  return auth || undefined;
-}
+function generateOutboundAgentJwt(execId: string): string | undefined {
+  const secret = safeString(process.env.JWT_SECRET);
+  if (!secret) {
+    const fromEnv = safeString(process.env.AGENT_EXECUTE_AUTHORIZATION);
+    return fromEnv || undefined;
+  }
 
-function getAgentAuthorization(req: Request): string | undefined {
-  const incoming = getIncomingAuthorization(req);
-  if (incoming) return incoming;
+  const issuer =
+    safeString(process.env.JWT_ISSUER) || "psc-sre-automacao-controller";
+  const audience =
+    safeString(process.env.JWT_AUDIENCE) || "psc-sre-automacao-agent";
+  const subject =
+    safeString(process.env.JWT_DEFAULT_SUBJECT) || "oas-sre-controller";
+  const expiresIn = safeString(process.env.JWT_EXPIRES_IN) || "5m";
+  const algorithm = (safeString(process.env.JWT_SIGN_ALG) ||
+    "HS256") as jwt.Algorithm;
 
-  const fromEnv = safeString(process.env.AGENT_EXECUTE_AUTHORIZATION);
-  return fromEnv || undefined;
+  const scopeExecute = safeString(process.env.SCOPE_EXECUTE_AUTOMATION);
+
+  const token = jwt.sign(
+    {
+      sub: subject,
+      scope: scopeExecute ? [scopeExecute] : [],
+      execId,
+    },
+    secret,
+    { algorithm, expiresIn, issuer, audience },
+  );
+
+  return `Bearer ${token}`;
 }
 
 async function callAgent(
@@ -431,7 +451,7 @@ export async function postOasSreController(
 
   const requestId = safeString(req.header("x-request-id")) || execId;
   const authDecision = readAuthDecision(res);
-  const outboundAuthorization = getAgentAuthorization(req);
+  const outboundAuthorization = generateOutboundAgentJwt(execId);
 
   console.info(
     "[oas-sre-controller] start execId=%s image=%s clusters=%d authMode=%s",

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -24,10 +24,20 @@
       "action": "replace-file",
       "target_path": "src/__tests__/unit/cronjob-result.controller.test.ts",
       "content_ref": "patches/cronjob-result.controller.test.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/controllers/oas-sre-controller.controller.ts",
+      "content_ref": "patches/oas-sre-controller.controller.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/controllers/execute.controller.ts",
+      "content_ref": "patches/execute.controller.ts"
     }
   ],
-  "commit_message": "fix(controller): align unit test statusEndpoint with /api/ prefix (v3.8.0)",
+  "commit_message": "fix(controller): generate outbound JWT for agent dispatch instead of forwarding caller token (v3.8.0)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 100
+  "run": 101
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `getAgentAuthorization()` forwarded the OaaS caller's JWT to the agent, causing 401 rejection
- **Fix**: New `generateOutboundAgentJwt()` creates a proper JWT using `JWT_SECRET`, `JWT_ISSUER`, `JWT_AUDIENCE` env vars already in values.yaml
- **Scope**: Both `oas-sre-controller.controller.ts` and `execute.controller.ts` patched
- **Fallback**: Gracefully falls back to `AGENT_EXECUTE_AUTHORIZATION` env when `JWT_SECRET` unavailable (test envs)

## Test plan
- [ ] Corporate CI (Esteira de Build NPM) passes all 147 tests
- [ ] OaaS runtime test no longer returns 401 from agent
- [ ] Agent accepts controller-issued JWT with correct iss/aud

https://claude.ai/code/session_01YC9RyjbGfw471NTB928HcA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
