### PR TITLE
fix: enable GitHub Pages deploy with .nojekyll

### DIFF
--- a/panel/dashboard/.deploy-trigger
+++ b/panel/dashboard/.deploy-trigger
@@ -1,1 +1,1 @@
-Trigger deploy
+Trigger deploy 2026-04-06


### PR DESCRIPTION
## Summary
- Adds `.nojekyll` file to `panel/` to prevent Jekyll from interfering with GitHub Pages deployment
- Updates deploy trigger to force a fresh deployment

## Required Manual Step
GitHub Pages must be enabled in repo settings:
1. Go to **Settings → Pages**
2. Under **Source**, select **GitHub Actions**
3. Save

Once merged and Pages is enabled, the dashboard will be live at:
- `lucassfreiree.github.io/autopilot/` (control plane)
- `lucassfreiree.github.io/autopilot/dashboard/` (dashboard)

## Test plan
- [ ] Enable GitHub Pages (Source: GitHub Actions) in repo settings
- [ ] Merge this PR
- [ ] Verify deploy-panel workflow runs successfully
- [ ] Confirm dashboard loads at lucassfreiree.github.io/autopilot/dashboard/

https://claude.ai/code/session_01TgjR6f3LnLCuwguWTBQCek