### PR TITLE
fix: remove invalid ignoreDeprecations from controller tsconfig

### DIFF
--- a/patches/controller-tsconfig.json
+++ b/patches/controller-tsconfig.json
@@ -10,7 +10,6 @@
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "ignoreDeprecations": "6.0",
     "typeRoots": ["./src/types", "./node_modules/@types"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -7,12 +7,12 @@
   "changes": [
     {
       "action": "replace-file",
-      "target_path": "package-lock.json",
-      "content_ref": "patches/controller-package-lock.json"
+      "target_path": "tsconfig.json",
+      "content_ref": "patches/controller-tsconfig.json"
     }
   ],
-  "commit_message": "fix(controller): sync package-lock for better-sqlite3 12.9.0",
+  "commit_message": "fix(controller): remove invalid ignoreDeprecations from tsconfig",
   "skip_ci_wait": false,
   "promote": false,
-  "run": 108
+  "run": 109
 }


### PR DESCRIPTION
## Objetivo

Remover o campo `ignoreDeprecations` do `tsconfig.json` do controller, porque a esteira corporativa passou a falhar com `TS5103: Invalid value for --ignoreDeprecations`.

## Alteracoes

- atualiza `patches/controller-tsconfig.json` removendo `ignoreDeprecations`
- ajusta `trigger/source-change.json` para uma rodada focada apenas em `tsconfig.json`
- incrementa o `run` para disparar nova execucao

## Evidencia

Log real da esteira corporativa salvo em `ci-logs-controller-72575193441.txt` mostra:

`tsconfig.json(13,27): error TS5103: Invalid value for --ignoreDeprecations.`

Nesta rodada anterior, o `npm ci` ja passou, entao o lock drift foi superado e o erro residual ficou isolado no `tsconfig`.