### PR TITLE
fix(workflows): treat no-op promotion as success

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -799,8 +799,13 @@ jobs:
             echo "promoted=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "Promoted!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+            echo "Values already point to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match in values.yaml"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "promoted=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -848,8 +853,13 @@ jobs:
             echo "promoted=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "Promoted controller to $TAG!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+            echo "Controller values already point to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match in controller values.yaml"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "promoted=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -78,7 +78,9 @@ jobs:
       skip_ci: ${{ steps.cfg.outputs.skip_ci }}
       promote: ${{ steps.cfg.outputs.promote }}
       agent_repo: ${{ steps.cfg.outputs.agent_repo }}
+      agent_branch: ${{ steps.cfg.outputs.agent_branch }}
       controller_repo: ${{ steps.cfg.outputs.controller_repo }}
+      controller_branch: ${{ steps.cfg.outputs.controller_branch }}
       cap_repo: ${{ steps.cfg.outputs.cap_repo }}
       cap_branch: ${{ steps.cfg.outputs.cap_branch }}
       cap_values: ${{ steps.cfg.outputs.cap_values }}

--- a/.github/workflows/ci-monitor-loop.yml
+++ b/.github/workflows/ci-monitor-loop.yml
@@ -75,11 +75,25 @@ jobs:
         run: |
           set -e
 
+          read_state() {
+            gh api \
+              "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/${1}-release-state.json?ref=$STATE_BRANCH" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}'
+          }
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             WS_ID="${{ github.event.inputs.workspace_id }}"
             COMPONENT="${{ github.event.inputs.component }}"
             COMMIT_SHA="${{ github.event.inputs.commit_sha }}"
             VERSION="${{ github.event.inputs.version }}"
+
+            if [ -n "$COMPONENT" ] && { [ -z "$COMMIT_SHA" ] || [ -z "$VERSION" ] || [ "$VERSION" = "source-change" ]; }; then
+              STATE=$(read_state "$COMPONENT")
+              [ -z "$COMMIT_SHA" ] && COMMIT_SHA=$(echo "$STATE" | jq -r '.lastReleasedSha // ""')
+              if [ -z "$VERSION" ] || [ "$VERSION" = "source-change" ]; then
+                VERSION=$(echo "$STATE" | jq -r '.lastTag // ""')
+              fi
+            fi
           else
             # Triggered by apply-source-change — read last release state for each component.
             # apply-source-change runs only for ws-default today; extend here when other
@@ -90,9 +104,7 @@ jobs:
             COMPONENT=""
 
             for COMP in controller agent; do
-              STATE=$(gh api \
-                "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/${COMP}-release-state.json?ref=$STATE_BRANCH" \
-                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+              STATE=$(read_state "$COMP")
 
               RUN_ID=$(echo "$STATE" | jq -r '.runId // ""')
               TRIGGER_RUN="${{ github.event.workflow_run.id }}"
@@ -111,9 +123,7 @@ jobs:
             if [ -z "$COMPONENT" ]; then
               echo "::warning ::Could not match run ID to a release state entry; falling back to most recent controller state."
               COMPONENT="controller"
-              STATE=$(gh api \
-                "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/controller-release-state.json?ref=$STATE_BRANCH" \
-                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+              STATE=$(read_state "$COMPONENT")
               COMMIT_SHA=$(echo "$STATE" | jq -r '.lastReleasedSha // ""')
               VERSION=$(echo "$STATE" | jq -r '.lastTag // ""')
             fi

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -34,5 +34,5 @@
   "commit_message": "fix(controller): support new oas sre functions",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 110
+  "run": 111
 }


### PR DESCRIPTION
## Resumo
- trata promocao sem alteracao no values.yaml como sucesso quando a tag ja esta aplicada
- preserva a tag no output da promocao mesmo quando nao ha escrita
- faz o ci-monitor recuperar commit e versao do release-state quando o dispatch vier sem esses campos

## Validacao
- parse YAML dos workflows ajustados
- revisao do diff local
