### PR TITLE
fix(workflows): export source branch outputs

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -78,7 +78,9 @@ jobs:
       skip_ci: ${{ steps.cfg.outputs.skip_ci }}
       promote: ${{ steps.cfg.outputs.promote }}
       agent_repo: ${{ steps.cfg.outputs.agent_repo }}
+      agent_branch: ${{ steps.cfg.outputs.agent_branch }}
       controller_repo: ${{ steps.cfg.outputs.controller_repo }}
+      controller_branch: ${{ steps.cfg.outputs.controller_branch }}
       cap_repo: ${{ steps.cfg.outputs.cap_repo }}
       cap_branch: ${{ steps.cfg.outputs.cap_branch }}
       cap_values: ${{ steps.cfg.outputs.cap_values }}

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -34,5 +34,5 @@
   "commit_message": "fix(controller): support new oas sre functions",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 110
+  "run": 111
 }


### PR DESCRIPTION
## Objetivo
Completar a correção do apply-source-change para usar a branch configurada do componente sem perder esse valor entre jobs.

## Ajustes
- expõe agent_branch no output do setup
- expõe controller_branch no output do setup
- incrementa o run do trigger para reexecutar a mesma mudança do controller

## Validacao
- parse YAML do workflow
- JSON válido do trigger
