### PR TITLE
fix(controller): TS2769 expiresIn type fix + v3.8.2 (run 103)

### DIFF
--- a/patches/execute.controller.ts
+++ b/patches/execute.controller.ts
@@ -163,6 +163,21 @@ async function postJson(
   return { ok: false, status: resp.status, text };
 }
 
+function parseExpiresIn(raw: string): number {
+  if (!raw) return 0;
+  const num = Number(raw);
+  if (Number.isFinite(num) && num > 0) return Math.floor(num);
+  const match = raw.match(/^(\d+)\s*(s|m|h|d)$/i);
+  if (!match) return 0;
+  const value = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  if (unit === "s") return value;
+  if (unit === "m") return value * 60;
+  if (unit === "h") return value * 3600;
+  if (unit === "d") return value * 86400;
+  return 0;
+}
+
 function generateOutboundAgentJwt(execId: string): string | undefined {
   const secret = safeString(process.env.JWT_SECRET);
   if (!secret) {
@@ -176,7 +191,8 @@ function generateOutboundAgentJwt(execId: string): string | undefined {
     safeString(process.env.JWT_AUDIENCE) || "psc-sre-automacao-agent";
   const subject =
     safeString(process.env.JWT_DEFAULT_SUBJECT) || "execute-controller";
-  const expiresIn = safeString(process.env.JWT_EXPIRES_IN) || "5m";
+  const expiresInRaw = safeString(process.env.JWT_EXPIRES_IN);
+  const expiresIn = parseExpiresIn(expiresInRaw) || 300;
   const algorithm = (safeString(process.env.JWT_SIGN_ALG) ||
     "HS256") as jwt.Algorithm;
 

--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -335,6 +335,21 @@ function validateSreControllerPayload(body: unknown): ValidationResult {
   };
 }
 
+function parseExpiresIn(raw: string): number {
+  if (!raw) return 0;
+  const num = Number(raw);
+  if (Number.isFinite(num) && num > 0) return Math.floor(num);
+  const match = raw.match(/^(\d+)\s*(s|m|h|d)$/i);
+  if (!match) return 0;
+  const value = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  if (unit === "s") return value;
+  if (unit === "m") return value * 60;
+  if (unit === "h") return value * 3600;
+  if (unit === "d") return value * 86400;
+  return 0;
+}
+
 function generateOutboundAgentJwt(execId: string): string | undefined {
   const secret = safeString(process.env.JWT_SECRET);
   if (!secret) {
@@ -348,7 +363,8 @@ function generateOutboundAgentJwt(execId: string): string | undefined {
     safeString(process.env.JWT_AUDIENCE) || "psc-sre-automacao-agent";
   const subject =
     safeString(process.env.JWT_DEFAULT_SUBJECT) || "oas-sre-controller";
-  const expiresIn = safeString(process.env.JWT_EXPIRES_IN) || "5m";
+  const expiresInRaw = safeString(process.env.JWT_EXPIRES_IN);
+  const expiresIn = parseExpiresIn(expiresInRaw) || 300;
   const algorithm = (safeString(process.env.JWT_SIGN_ALG) ||
     "HS256") as jwt.Algorithm;
 

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -3,7 +3,7 @@
 # Source: bbvinet/psc_releases_cap_sre-aut-controller (GitHub)
 # Path: releases/openshift/hml/deploy/values.yaml
 # Image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller
-# Current tag: 3.8.1
+# Current tag: 3.8.2
 # Secret: psc-sre-automacao-controller-runtime
 # Auto-promote: Stage 4 of apply-source-change.yml updates tag
 #   after corporate CI passes (Esteira de Build NPM green)
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.8.1
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.8.2
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,25 +3,25 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "changes": [
     {
       "action": "search-replace",
       "target_path": "package.json",
-      "search": "\"version\": \"3.8.0\"",
-      "replace": "\"version\": \"3.8.1\""
+      "search": "\"version\": \"3.8.1\"",
+      "replace": "\"version\": \"3.8.2\""
     },
     {
       "action": "search-replace",
       "target_path": "package-lock.json",
-      "search": "\"version\": \"3.8.0\"",
-      "replace": "\"version\": \"3.8.1\""
+      "search": "\"version\": \"3.8.1\"",
+      "replace": "\"version\": \"3.8.2\""
     },
     {
       "action": "search-replace",
       "target_path": "src/swagger/swagger.json",
-      "search": "\"version\": \"3.8.0\"",
-      "replace": "\"version\": \"3.8.1\""
+      "search": "\"version\": \"3.8.1\"",
+      "replace": "\"version\": \"3.8.2\""
     },
     {
       "action": "replace-file",
@@ -54,8 +54,8 @@
       "content_ref": "patches/execute.controller.ts"
     }
   ],
-  "commit_message": "fix(controller): generate outbound JWT for agent dispatch + bump to 3.8.1 (v3.8.1)",
+  "commit_message": "fix(controller): fix TS2769 expiresIn type — use numeric seconds for jwt.sign (v3.8.2)",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 102
+  "run": 103
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `jwt.sign()` `expiresIn` expects `number|StringValue`, not plain `string` in this `@types/jsonwebtoken` version
- **Fix**: Added `parseExpiresIn()` that converts env `"5m"` to `300` (numeric seconds)
- **Version**: 3.8.1 → 3.8.2 (3.8.1 tag already exists)

https://claude.ai/code/session_01YC9RyjbGfw471NTB928HcA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
