### PR TITLE
chore: clone controller repo for CI correction

### DIFF
--- a/trigger/clone-repos.json
+++ b/trigger/clone-repos.json
@@ -1,6 +1,6 @@
 {
   "_context": "GETRONICS | ws-default | BBVINET_TOKEN",
-  "repos": "all",
-  "note": "Clone all 4 corporate repos into corporate-repos/ directory",
-  "run": 1
+  "repos": "bbvinet/psc-sre-automacao-controller",
+  "note": "Clone controller corporate repo into corporate-repos/ directory",
+  "run": 2
 }


### PR DESCRIPTION
## Contexto
- trazer o repositório completo do controller para ajustar a falha atual da esteira com base no lock real

## Escopo
- dispara clone apenas de `bbvinet/psc-sre-automacao-controller`
- usa o mecanismo padrão já existente no autopilot

## Trigger
- trigger/clone-repos.json run 2