### PR TITLE
fix(workflows): require verified publish before promotion

### DIFF
--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -799,8 +799,13 @@ jobs:
             echo "promoted=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "Promoted!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+            echo "Values already point to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match in values.yaml"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "promoted=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -848,8 +853,13 @@ jobs:
             echo "promoted=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "Promoted controller to $TAG!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+            echo "Controller values already point to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match in controller values.yaml"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "promoted=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -71,6 +71,7 @@ jobs:
       component: ${{ steps.cfg.outputs.component }}
       components_json: ${{ steps.cfg.outputs.components_json }}
       change_type: ${{ steps.cfg.outputs.change_type }}
+      version: ${{ steps.cfg.outputs.version }}
       target_path: ${{ steps.cfg.outputs.target_path }}
       file_content_b64: ${{ steps.cfg.outputs.file_content_b64 }}
       changes_b64: ${{ steps.cfg.outputs.changes_b64 }}
@@ -104,6 +105,7 @@ jobs:
             WS_ID=$(echo "$TRIG" | jq -r '.workspace_id // "ws-default"')
             COMPONENT=$(echo "$TRIG" | jq -r '.component // "agent"')
             CHANGE_TYPE=$(echo "$TRIG" | jq -r '.change_type // "add-file"')
+            VERSION=$(echo "$TRIG" | jq -r '.version // ""')
             TARGET_PATH=$(echo "$TRIG" | jq -r '.target_path // ""')
             FILE_CONTENT=$(echo "$TRIG" | jq -r '.file_content // ""')
             COMMIT_MSG=$(echo "$TRIG" | jq -r '.commit_message // "feat: apply source code change via autopilot"')
@@ -113,6 +115,7 @@ jobs:
             WS_ID="${{ github.event.inputs.workspace_id || 'ws-default' }}"
             COMPONENT="${{ github.event.inputs.component }}"
             CHANGE_TYPE="${{ github.event.inputs.change_type }}"
+            VERSION=""
             TARGET_PATH="${{ github.event.inputs.target_path }}"
             FILE_CONTENT="${{ github.event.inputs.file_content }}"
             COMMIT_MSG="${{ github.event.inputs.commit_message }}"
@@ -138,6 +141,7 @@ jobs:
           echo "component=$COMPONENT" >> "$GITHUB_OUTPUT"
           echo "components_json=$COMPONENTS_JSON" >> "$GITHUB_OUTPUT"
           echo "change_type=$CHANGE_TYPE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "target_path=$TARGET_PATH" >> "$GITHUB_OUTPUT"
           echo "commit_message=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
           echo "skip_ci=$SKIP_CI" >> "$GITHUB_OUTPUT"
@@ -725,11 +729,13 @@ jobs:
             echo "decision=pass" >> "$GITHUB_OUTPUT"
             echo "CI passed or no CI configured"
           elif [ "$PRE" = "true" ]; then
-            echo "decision=pass-preexisting" >> "$GITHUB_OUTPUT"
-            echo "::warning ::CI failed but failure is PRE-EXISTING. Allowing promotion."
+            echo "decision=block-preexisting" >> "$GITHUB_OUTPUT"
+            echo "::error ::CI failed. Failure may be pre-existing, but promotion is blocked until the source pipeline is green."
+            exit 1
           elif [ "$PRE" = "unknown" ]; then
-            echo "decision=pass-unknown" >> "$GITHUB_OUTPUT"
-            echo "::warning ::CI failed, could not determine if pre-existing. Allowing with caution."
+            echo "decision=block-unknown" >> "$GITHUB_OUTPUT"
+            echo "::error ::CI failed and the cause could not be determined. Promotion is blocked until the source pipeline is green."
+            exit 1
           else
             echo "decision=block" >> "$GITHUB_OUTPUT"
             echo "::error ::CI failed due to our change. Blocking promotion."
@@ -745,7 +751,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.promote == 'true' &&
-      needs.ci-gate.result != 'failure'
+      needs.ci-gate.outputs.gate_decision == 'pass'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -897,6 +903,7 @@ jobs:
           [ -z "$CI_RES" ] && CI_RES="unknown"
 
           TAG="${{ needs.promote.outputs.tag }}"
+          [ -z "$TAG" ] && TAG="${{ needs.setup.outputs.version }}"
           [ -z "$TAG" ] && TAG="source-change"
 
           PROMOTED="${{ needs.promote.outputs.promoted }}"
@@ -905,8 +912,6 @@ jobs:
 
           if [ "$CI_RES" = "success" ] && [ "$PROMOTED" = "true" ]; then
             STATUS="promoted"
-          elif [ "$GATE" = "pass-preexisting" ] && [ "$PROMOTED" = "true" ]; then
-            STATUS="promoted-preexisting-ci-fail"
           elif [ "$CI_RES" = "success" ]; then
             STATUS="ci-passed"
           elif [ "$PRE_EXISTING" = "true" ]; then

--- a/.github/workflows/apply-source-change.yml
+++ b/.github/workflows/apply-source-change.yml
@@ -78,7 +78,9 @@ jobs:
       skip_ci: ${{ steps.cfg.outputs.skip_ci }}
       promote: ${{ steps.cfg.outputs.promote }}
       agent_repo: ${{ steps.cfg.outputs.agent_repo }}
+      agent_branch: ${{ steps.cfg.outputs.agent_branch }}
       controller_repo: ${{ steps.cfg.outputs.controller_repo }}
+      controller_branch: ${{ steps.cfg.outputs.controller_branch }}
       cap_repo: ${{ steps.cfg.outputs.cap_repo }}
       cap_branch: ${{ steps.cfg.outputs.cap_branch }}
       cap_values: ${{ steps.cfg.outputs.cap_values }}

--- a/.github/workflows/ci-monitor-loop.yml
+++ b/.github/workflows/ci-monitor-loop.yml
@@ -75,11 +75,25 @@ jobs:
         run: |
           set -e
 
+          read_state() {
+            gh api \
+              "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/${1}-release-state.json?ref=$STATE_BRANCH" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}'
+          }
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             WS_ID="${{ github.event.inputs.workspace_id }}"
             COMPONENT="${{ github.event.inputs.component }}"
             COMMIT_SHA="${{ github.event.inputs.commit_sha }}"
             VERSION="${{ github.event.inputs.version }}"
+
+            if [ -n "$COMPONENT" ] && { [ -z "$COMMIT_SHA" ] || [ -z "$VERSION" ] || [ "$VERSION" = "source-change" ]; }; then
+              STATE=$(read_state "$COMPONENT")
+              [ -z "$COMMIT_SHA" ] && COMMIT_SHA=$(echo "$STATE" | jq -r '.lastReleasedSha // ""')
+              if [ -z "$VERSION" ] || [ "$VERSION" = "source-change" ]; then
+                VERSION=$(echo "$STATE" | jq -r '.lastTag // ""')
+              fi
+            fi
           else
             # Triggered by apply-source-change — read last release state for each component.
             # apply-source-change runs only for ws-default today; extend here when other
@@ -90,9 +104,7 @@ jobs:
             COMPONENT=""
 
             for COMP in controller agent; do
-              STATE=$(gh api \
-                "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/${COMP}-release-state.json?ref=$STATE_BRANCH" \
-                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+              STATE=$(read_state "$COMP")
 
               RUN_ID=$(echo "$STATE" | jq -r '.runId // ""')
               TRIGGER_RUN="${{ github.event.workflow_run.id }}"
@@ -111,9 +123,7 @@ jobs:
             if [ -z "$COMPONENT" ]; then
               echo "::warning ::Could not match run ID to a release state entry; falling back to most recent controller state."
               COMPONENT="controller"
-              STATE=$(gh api \
-                "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/controller-release-state.json?ref=$STATE_BRANCH" \
-                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo '{}')
+              STATE=$(read_state "$COMPONENT")
               COMMIT_SHA=$(echo "$STATE" | jq -r '.lastReleasedSha // ""')
               VERSION=$(echo "$STATE" | jq -r '.lastTag // ""')
             fi

--- a/.github/workflows/ci-monitor-loop.yml
+++ b/.github/workflows/ci-monitor-loop.yml
@@ -144,14 +144,16 @@ jobs:
             "repos/$AUTOPILOT_REPO/contents/state/workspaces/${WS_ID}/workspace.json?ref=$STATE_BRANCH" \
             --jq '.content' | base64 -d)
           SOURCE_REPO=$(echo "$WS_JSON" | jq -r ".${COMPONENT}.sourceRepo // \"\"")
+          CI_WORKFLOW_NAME=$(echo "$WS_JSON" | jq -r ".${COMPONENT}.ciWorkflowName // \"\"")
 
           echo "ws_id=$WS_ID"          >> "$GITHUB_OUTPUT"
           echo "component=$COMPONENT"  >> "$GITHUB_OUTPUT"
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION"       >> "$GITHUB_OUTPUT"
           echo "source_repo=$SOURCE_REPO" >> "$GITHUB_OUTPUT"
+          echo "ci_workflow_name=$CI_WORKFLOW_NAME" >> "$GITHUB_OUTPUT"
 
-          echo "=== Monitor: ws=$WS_ID component=$COMPONENT sha=$COMMIT_SHA version=$VERSION repo=$SOURCE_REPO ==="
+          echo "=== Monitor: ws=$WS_ID component=$COMPONENT sha=$COMMIT_SHA version=$VERSION repo=$SOURCE_REPO workflow=${CI_WORKFLOW_NAME:-any} ==="
 
       # ── 2. Poll corporate CI ─────────────────────────────────────────────────
       - name: "Poll corporate CI"
@@ -166,6 +168,7 @@ jobs:
           SOURCE_REPO="${{ steps.inputs.outputs.source_repo }}"
           COMMIT_SHA="${{ steps.inputs.outputs.commit_sha }}"
           COMPONENT="${{ steps.inputs.outputs.component }}"
+          CI_WORKFLOW_NAME="${{ steps.inputs.outputs.ci_workflow_name }}"
 
           if [ -z "$SOURCE_REPO" ] || [ "$SOURCE_REPO" = "null" ]; then
             echo "::error ::No source repo configured for $COMPONENT — cannot poll CI."
@@ -173,6 +176,9 @@ jobs:
           fi
 
           OVERALL="unknown"
+          SUCCESS_RUN_ID=""
+          SUCCESS_RUN_URL=""
+          SUCCESS_RUN_NAME=""
           FAILED_RUN_URL=""
           TOTAL_ATTEMPTS=$(( FAST_ATTEMPTS + SLOW_ATTEMPTS ))
 
@@ -188,26 +194,35 @@ jobs:
             echo "=== Attempt $ATTEMPT / $TOTAL_ATTEMPTS (${PHASE} phase, ${INTERVAL}s interval) ==="
 
             if [ -n "$COMMIT_SHA" ] && [ "$COMMIT_SHA" != "null" ]; then
-              RUNS=$(GH_TOKEN="$BBVINET_TOKEN" gh api \
+              RAW_RUNS=$(GH_TOKEN="$BBVINET_TOKEN" gh api \
                 "repos/$SOURCE_REPO/actions/runs?head_sha=${COMMIT_SHA}&per_page=10" \
                 2>/dev/null || echo '{"workflow_runs":[]}')
             else
               # Fallback: check the last 5 runs in the repo
-              RUNS=$(GH_TOKEN="$BBVINET_TOKEN" gh api \
+              RAW_RUNS=$(GH_TOKEN="$BBVINET_TOKEN" gh api \
                 "repos/$SOURCE_REPO/actions/runs?per_page=5" \
                 2>/dev/null || echo '{"workflow_runs":[]}')
+            fi
+
+            if [ -n "$CI_WORKFLOW_NAME" ] && [ "$CI_WORKFLOW_NAME" != "null" ]; then
+              RUNS=$(echo "$RAW_RUNS" | jq --arg wf "$CI_WORKFLOW_NAME" '{workflow_runs: [.workflow_runs[] | select(.name == $wf)]}')
+            else
+              RUNS="$RAW_RUNS"
             fi
 
             TOTAL=$(echo "$RUNS"       | jq '.workflow_runs | length')
             IN_PROG=$(echo "$RUNS"     | jq '[.workflow_runs[] | select(.status != "completed")] | length')
             SUCCESS=$(echo "$RUNS"     | jq '[.workflow_runs[] | select(.conclusion == "success")] | length')
             FAILED=$(echo "$RUNS"      | jq '[.workflow_runs[] | select(.conclusion == "failure")] | length')
+            SUCCESS_RUN_ID=$(echo "$RUNS" | jq -r '[.workflow_runs[] | select(.conclusion == "success")] | first | .id // ""')
+            SUCCESS_RUN_URL=$(echo "$RUNS" | jq -r '[.workflow_runs[] | select(.conclusion == "success")] | first | .html_url // ""')
+            SUCCESS_RUN_NAME=$(echo "$RUNS" | jq -r '[.workflow_runs[] | select(.conclusion == "success")] | first | .name // ""')
             FAILED_RUN_URL=$(echo "$RUNS" | jq -r '[.workflow_runs[] | select(.conclusion == "failure")] | first | .html_url // ""')
 
-            echo "  total=$TOTAL in_progress=$IN_PROG success=$SUCCESS failed=$FAILED"
+            echo "  total=$TOTAL in_progress=$IN_PROG success=$SUCCESS failed=$FAILED workflow=${CI_WORKFLOW_NAME:-any}"
 
             if [ "$TOTAL" -eq 0 ]; then
-              echo "  No runs found yet — waiting..."
+              echo "  No matching workflow run found yet — waiting..."
               OVERALL="pending"
             elif [ "$SUCCESS" -gt 0 ] && [ "$IN_PROG" -eq 0 ]; then
               OVERALL="success"
@@ -234,12 +249,83 @@ jobs:
           fi
 
           echo "overall=$OVERALL"            >> "$GITHUB_OUTPUT"
+          echo "success_run_id=$SUCCESS_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "success_run_url=$SUCCESS_RUN_URL" >> "$GITHUB_OUTPUT"
+          echo "success_run_name=$SUCCESS_RUN_NAME" >> "$GITHUB_OUTPUT"
           echo "failed_run_url=$FAILED_RUN_URL" >> "$GITHUB_OUTPUT"
           echo "=== Final CI status: $OVERALL ==="
 
-      # ── 3a. On success → promote CAP ─────────────────────────────────────────
-      - name: "Trigger promote-cap (on success)"
+      # ── 3a. On success → verify publish evidence ─────────────────────────────
+      - name: "Verify image publication"
+        id: publish
         if: steps.poll.outputs.overall == 'success'
+        env:
+          BBVINET_TOKEN: ${{ secrets.BBVINET_TOKEN }}
+        run: |
+          set -e
+
+          SOURCE_REPO="${{ steps.inputs.outputs.source_repo }}"
+          VERSION="${{ steps.inputs.outputs.version }}"
+          RUN_ID="${{ steps.poll.outputs.success_run_id }}"
+          IMAGE_NAME=$(echo "$SOURCE_REPO" | awk -F/ '{print $2}')
+
+          VERIFIED=false
+          EVIDENCE=""
+
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::warning ::Successful workflow run not available for artifact verification."
+          else
+            JOBS=$(GH_TOKEN="$BBVINET_TOKEN" gh api \
+              "repos/$SOURCE_REPO/actions/runs/$RUN_ID/jobs?per_page=100" \
+              2>/dev/null || echo '{"jobs":[]}')
+
+            JOB_IDS=$(echo "$JOBS" | jq -r '[.jobs[] | select((.name | ascii_downcase | test("publish|push|docker|image|build"))) | .id] | unique | .[]')
+            if [ -z "$JOB_IDS" ]; then
+              JOB_IDS=$(echo "$JOBS" | jq -r '[.jobs[] | .id] | .[:5] | .[]')
+            fi
+
+            for JOB_ID in $JOB_IDS; do
+              JOB_NAME=$(echo "$JOBS" | jq -r --arg id "$JOB_ID" '.jobs[] | select((.id | tostring) == $id) | .name // ""')
+              JOB_LOGS=$(GH_TOKEN="$BBVINET_TOKEN" gh api \
+                "repos/$SOURCE_REPO/actions/jobs/$JOB_ID/logs" \
+                2>/dev/null || echo "")
+
+              HAS_VERSION=false
+              HAS_PUBLISH=false
+
+              echo "$JOB_LOGS" | grep -Fq "$VERSION" && HAS_VERSION=true || true
+              echo "$JOB_LOGS" | grep -Eiq "docker\\.binarios\\.intranet|docker push|published|publish|registry|push refer|${IMAGE_NAME}:${VERSION}" && HAS_PUBLISH=true || true
+
+              if [ "$HAS_VERSION" = "true" ] && [ "$HAS_PUBLISH" = "true" ]; then
+                VERIFIED=true
+                EVIDENCE="workflow=${{ steps.poll.outputs.success_run_name }} job=${JOB_NAME} run=${RUN_ID}"
+                echo "Artifact verified via $JOB_NAME"
+                break
+              fi
+            done
+          fi
+
+          echo "verified=$VERIFIED" >> "$GITHUB_OUTPUT"
+          echo "evidence=$EVIDENCE" >> "$GITHUB_OUTPUT"
+
+      - name: "Finalize monitor result"
+        id: final
+        if: always()
+        run: |
+          POLL_RESULT="${{ steps.poll.outputs.overall || 'unknown' }}"
+          VERIFIED="${{ steps.publish.outputs.verified || 'false' }}"
+          FINAL_RESULT="$POLL_RESULT"
+
+          if [ "$POLL_RESULT" = "success" ] && [ "$VERIFIED" != "true" ]; then
+            FINAL_RESULT="artifact-unverified"
+          fi
+
+          echo "overall=$FINAL_RESULT" >> "$GITHUB_OUTPUT"
+          echo "=== Final monitored status: $FINAL_RESULT ==="
+
+      # ── 3b. On verified success → promote CAP ────────────────────────────────
+      - name: "Trigger promote-cap (on success)"
+        if: steps.final.outputs.overall == 'success'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
@@ -258,18 +344,18 @@ jobs:
 
           echo "Promote-CAP workflow dispatched for $COMPONENT $VERSION."
 
-      # ── 3b. On failure/timeout → diagnose + fix ───────────────────────────────
+      # ── 3c. On failure/timeout → diagnose + fix ───────────────────────────────
       - name: "Trigger ci-diagnose (on failure)"
         if: >
-          steps.poll.outputs.overall == 'failure' ||
-          steps.poll.outputs.overall == 'timeout'
+          steps.final.outputs.overall == 'failure' ||
+          steps.final.outputs.overall == 'timeout'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           WS_ID="${{ steps.inputs.outputs.ws_id }}"
           COMPONENT="${{ steps.inputs.outputs.component }}"
           COMMIT_SHA="${{ steps.inputs.outputs.commit_sha }}"
-          OVERALL="${{ steps.poll.outputs.overall }}"
+          OVERALL="${{ steps.final.outputs.overall }}"
 
           echo "=== CI $OVERALL — diagnosing $COMPONENT ==="
 
@@ -287,11 +373,12 @@ jobs:
       # diagnosis and apply smarter fixes. Chain: ci-diagnose → fix-corporate-ci.
       # Previous behavior: both dispatched in parallel (fix couldn't read diagnosis).
 
-      # ── 3c. Create failure notification issue ─────────────────────────────────
+      # ── 3d. Create failure notification issue ─────────────────────────────────
       - name: "Create CI failure notification issue"
         if: >
-          steps.poll.outputs.overall == 'failure' ||
-          steps.poll.outputs.overall == 'timeout'
+          steps.final.outputs.overall == 'failure' ||
+          steps.final.outputs.overall == 'timeout' ||
+          steps.final.outputs.overall == 'artifact-unverified'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
@@ -299,8 +386,10 @@ jobs:
           VERSION="${{ steps.inputs.outputs.version }}"
           COMMIT_SHA="${{ steps.inputs.outputs.commit_sha }}"
           FAILED_URL="${{ steps.poll.outputs.failed_run_url }}"
-          OVERALL="${{ steps.poll.outputs.overall }}"
+          SUCCESS_URL="${{ steps.poll.outputs.success_run_url }}"
+          OVERALL="${{ steps.final.outputs.overall }}"
           SOURCE_REPO="${{ steps.inputs.outputs.source_repo }}"
+          PUBLISH_EVIDENCE="${{ steps.publish.outputs.evidence }}"
           NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           # Dedup: check if an open issue already exists for this component CI failure
@@ -317,12 +406,12 @@ jobs:
             gh issue comment "$EXISTING_ISSUE" \
               --repo "$AUTOPILOT_REPO" \
               --body "**Update**: CI still failing at $NOW
-          Outcome: $OVERALL | SHA: $COMMIT_SHA | Run: $FAILED_URL
-          Auto-fix dispatched again (ci-diagnose + fix-corporate-ci)." \
+          Outcome: $OVERALL | SHA: $COMMIT_SHA | Failed run: $FAILED_URL | Success run: $SUCCESS_URL
+          Publish evidence: ${PUBLISH_EVIDENCE:-not-found}" \
               2>/dev/null || true
           else
             TITLE="[AutoPilot] Corporate CI $OVERALL: $COMPONENT $VERSION"
-            BODY="Corporate CI failed and auto-fix has been dispatched.
+            BODY="Corporate pipeline requires remediation.
 
           Component: $COMPONENT
           Version: $VERSION
@@ -330,13 +419,15 @@ jobs:
           Source repo: $SOURCE_REPO
           Outcome: $OVERALL
           Failed run: $FAILED_URL
+          Successful run: $SUCCESS_URL
+          Publish evidence: ${PUBLISH_EVIDENCE:-not-found}
 
           Actions taken:
-          - ci-diagnose dispatched (logs saved to autopilot-state)
-          - fix-corporate-ci dispatched (will attempt lint/build auto-fix)
-          - ci-monitor-loop will be re-dispatched by fix-corporate-ci with the fix SHA
+          - promotion blocked
+          - ci-diagnose dispatched when CI failed or timed out
+          - monitor state saved on autopilot-state
 
-          If this issue persists after auto-fix, manual intervention is needed.
+          If this issue persists, manual intervention is needed.
           Check: state/workspaces/ws-default/ci-logs-${COMPONENT}-*.txt on autopilot-state branch."
 
             gh issue create \
@@ -356,7 +447,7 @@ jobs:
           set -e
           WS_ID="${{ steps.inputs.outputs.ws_id }}"
           COMPONENT="${{ steps.inputs.outputs.component }}"
-          OVERALL="${{ steps.poll.outputs.overall || 'unknown' }}"
+          OVERALL="${{ steps.final.outputs.overall || 'unknown' }}"
           NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           RESULT=$(jq -n \
@@ -367,6 +458,12 @@ jobs:
             --arg ts "$NOW" \
             --arg overall "$OVERALL" \
             --arg run "${{ github.run_id }}" \
+            --arg ci_workflow "${{ steps.inputs.outputs.ci_workflow_name }}" \
+            --arg workflow_run_id "${{ steps.poll.outputs.success_run_id }}" \
+            --arg workflow_run_url "${{ steps.poll.outputs.success_run_url }}" \
+            --arg workflow_run_name "${{ steps.poll.outputs.success_run_name }}" \
+            --arg artifact_verified "${{ steps.publish.outputs.verified || 'false' }}" \
+            --arg artifact_evidence "${{ steps.publish.outputs.evidence || '' }}" \
             --arg failed_url "${{ steps.poll.outputs.failed_run_url || '' }}" \
             '{
               workspaceId: $ws,
@@ -376,6 +473,12 @@ jobs:
               monitoredAt: $ts,
               ciOutcome: $overall,
               monitorRunId: $run,
+              ciWorkflowName: $ci_workflow,
+              matchedWorkflowRunId: $workflow_run_id,
+              matchedWorkflowRunUrl: $workflow_run_url,
+              matchedWorkflowRunName: $workflow_run_name,
+              artifactVerified: ($artifact_verified == "true"),
+              artifactEvidence: $artifact_evidence,
               failedRunUrl: $failed_url
             }')
 
@@ -400,7 +503,16 @@ jobs:
           echo "| Version | \`${{ steps.inputs.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Commit | \`${{ steps.inputs.outputs.commit_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| CI Outcome | **$OVERALL** |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Workflow | \`${{ steps.inputs.outputs.ci_workflow_name || 'any' }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Source Repo | \`${{ steps.inputs.outputs.source_repo }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact Verified | ${{ steps.publish.outputs.verified || 'false' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact Evidence | ${{ steps.publish.outputs.evidence || 'n/a' }} |" >> "$GITHUB_STEP_SUMMARY"
+          MATCHED_RUN_URL="${{ steps.poll.outputs.success_run_url || steps.poll.outputs.failed_run_url }}"
+          if [ -n "$MATCHED_RUN_URL" ]; then
+            echo "| Matched Run | [$MATCHED_RUN_URL]($MATCHED_RUN_URL) |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| Matched Run | n/a |" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "$OVERALL" = "failure" ] && [ -n "${{ steps.poll.outputs.failed_run_url }}" ]; then
             echo "| Failed Run | [${{ steps.poll.outputs.failed_run_url }}](${{ steps.poll.outputs.failed_run_url }}) |" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/deploy-pipeline-monitor.yml
+++ b/.github/workflows/deploy-pipeline-monitor.yml
@@ -24,8 +24,8 @@ on:
     workflows:
       - "[Corp] Deploy: Apply Source Change"
       - "[Core] CI Monitor Loop"
-      - "[Corp] Fix: CI Lint Errors"
-      - "[Corp] Diagnose: CI Failure"
+      - "[Corp] Fix: CI Lint + Test Errors"
+      - "[Corp] CI: Diagnose Error Logs"
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -106,9 +106,12 @@ jobs:
 
             # Read ci-monitor result
             MONITOR=$(read_state "state/workspaces/${WS_ID}/ci-monitor-${COMP}.json")
-            MONITOR_AT=$(echo "$MONITOR"     | jq -r '.monitoredAt // ""')
-            MONITOR_RESULT=$(echo "$MONITOR" | jq -r '.ciOutcome // ""')
-            MONITOR_RUN=$(echo "$MONITOR"    | jq -r '.monitorRunId // ""')
+            MONITOR_AT=$(echo "$MONITOR"          | jq -r '.monitoredAt // ""')
+            MONITOR_RESULT=$(echo "$MONITOR"      | jq -r '.ciOutcome // ""')
+            MONITOR_RUN=$(echo "$MONITOR"         | jq -r '.monitorRunId // ""')
+            MONITOR_WORKFLOW=$(echo "$MONITOR"    | jq -r '.ciWorkflowName // ""')
+            ARTIFACT_VERIFIED=$(echo "$MONITOR"   | jq -r '.artifactVerified // false')
+            ARTIFACT_EVIDENCE=$(echo "$MONITOR"   | jq -r '.artifactEvidence // ""')
 
             MONITOR_AGE=$(age_min "$MONITOR_AT")
 
@@ -141,8 +144,24 @@ jobs:
                 STAGE="ci-monitoring"
                 HEALTH="ok"
               elif [ "$MONITOR_RESULT" = "success" ]; then
-                STAGE="complete"
-                HEALTH="ok"
+                if [ "$ARTIFACT_VERIFIED" = "true" ]; then
+                  STAGE="complete"
+                  HEALTH="ok"
+                else
+                  STAGE="artifact-unverified"
+                  HEALTH="warning"
+                  OVERALL_STATUS="degraded"
+                  if [ "$MONITOR_AGE" -gt "$ALERT_THRESHOLD_MIN" ]; then
+                    ALERT_NEEDED="${ALERT_NEEDED}${COMP},"
+                  fi
+                fi
+              elif [ "$MONITOR_RESULT" = "artifact-unverified" ]; then
+                STAGE="artifact-unverified"
+                HEALTH="warning"
+                OVERALL_STATUS="degraded"
+                if [ "$MONITOR_AGE" -gt "$ALERT_THRESHOLD_MIN" ]; then
+                  ALERT_NEEDED="${ALERT_NEEDED}${COMP},"
+                fi
               elif [ "$MONITOR_RESULT" = "failure" ]; then
                 STAGE="ci-failed"
                 HEALTH="error"
@@ -175,6 +194,9 @@ jobs:
               --arg gate "$GATE" \
               --arg monitor_at "$MONITOR_AT" \
               --arg monitor_result "$MONITOR_RESULT" \
+              --arg monitor_workflow "$MONITOR_WORKFLOW" \
+              --arg artifact_verified "$ARTIFACT_VERIFIED" \
+              --arg artifact_evidence "$ARTIFACT_EVIDENCE" \
               --arg stage "$STAGE" \
               --arg health "$HEALTH" \
               --arg action "$ACTION_TAKEN" \
@@ -187,6 +209,9 @@ jobs:
                 gateDecision: $gate,
                 ciMonitorResult: $monitor_result,
                 ciMonitorAt: $monitor_at,
+                ciWorkflowName: $monitor_workflow,
+                artifactVerified: ($artifact_verified == "true"),
+                artifactEvidence: $artifact_evidence,
                 stage: $stage,
                 health: $health,
                 actionTaken: $action,
@@ -230,36 +255,13 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           ALERT="${{ steps.status.outputs.alert_needed }}"
-          BODY="Deploy pipeline stuck for components: ${ALERT}. ci-monitor ran but CI still failing after 60+ min. Manual investigation may be needed. Auto-dispatch already triggered."
+          BODY="Deploy pipeline stuck for components: ${ALERT}. The monitor detected a blocked state for more than 60 minutes and promotion is still not complete. Manual investigation may be needed. Auto-dispatch already triggered."
           gh issue create \
             --repo "$AUTOPILOT_REPO" \
             --title "[Pipeline Alert] Stuck deploy pipeline: $ALERT" \
             --body "$BODY" \
             --label "pipeline-alert,autonomous" 2>/dev/null || \
             echo "::warning ::Could not create alert issue"
-
-          # Escalate to Claude Code for intelligent pipeline diagnosis
-          ESCALATION_BODY=$(cat <<'ESCEOF'
-          ## Auto-Escalation from Deploy Pipeline Monitor
-
-          Deploy pipeline stuck for 60+ minutes. ci-monitor-loop was dispatched but CI is still failing.
-
-          ### What to do
-          @claude The deploy pipeline is stuck. Read the latest CI logs from state/workspaces/ws-default/ci-logs-*.txt on autopilot-state. Diagnose the corporate CI failure, create a fix patch, bump the version, and redeploy. Use ci-fix and deploy-monitor skills.
-
-          ### Context
-          - Session memory: contracts/claude-session-memory.json
-          - CI fix patterns: .claude/skills/ci-fix.md
-          - Deploy monitor: .claude/skills/deploy-monitor.md
-          - CI logs: state/workspaces/ws-default/ci-logs-*.txt (autopilot-state)
-          ESCEOF
-          )
-          gh issue create \
-            --repo "$AUTOPILOT_REPO" \
-            --title "[AutoPilot] @claude Pipeline stuck — $ALERT needs intelligent diagnosis" \
-            --label "automated,needs-claude,pipeline-alert" \
-            --body "$ESCALATION_BODY" 2>/dev/null || \
-            echo "::warning ::Could not create Claude escalation issue"
 
       - name: "Write pipeline-status.json to autopilot-state"
         if: always()
@@ -314,15 +316,17 @@ jobs:
           echo "| Trigger | ${{ github.event_name }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Component Status" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Component | Version | Stage | CI Monitor | Health |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----------|---------|-------|------------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Component | Version | Stage | CI Monitor | Artifact | Health |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|---------|-------|------------|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
           AGENT_VER=$(echo "$COMP_STATUS"    | jq -r '.agent.version // "-"')
           AGENT_STAGE=$(echo "$COMP_STATUS"  | jq -r '.agent.stage // "-"')
           AGENT_CI=$(echo "$COMP_STATUS"     | jq -r '.agent.ciMonitorResult // "-"')
+          AGENT_ART=$(echo "$COMP_STATUS"    | jq -r '.agent.artifactVerified // "-"')
           AGENT_H=$(echo "$COMP_STATUS"      | jq -r '.agent.health // "-"')
           CTRL_VER=$(echo "$COMP_STATUS"     | jq -r '.controller.version // "-"')
           CTRL_STAGE=$(echo "$COMP_STATUS"   | jq -r '.controller.stage // "-"')
           CTRL_CI=$(echo "$COMP_STATUS"      | jq -r '.controller.ciMonitorResult // "-"')
+          CTRL_ART=$(echo "$COMP_STATUS"     | jq -r '.controller.artifactVerified // "-"')
           CTRL_H=$(echo "$COMP_STATUS"       | jq -r '.controller.health // "-"')
-          echo "| agent | $AGENT_VER | $AGENT_STAGE | $AGENT_CI | $AGENT_H |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| controller | $CTRL_VER | $CTRL_STAGE | $CTRL_CI | $CTRL_H |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| agent | $AGENT_VER | $AGENT_STAGE | $AGENT_CI | $AGENT_ART | $AGENT_H |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| controller | $CTRL_VER | $CTRL_STAGE | $CTRL_CI | $CTRL_ART | $CTRL_H |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-cap.yml
+++ b/.github/workflows/promote-cap.yml
@@ -128,6 +128,8 @@ jobs:
               -f "content=$(echo "$UPDATED" | base64 -w0)" \
               -f "sha=$VSHA"
             echo "Promoted $COMPONENT to $TAG!"
+          elif echo "$VALUES" | grep -Eq "${IMAGE_PATTERN}${TAG}([[:space:]]|$|[\"'])"; then
+            echo "$COMPONENT already points to $TAG. Nothing to update."
           else
             echo "::warning ::Image pattern didn't match — tag may already be updated"
             echo "Current image line:"

--- a/ops/docs/deploy-process/09-monitor-corporate-ci.md
+++ b/ops/docs/deploy-process/09-monitor-corporate-ci.md
@@ -14,6 +14,25 @@ O workflow `apply-source-change.yml` verifica o CI Gate (Stage 3), mas isso e ap
 
 **O deploy so esta COMPLETO quando a imagem Docker e publicada no registry corporativo.**
 
+## Protocolo Operacional Endurecido
+
+Use este protocolo como regra obrigatoria para qualquer deploy de source code:
+
+1. Monitorar o **commit SHA corporativo correto** gerado pelo Stage 2 do `apply-source-change.yml`
+2. Filtrar apenas a **esteira configurada no `workspace.json`** (`ciWorkflowName`)
+3. Esperar a esteira terminar com **`success`** para o SHA certo
+4. Confirmar nos logs do workflow bem-sucedido a **publicacao da imagem** da versao esperada
+5. So depois disso promover a tag no repositorio de deploy
+6. Se a esteira falhar, expirar ou terminar sem evidencia de publish, **bloquear a promocao**
+
+Resumo direto:
+
+```text
+source push aceito != deploy pronto
+ci verde sem publish confirmado != deploy pronto
+deploy pronto = esteira certa verde + imagem publicada + so entao promocao
+```
+
 ## O que e a Esteira de Build NPM
 
 A esteira corporativa e um pipeline CI/CD que roda em runner corporativo (nao no GitHub Actions do autopilot). Ela executa:
@@ -30,6 +49,16 @@ A esteira corporativa e um pipeline CI/CD que roda em runner corporativo (nao no
 ```
 
 ## Como Monitorar a Esteira
+
+### Regra de Ouro
+
+Nao basta encontrar qualquer workflow verde no repo corporativo. O monitor precisa validar, para o mesmo SHA:
+
+- nome da esteira correto
+- conclusao `success`
+- evidencia de build/publish da imagem da versao esperada
+
+Se qualquer um desses tres pontos faltar, o estado correto e **nao promover**.
 
 ### Metodo 1: Via ci-status-check.yml (Recomendado)
 
@@ -80,6 +109,15 @@ REPO="bbvinet/psc-sre-automacao-controller"
 # Verificar check-runs
 gh api "repos/$REPO/commits/$SHA/check-runs" \
   --jq '.check_runs[] | {name, status, conclusion}'
+```
+
+Para validar a esteira certa no repo corporativo:
+
+```bash
+WORKFLOW="Esteira de Build NPM"
+
+gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=20" \
+  --jq --arg wf "$WORKFLOW" '.workflow_runs[] | select(.name == $wf) | {id, name, status, conclusion, html_url}'
 ```
 
 ### Metodo 3: Via Audit Trail no autopilot-state
@@ -166,7 +204,9 @@ Check-runs: gh api "repos/bbvinet/psc-sre-automacao-controller/commits/def5678/c
 |----------------------|----------------|
 | Workflow run do autopilot | `gh api repos/lucassfreiree/autopilot/actions/runs/<run_id>` |
 | SHA do commit corporativo | `controller-release-state.json` no autopilot-state, campo `lastReleasedSha` |
-| Status da esteira | `ci-status-controller.json` no autopilot-state |
+| Status da esteira | `ci-monitor-controller.json` no autopilot-state |
+| Workflow corporativo validado | `ci-monitor-controller.json`, campos `ciWorkflowName`, `matchedWorkflowRunId`, `matchedWorkflowRunUrl` |
+| Evidencia de publish | `ci-monitor-controller.json`, campos `artifactVerified`, `artifactEvidence` |
 | Logs da esteira | `ci-logs-controller-<job_id>.txt` no autopilot-state |
 | Tag promovida no CAP | `audit/source-change-*.json` no autopilot-state, campo `promoted` |
 
@@ -219,10 +259,13 @@ Agent:
 ## Checklist da Fase 09
 
 - [ ] SHA do commit corporativo identificado (output do Stage 2)
-- [ ] Esteira de Build NPM acionada (check-runs aparecendo)
-- [ ] Status monitorado ate conclusao (success ou failure)
+- [ ] Esteira configurada no workspace acionada
+- [ ] Status monitorado ate conclusao (success ou failure) para o SHA correto
+- [ ] Workflow corporativo correto identificado
 - [ ] Se failure: logs baixados e analisados
+- [ ] Se success: evidencia de publish da imagem da versao esperada confirmada
 - [ ] Se failure: patch corrigido e re-deploy iniciado
+- [ ] Promocao so ocorreu depois da confirmacao de publish
 - [ ] Imagem Docker publicada no registry (deploy COMPLETO)
 - [ ] Resultado registrado na session memory
 

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -34,5 +34,5 @@
   "commit_message": "fix(controller): support new oas sre functions",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 110
+  "run": 111
 }


### PR DESCRIPTION
## Resumo
- restringe o monitor da esteira ao workflow configurado no workspace
- exige evidencia de publicacao da imagem da versao esperada antes de promover deploy
- marca estados intermediarios como artifact-unverified em vez de sucesso prematuro
- corrige nomes de workflows observados pelo deploy-pipeline-monitor
- atualiza a documentacao operacional com o protocolo endurecido

## Validacao
- parse YAML dos workflows alterados
- revisao do diff local
