### PR TITLE
fix(controller): reapply oas sre contract on main

### DIFF
--- a/patches/controller-package.json
+++ b/patches/controller-package.json
@@ -1,0 +1,139 @@
+{
+  "name": "psc-sre-automacao-controller",
+  "version": "3.9.3",
+  "private": true,
+  "description": "psc-sre-automacao-controller in node with expressjs",
+  "repository": {
+    "type": "git",
+    "url": "https://***REDACTED***/psc/psc-sre-automacao-controller/psc-sre-automacao-controller.git"
+  },
+  "license": "ISC",
+  "author": "Equipe DS",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=22 <23"
+  },
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p ./tsconfig.json",
+    "debug": "tsc && node --inspect=9229 dist/server.js",
+    "lint": "tsc --noEmit && eslint . --quiet --fix --resolve-plugins-relative-to .",
+    "start": "node dist/server.js",
+    "prestart": "npm run build",
+    "dev": "nodemon --watch src --exec ts-node-dev src/server.ts",
+    "test": "jest",
+    "unitTest": "jest --testPathPattern=ut.test\\.ts$",
+    "integrationTest": "jest --testPathPattern=it.test\\.ts$ --detectOpenHandles --passWithNoTests --forceExit"
+  },
+  "jest": {
+    "collectCoverage": true,
+    "coverageDirectory": "coverage/typescript",
+    "coverageReporters": [
+      "json",
+      "html",
+      "lcov"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "<rootDir>/node_modules/",
+      "<rootDir>/dist/"
+    ],
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx?)$",
+    "testResultsProcessor": "jest-sonar-reporter",
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "verbose": true,
+    "setupFiles": [
+      "<rootDir>/src/jest.setup.ts"
+    ]
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.645.0",
+    "@labbsr0x/express-monitor": "2.11.0",
+    "@smithy/node-http-handler": "^3.0.0",
+    "@types/aws-sdk": "^0.0.42",
+    "aws-sdk": "^2.1693.0",
+    "better-sqlite3": "^9.4.0",
+    "body-parser": "1.20.3",
+    "cors": "2.8.5",
+    "date-fns": "^3.6.0",
+    "dev-express-b5-monitor": "^1.0.0",
+    "dev-javascript-erro": "2.1.0",
+    "dev-typescript-libs": "^1.2.2",
+    "dotenv": "^17.2.1",
+    "express": "^4.21.2",
+    "express-request-id": "3.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "luxon": "^3.5.0",
+    "morgan": "^1.10.0",
+    "pino": "9.3.2",
+    "pino-http": "10.2.0",
+    "pino-pretty": "11.2.2",
+    "prom-client": "^15.1.3",
+    "reflect-metadata": "0.2.2",
+    "sequelize": "6.37.5",
+    "sequelize-typescript": "2.1.6",
+    "sqlite3": "^5.0.2",
+    "swagger-jsdoc": "6.2.8",
+    "swagger-ui-express": "5.0.1",
+    "tedious": "18.3.0",
+    "tsoa": "6.4.0",
+    "uuid": "^9.0.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/cors": "2.8.17",
+    "@types/dockerode": "3.3.31",
+    "@types/express": "^4.17.21",
+    "@types/jest": "29.5.12",
+    "@types/jsonwebtoken": "^9.0.6",
+    "@types/luxon": "^3.7.1",
+    "@types/morgan": "^1.9.9",
+    "@types/node": "22.1.0",
+    "@types/supertest": "^6.0.2",
+    "@types/swagger-jsdoc": "6.0.4",
+    "@types/swagger-ui-express": "4.1.6",
+    "@types/uuid": "^9.0.1",
+    "@types/validator": "13.12.0",
+    "@typescript-eslint/eslint-plugin": "8.0.1",
+    "@typescript-eslint/parser": "8.0.1",
+    "eslint": "8.57.0",
+    "eslint-config-airbnb-base": "15.0.0",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-import": "2.29.1",
+    "eslint-plugin-prettier": "5.2.1",
+    "jest": "29.7.0",
+    "jest-sonar-reporter": "2.0.0",
+    "nodemon": "3.1.4",
+    "prettier": "3.3.3",
+    "supertest": "^7.0.0",
+    "testcontainers": "^11.12.0",
+    "ts-jest": "29.2.4",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.6.3"
+  },
+  "overrides": {
+    "bl": "6.1.4",
+    "qs": "6.14.1",
+    "better-sqlite3": {
+      "bl": "6.1.4"
+    },
+    "sqlite3": {
+      "bl": "6.1.4"
+    },
+    "body-parser": {
+      "qs": "6.14.1"
+    }
+  }
+}

--- a/patches/controller-trusted-agent.ts
+++ b/patches/controller-trusted-agent.ts
@@ -1,0 +1,28 @@
+import { AgentsRepo } from "../repository/agentsRepo";
+import { resolveAgentExecuteUrl } from "./agent-url";
+
+type TrustedAgentInput = {
+  cluster: string;
+  namespace: string;
+};
+
+export function resolveTrustedRegisteredAgentExecuteUrl(
+  input: TrustedAgentInput,
+): string | null {
+  const registeredAgent = AgentsRepo.getAgentByClusterAndNamespace(
+    input.cluster,
+    input.namespace,
+  );
+  if (!registeredAgent) return null;
+
+  return resolveAgentExecuteUrl({ cluster: registeredAgent.Cluster });
+}
+
+export function resolveTrustedRegisteredAgentExecuteUrlByCluster(
+  cluster: string,
+): string | null {
+  const registeredAgent = AgentsRepo.getAgentByCluster(cluster);
+  if (!registeredAgent) return null;
+
+  return resolveAgentExecuteUrl({ cluster: registeredAgent.Cluster });
+}

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -7,12 +7,32 @@
   "changes": [
     {
       "action": "replace-file",
-      "target_path": "tsconfig.json",
-      "content_ref": "patches/controller-tsconfig.json"
+      "target_path": "package.json",
+      "content_ref": "patches/controller-package.json"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/util/trusted-agent.ts",
+      "content_ref": "patches/controller-trusted-agent.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/controllers/oas-sre-controller.controller.ts",
+      "content_ref": "patches/oas-sre-controller.controller.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/__tests__/unit/oas-sre-controller.route.test.ts",
+      "content_ref": "patches/oas-sre-controller.route.test.ts"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "src/swagger/swagger.json",
+      "content_ref": "patches/controller-swagger.json"
     }
   ],
-  "commit_message": "fix(controller): remove invalid ignoreDeprecations from tsconfig",
+  "commit_message": "fix(controller): support new oas sre functions",
   "skip_ci_wait": false,
-  "promote": false,
-  "run": 109
+  "promote": true,
+  "run": 110
 }


### PR DESCRIPTION
## Objetivo
Reaplicar a correção do /oas/sre-controller em cima da main real do controller e publicar a versão 3.9.3.

## Ajustes
- package.json do controller em 3.9.3
- helper trusted-agent alinhado com o controller
- controller /oas/sre-controller com suporte às novas functions e contrato atualizado de copy_resources
- teste unitário do endpoint apontado no caminho real do source repo
- swagger do controller atualizado
- trigger com promoção automática após a esteira

## Base validada
- fetch-files corrigido para usar a branch configurada
- base atual do controller lida novamente da main
- JSONs válidos e transpile sintático dos arquivos TS de patch
