### PR TITLE
fix(controller): bump to 3.8.1 + JWT generation fix (run 102)

### DIFF
--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -3,7 +3,7 @@
 # Source: bbvinet/psc_releases_cap_sre-aut-controller (GitHub)
 # Path: releases/openshift/hml/deploy/values.yaml
 # Image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller
-# Current tag: 3.8.0
+# Current tag: 3.8.1
 # Secret: psc-sre-automacao-controller-runtime
 # Auto-promote: Stage 4 of apply-source-change.yml updates tag
 #   after corporate CI passes (Esteira de Build NPM green)
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.8.0
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.8.1
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,8 +3,26 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "changes": [
+    {
+      "action": "search-replace",
+      "target_path": "package.json",
+      "search": "\"version\": \"3.8.0\"",
+      "replace": "\"version\": \"3.8.1\""
+    },
+    {
+      "action": "search-replace",
+      "target_path": "package-lock.json",
+      "search": "\"version\": \"3.8.0\"",
+      "replace": "\"version\": \"3.8.1\""
+    },
+    {
+      "action": "search-replace",
+      "target_path": "src/swagger/swagger.json",
+      "search": "\"version\": \"3.8.0\"",
+      "replace": "\"version\": \"3.8.1\""
+    },
     {
       "action": "replace-file",
       "target_path": "tsconfig.json",
@@ -36,8 +54,8 @@
       "content_ref": "patches/execute.controller.ts"
     }
   ],
-  "commit_message": "fix(controller): generate outbound JWT for agent dispatch instead of forwarding caller token (v3.8.0)",
+  "commit_message": "fix(controller): generate outbound JWT for agent dispatch + bump to 3.8.1 (v3.8.1)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 101
+  "run": 102
 }


### PR DESCRIPTION
## Summary
- **Run 101 failed**: Tag 3.8.0 already existed in corporate CI (created by successful run 100)
- **Fix**: Version bump to 3.8.1 across package.json, package-lock.json, swagger.json, CAP values.yaml
- **JWT fix preserved**: `generateOutboundAgentJwt()` replaces caller token forwarding in both controllers

## Test plan
- [ ] Corporate CI accepts new tag 3.8.1 (no duplicate)
- [ ] All 147 tests pass
- [ ] CAP promoted to 3.8.1

https://claude.ai/code/session_01YC9RyjbGfw471NTB928HcA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
