### PR TITLE
fix: improve claude-assistant.yml trigger condition

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -23,9 +23,9 @@ jobs:
   respond:
     name: "Claude Code Response"
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body || '', '@claude'))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body || '', '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title || '', '@claude')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fix potential null body evaluation in `if` condition of claude-assistant.yml
- Add title matching for @claude detection (issues with @claude in title now also trigger)
- Normalize `|| ''` fallback across all event types

## Root Cause of Issue #487 Not Triggering
The `ANTHROPIC_API_KEY` IS configured. The most likely cause is GitHub's **anti-loop protection**: Issue #487 was created via API token (MCP GitHub), and GitHub prevents token-created events from triggering workflows to avoid infinite loops. Only human-initiated events (via browser/CLI) trigger workflows.

## Test Plan
- [x] YAML validated
- [ ] Create a new test issue manually via GitHub UI (not API) to confirm trigger works

https://claude.ai/code/session_01YC9RyjbGfw471NTB928HcA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lucassfreiree/autopilot/pull/489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
