### PR TITLE
fix(workflows): block deploy promotion on source ci failure

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -799,8 +799,13 @@ jobs:
             echo "promoted=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "Promoted!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+            echo "Values already point to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match in values.yaml"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "promoted=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -848,8 +853,13 @@ jobs:
             echo "promoted=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "Promoted controller to $TAG!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+            echo "Controller values already point to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match in controller values.yaml"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "promoted=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -71,6 +71,7 @@ jobs:
       component: ${{ steps.cfg.outputs.component }}
       components_json: ${{ steps.cfg.outputs.components_json }}
       change_type: ${{ steps.cfg.outputs.change_type }}
+      version: ${{ steps.cfg.outputs.version }}
       target_path: ${{ steps.cfg.outputs.target_path }}
       file_content_b64: ${{ steps.cfg.outputs.file_content_b64 }}
       changes_b64: ${{ steps.cfg.outputs.changes_b64 }}
@@ -104,6 +105,7 @@ jobs:
             WS_ID=$(echo "$TRIG" | jq -r '.workspace_id // "ws-default"')
             COMPONENT=$(echo "$TRIG" | jq -r '.component // "agent"')
             CHANGE_TYPE=$(echo "$TRIG" | jq -r '.change_type // "add-file"')
+            VERSION=$(echo "$TRIG" | jq -r '.version // ""')
             TARGET_PATH=$(echo "$TRIG" | jq -r '.target_path // ""')
             FILE_CONTENT=$(echo "$TRIG" | jq -r '.file_content // ""')
             COMMIT_MSG=$(echo "$TRIG" | jq -r '.commit_message // "feat: apply source code change via autopilot"')
@@ -113,6 +115,7 @@ jobs:
             WS_ID="${{ github.event.inputs.workspace_id || 'ws-default' }}"
             COMPONENT="${{ github.event.inputs.component }}"
             CHANGE_TYPE="${{ github.event.inputs.change_type }}"
+            VERSION=""
             TARGET_PATH="${{ github.event.inputs.target_path }}"
             FILE_CONTENT="${{ github.event.inputs.file_content }}"
             COMMIT_MSG="${{ github.event.inputs.commit_message }}"
@@ -138,6 +141,7 @@ jobs:
           echo "component=$COMPONENT" >> "$GITHUB_OUTPUT"
           echo "components_json=$COMPONENTS_JSON" >> "$GITHUB_OUTPUT"
           echo "change_type=$CHANGE_TYPE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "target_path=$TARGET_PATH" >> "$GITHUB_OUTPUT"
           echo "commit_message=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
           echo "skip_ci=$SKIP_CI" >> "$GITHUB_OUTPUT"
@@ -725,11 +729,13 @@ jobs:
             echo "decision=pass" >> "$GITHUB_OUTPUT"
             echo "CI passed or no CI configured"
           elif [ "$PRE" = "true" ]; then
-            echo "decision=pass-preexisting" >> "$GITHUB_OUTPUT"
-            echo "::warning ::CI failed but failure is PRE-EXISTING. Allowing promotion."
+            echo "decision=block-preexisting" >> "$GITHUB_OUTPUT"
+            echo "::error ::CI failed. Failure may be pre-existing, but promotion is blocked until the source pipeline is green."
+            exit 1
           elif [ "$PRE" = "unknown" ]; then
-            echo "decision=pass-unknown" >> "$GITHUB_OUTPUT"
-            echo "::warning ::CI failed, could not determine if pre-existing. Allowing with caution."
+            echo "decision=block-unknown" >> "$GITHUB_OUTPUT"
+            echo "::error ::CI failed and the cause could not be determined. Promotion is blocked until the source pipeline is green."
+            exit 1
           else
             echo "decision=block" >> "$GITHUB_OUTPUT"
             echo "::error ::CI failed due to our change. Blocking promotion."
@@ -745,7 +751,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.promote == 'true' &&
-      needs.ci-gate.result != 'failure'
+      needs.ci-gate.outputs.gate_decision == 'pass'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -897,6 +903,7 @@ jobs:
           [ -z "$CI_RES" ] && CI_RES="unknown"
 
           TAG="${{ needs.promote.outputs.tag }}"
+          [ -z "$TAG" ] && TAG="${{ needs.setup.outputs.version }}"
           [ -z "$TAG" ] && TAG="source-change"
 
           PROMOTED="${{ needs.promote.outputs.promoted }}"
@@ -905,8 +912,6 @@ jobs:
 
           if [ "$CI_RES" = "success" ] && [ "$PROMOTED" = "true" ]; then
             STATUS="promoted"
-          elif [ "$GATE" = "pass-preexisting" ] && [ "$PROMOTED" = "true" ]; then
-            STATUS="promoted-preexisting-ci-fail"
           elif [ "$CI_RES" = "success" ]; then
             STATUS="ci-passed"
           elif [ "$PRE_EXISTING" = "true" ]; then

--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -78,7 +78,9 @@ jobs:
       skip_ci: ${{ steps.cfg.outputs.skip_ci }}
       promote: ${{ steps.cfg.outputs.promote }}
       agent_repo: ${{ steps.cfg.outputs.agent_repo }}
+      agent_branch: ${{ steps.cfg.outputs.agent_branch }}
       controller_repo: ${{ steps.cfg.outputs.controller_repo }}
+      controller_branch: ${{ steps.cfg.outputs.controller_branch }}
       cap_repo: ${{ steps.cfg.outputs.cap_repo }}
       cap_branch: ${{ steps.cfg.outputs.cap_branch }}
       cap_values: ${{ steps.cfg.outputs.cap_values }}

--- a/.github/workflows/ci-monitor-loop.yml
+++ b/.github/workflows/ci-monitor-loop.yml
@@ -75,11 +75,25 @@ jobs:
         run: |
           set -e
 
+          read_state() {
+            gh api \
+              "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/${1}-release-state.json?ref=$STATE_BRANCH" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}'
+          }
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             WS_ID="${{ github.event.inputs.workspace_id }}"
             COMPONENT="${{ github.event.inputs.component }}"
             COMMIT_SHA="${{ github.event.inputs.commit_sha }}"
             VERSION="${{ github.event.inputs.version }}"
+
+            if [ -n "$COMPONENT" ] && { [ -z "$COMMIT_SHA" ] || [ -z "$VERSION" ] || [ "$VERSION" = "source-change" ]; }; then
+              STATE=$(read_state "$COMPONENT")
+              [ -z "$COMMIT_SHA" ] && COMMIT_SHA=$(echo "$STATE" | jq -r '.lastReleasedSha // ""')
+              if [ -z "$VERSION" ] || [ "$VERSION" = "source-change" ]; then
+                VERSION=$(echo "$STATE" | jq -r '.lastTag // ""')
+              fi
+            fi
           else
             # Triggered by apply-source-change — read last release state for each component.
             # apply-source-change runs only for ws-default today; extend here when other
@@ -90,9 +104,7 @@ jobs:
             COMPONENT=""
 
             for COMP in controller agent; do
-              STATE=$(gh api \
-                "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/${COMP}-release-state.json?ref=$STATE_BRANCH" \
-                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+              STATE=$(read_state "$COMP")
 
               RUN_ID=$(echo "$STATE" | jq -r '.runId // ""')
               TRIGGER_RUN="${{ github.event.workflow_run.id }}"
@@ -111,9 +123,7 @@ jobs:
             if [ -z "$COMPONENT" ]; then
               echo "::warning ::Could not match run ID to a release state entry; falling back to most recent controller state."
               COMPONENT="controller"
-              STATE=$(gh api \
-                "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/controller-release-state.json?ref=$STATE_BRANCH" \
-                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+              STATE=$(read_state "$COMPONENT")
               COMMIT_SHA=$(echo "$STATE" | jq -r '.lastReleasedSha // ""')
               VERSION=$(echo "$STATE" | jq -r '.lastTag // ""')
             fi

--- a/.github/workflows/promote-cap.yml
+++ b/.github/workflows/promote-cap.yml
@@ -128,6 +128,8 @@ jobs:
               -f "content=$(echo "$UPDATED" | base64 -w0)" \
               -f "sha=$VSHA"
             echo "Promoted $COMPONENT to $TAG!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "$COMPONENT already points to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match — tag may already be updated"
             echo "Current image line:"

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -34,5 +34,5 @@
   "commit_message": "fix(controller): support new oas sre functions",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 110
+  "run": 111
 }


### PR DESCRIPTION
## Resumo
- bloqueia a promocao de deploy quando a esteira do codigo-fonte falhar, inclusive em falha preexistente ou indeterminada
- exige explicitamente gate_decision=pass para entrar na etapa de promote
- propaga a versao do trigger no setup para o estado nao cair em source-change quando a promocao nao roda

## Validacao
- parse YAML do apply-source-change.yml
- revisao do diff local
