### PR TITLE
fix: restore controller CI on Node 22

### DIFF
--- a/patches/controller-tsconfig.json
+++ b/patches/controller-tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
+    "typeRoots": ["./src/types", "./node_modules/@types"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*.ts", "jest.setup.ts"],
+  "exclude": ["node_modules", "dist", "src/__tests__/**", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -7,40 +7,36 @@
   "changes": [
     {
       "action": "replace-file",
-      "target_path": "src/controllers/oas-sre-controller.controller.ts",
-      "content_ref": "patches/oas-sre-controller.controller.ts"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "src/__tests__/unit/oas-sre-controller.route.test.ts",
-      "content_ref": "patches/oas-sre-controller.route.test.ts"
-    },
-    {
-      "action": "replace-file",
-      "target_path": "src/swagger/swagger.json",
-      "content_ref": "patches/swagger.json"
+      "target_path": "tsconfig.json",
+      "content_ref": "patches/controller-tsconfig.json"
     },
     {
       "action": "search-replace",
       "target_path": "package.json",
-      "search": "\"version\": \"3.9.2\"",
-      "replace": "\"version\": \"3.9.3\""
+      "search": "\"better-sqlite3\": \"^9.4.0\"",
+      "replace": "\"better-sqlite3\": \"^12.9.0\""
     },
     {
       "action": "search-replace",
       "target_path": "package-lock.json",
-      "search": "\"version\": \"3.9.2\"",
-      "replace": "\"version\": \"3.9.3\""
+      "search": "\"better-sqlite3\": \"^9.4.0\"",
+      "replace": "\"better-sqlite3\": \"^12.9.0\""
     },
     {
       "action": "search-replace",
-      "target_path": "src/swagger/swagger.json",
-      "search": "\"version\": \"3.6.8\"",
-      "replace": "\"version\": \"3.9.3\""
+      "target_path": "package-lock.json",
+      "search": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.4.0.tgz",
+      "replace": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz"
+    },
+    {
+      "action": "search-replace",
+      "target_path": "package-lock.json",
+      "search": "sha512-5kynxekMxSjCMiFyUBLHggFcJkCmiZi6fUkiGz/B5GZOvdRWQJD0klqCx5/Y+bm2AKP7I/DHbSFx26AxjruWNg==",
+      "replace": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="
     }
   ],
-  "commit_message": "fix(controller): accept OAS functions and copy_resources contract (3.9.3)",
+  "commit_message": "fix(controller): restore node 22 CI for sqlite runtime",
   "skip_ci_wait": false,
-  "promote": true,
-  "run": 106
+  "promote": false,
+  "run": 107
 }


### PR DESCRIPTION
## Contexto
- corrigir a falha atual da esteira do controller após a publicação em 3.9.3
- manter a correção focada no ponto que quebra hoje a build

## Ajustes
- adiciona `ignoreDeprecations: "6.0"` no `tsconfig.json`
- atualiza `better-sqlite3` para linha compatível com Node 22
- alinha os replace/search do `package-lock.json` para a dependência
- mantém a versão `3.9.3`
- sem nova promoção de deploy (`promote=false`)

## Trigger
- trigger/source-change.json run 107