### PR TITLE
docs: persist source CI and release promotion protocol

### DIFF
--- a/contracts/agent-onboarding.md
+++ b/contracts/agent-onboarding.md
@@ -2,7 +2,7 @@
 
 > This guide enables ANY AI agent to operate the Autopilot control plane.
 > Read this ENTIRELY before performing any operation.
-> Last updated: 2026-03-29
+> Last updated: 2026-04-22
 
 ## 1. What is Autopilot
 
@@ -67,7 +67,7 @@ File: state/workspaces/ws-default/locks/session-lock.json
 | bbvinet/psc_releases_cap_sre-aut-controller | Controller K8s deploy |
 | bbvinet/psc_releases_cap_sre-aut-agent | Agent K8s deploy |
 
-**Access**: Only via workflows (BBVINET_TOKEN). NEVER push directly.
+**Access**: Only via autopilot workflows with `BBVINET_TOKEN`. ALWAYS fetch current files into autopilot, patch and validate there, and NEVER push directly.
 
 ## 5. How to Make Changes
 
@@ -82,16 +82,20 @@ File: state/workspaces/ws-default/locks/session-lock.json
 
 ### To corporate repos (code deploy):
 ```
-1. Create patches in patches/ directory
-2. Update trigger/source-change.json (increment run!)
-3. Branch + PR + merge to main
-4. apply-source-change.yml triggers automatically
-5. Pipeline: Setup → Guard → Apply → CI Gate → Promote → State → Audit
+1. Fetch/pull the live corporate base through autopilot
+2. Create patches in patches/ directory
+3. Validate locally in autopilot before any trigger
+4. Update trigger/source-change.json (increment run!)
+5. Branch + PR + merge to main
+6. apply-source-change.yml triggers automatically
+7. Monitor the exact source SHA, workloads/check-runs, and image publication
+8. Only after source CI is green and the image is published may the CAP/deploy tag be considered valid
 ```
 
 ## 6. Deploy Flow (Step by Step)
 
 ### Phase 1: Prepare
+- Fetch current corporate files first; never patch against stale local assumptions
 - Read trigger/source-change.json for current run number
 - Decide new version (after X.Y.9 → X.(Y+1).0, NEVER X.Y.10)
 - Create patches in patches/ (replace-file or search-replace)
@@ -121,9 +125,10 @@ All files in 1 commit → branch → PR → squash merge → workflow auto-trigg
 
 ### Phase 5: Monitor
 - apply-source-change runs 7 stages
-- ci-monitor-loop polls corporate CI every 2 min
-- If CI passes: promote-cap updates CAP tag
-- If CI fails: ci-diagnose + fix-corporate-ci auto-fix
+- source of truth is the pushed corporate commit SHA plus its workloads/check-runs
+- if workflow_runs are missing, check commit check-runs and image publication evidence
+- CAP/deploy tag update is blocked until source CI is green and the image is published
+- if CI fails: ci-diagnose + fix-corporate-ci auto-fix
 
 ## 7. Compliance Pipeline (4 Stages)
 
@@ -223,7 +228,8 @@ PR → compliance-gate.yml (14 checks) → apply-source-change (7 stages)
 7. ALWAYS monitor workflow after triggering
 8. NEVER assume success — verify via API
 9. After X.Y.9 → X.(Y+1).0 — NEVER X.Y.10
-10. Corporate CI success ≠ deploy complete (build runs after)
+10. Corporate CI success ≠ deploy complete (image publication must be confirmed)
+11. CAP/deploy promotion is invalid while source CI is failing, unknown, or unpublished
 
 ## 13. Auth Architecture (Getronics)
 

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -26,7 +26,7 @@
     "authentication": {
       "autopilotRepo": "GITHUB_TOKEN (disponivel automaticamente no Codex quando rodando no repo lucassfreiree/autopilot)",
       "corporateRepo": "BBVINET_TOKEN (secret do repo — so acessivel dentro de workflows GitHub Actions, NAO diretamente pelo Codex)",
-      "note": "Codex NAO tem acesso direto ao BBVINET_TOKEN. Para acessar repos corporativos, usar workflows (fetch-files.yml, ci-diagnose.yml, apply-source-change.yml)"
+      "note": "Codex NAO tem acesso direto ao BBVINET_TOKEN. Repos corporativos sao operados somente pelo autopilot via workflows (fetch-files.yml, ci-diagnose.yml, apply-source-change.yml, promote-cap.yml)."
     },
     "readState": {
       "description": "Ler estado do autopilot-state branch",
@@ -102,28 +102,30 @@
     }
   },
   "deployFlow": {
-    "description": "FLUXO COMPLETO de deploy — Codex DEVE seguir estes passos na ordem",
+    "description": "FLUXO COMPLETO de deploy — o autopilot e a unica porta para repos corporativos e Codex DEVE seguir estes passos na ordem",
     "steps": [
-      "0. OBRIGATORIO: Buscar arquivos corporativos ATUAIS via fetch-files (base correta)",
-      "1. Verificar versao REAL no repo corporativo (nao confiar so em session memory)",
-      "2. Criar patches MINIMOS a partir da base corporativa ATUAL",
-      "3. OBRIGATORIO: Validar patches (diff vs corporativo, verificar testes, dead code)",
-      "4. Configurar trigger/source-change.json com run incrementado",
-      "5. Atualizar references + CLAUDE.md + session memory",
-      "6. Commit tudo em 1 commit, push branch claude/*, PR, squash merge",
-      "7. Monitorar workflow apply-source-change (polling 30-60s)",
-      "8. Monitorar esteira corporativa ate imagem Docker ser publicada",
-      "9. Stage 4 (Promote) atualiza tag AUTOMATICAMENTE no CAP repo apos CI passar — agent (bbvinet/psc_releases_cap_sre-aut-agent) E controller (bbvinet/psc_releases_cap_sre-aut-controller)",
-      "10. Se falhar: ler logs, diagnosticar, corrigir, re-deploy AUTOMATICAMENTE"
+      "0. OBRIGATORIO: Usar o autopilot como unica porta para repos corporativos; nunca editar ou commitar diretamente neles",
+      "1. OBRIGATORIO: Buscar arquivos corporativos ATUAIS via fetch-files (base correta)",
+      "2. Verificar versao REAL no repo corporativo e no CAP antes de alterar qualquer patch",
+      "3. Criar patches MINIMOS a partir da base corporativa ATUAL",
+      "4. OBRIGATORIO: Validar patches localmente no autopilot (diff, JSON/YAML, testes/checks relevantes, dead code)",
+      "5. Configurar trigger/source-change.json com run incrementado",
+      "6. Atualizar references + memoria + docs operacionais necessarios",
+      "7. Commit tudo no autopilot em 1 commit, push branch claude/* ou codex/*, PR, squash merge",
+      "8. Monitorar workflow apply-source-change ate obter o commit SHA exato do source repo corporativo",
+      "9. Monitorar o commit SHA corporativo correto pelos check-runs/workloads e pela esteira configurada no workspace ate conclusao verde",
+      "10. Confirmar evidencia de publicacao da imagem da versao esperada",
+      "11. So entao considerar valida a promocao da tag no CAP/deploy repo",
+      "12. Se falhar: ler logs, diagnosticar, corrigir, re-deploy AUTOMATICAMENTE sem promover o CAP antes do source repo ficar verde"
     ],
     "preDeployValidation": {
       "workflow": "validate-patches.yml",
       "triggeredBy": "PR com changes em patches/ ou trigger/source-change.json",
       "whatItDoes": "Clona repo corporativo, aplica patches, roda npm ci + tsc + eslint + jest",
-      "rule": "NUNCA mergear PR de deploy se validate-patches falhar"
+      "rule": "NUNCA mergear PR de deploy se validate-patches ou o preflight local falharem"
     },
     "versioningRules": {
-      "currentVersion": "3.6.3",
+      "currentVersion": "3.9.3",
       "pattern": "Apos X.Y.9 vai para X.(Y+1).0 — NUNCA X.Y.10",
       "checkRegistry": "SEMPRE verificar se tag ja existe antes de bumpar",
       "versionFiles": [
@@ -154,11 +156,11 @@
     "stateAccess": "Use gh CLI to read/write state on autopilot-state branch. See githubConnection.readState for commands.",
     "lockProtocol": "Check locks/ directory via gh api before starting operations. Always release locks on completion.",
     "sessionGuard": "CRITICAL: Before any state-changing operation, check session-lock.json. If locked by claude-code, ABORT and create a handoff instead.",
-    "releaseProtocol": "Follow workspace.json config, use gh CLI for API operations. Follow deployFlow steps exactly.",
+    "releaseProtocol": "Follow workspace.json config, use gh CLI for API operations, and operate corporate repos only through autopilot workflows. Follow deployFlow steps exactly.",
     "handoffProtocol": "Read pending handoffs via gh api, update status on completion",
     "auditProtocol": "Record actions via gh api to audit directory after every state mutation",
-    "sourceCodeChanges": "Use apply-source-change.yml workflow or trigger file. ALWAYS validate patches first. Never push directly to corporate repos.",
-    "monitoringProtocol": "ALWAYS monitor both autopilot workflow AND corporate esteira. Deploy is NOT complete until Docker image is published. Poll every 30-60s.",
+    "sourceCodeChanges": "Corporate source changes live in autopilot. Always fetch the current corporate files first, implement patches only in autopilot, validate locally, then use apply-source-change.yml or trigger/source-change.json. Never push directly to corporate repos.",
+    "monitoringProtocol": "ALWAYS monitor the autopilot workflow plus the exact corporate source commit SHA. Use commit check-runs/workloads as the primary signal when workflow_runs are absent or renamed. Deploy is NOT complete until the expected Docker image is published, and CAP promotion is NOT valid before that. Poll every 30-60s.",
     "errorRecovery": "If deploy fails: read ci-logs-controller-*.txt from autopilot-state, diagnose, fix, re-deploy AUTOMATICALLY without asking user."
   },
   "memoryProtocol": {
@@ -194,6 +196,7 @@
       "Nunca operar sem workspace_id identificado",
       "Nunca misturar contextos entre workspaces",
       "Nunca mergear PR de deploy se validate-patches falhar",
+      "Nunca promover tag CAP/deploy se o source repo nao estiver verde com a imagem publicada",
       "Sempre monitorar workflows e esteira corporativa apos merge"
     ],
     "sourceOfTruth": [
@@ -209,9 +212,11 @@
       "5. Push da branch de trabalho",
       "6. Abrir PR para main com contexto tecnico completo",
       "7. Monitorar checks/workflows ate conclusao",
-      "8. Resolver conflitos/falhas automaticamente quando possivel",
-      "9. Realizar squash merge quando policy gates passarem",
-      "10. Monitorar pos-merge (workflows + esteira corporativa quando aplicavel)"
+      "8. Monitorar o commit SHA do source repo corporativo ate a esteira/workloads ficarem verdes e a imagem ser publicada",
+      "9. So depois disso permitir a promocao do deploy repo/CAP",
+      "10. Resolver conflitos/falhas automaticamente quando possivel",
+      "11. Realizar squash merge quando policy gates passarem",
+      "12. Monitorar pos-merge (workflows + esteira corporativa quando aplicavel)"
     ],
     "autopilotCommitWorkflowChain": [
       "[Agent] Auto PR + Auto-Merge (Codex) (push)",

--- a/contracts/codex-deploy-guide.md
+++ b/contracts/codex-deploy-guide.md
@@ -1,8 +1,8 @@
 # Codex Deploy Guide — Using the Existing Pipeline
 
 > This guide teaches Codex how to use the EXISTING deploy pipeline (`apply-source-change.yml`)
-> to deploy code changes to corporate repos. NO new workflows needed.
-> This is the SAME flow Claude uses. Follow it step by step.
+> to deploy code changes to corporate repos through the autopilot control plane.
+> Corporate repos are never edited directly from the session. Follow this flow step by step.
 
 ## Prerequisites
 
@@ -13,13 +13,15 @@ Before deploying, you need:
 
 ## The Flow (Same as Claude)
 
-```
-1. Fetch current corporate files (know what exists today)
+```text
+1. Fetch current corporate files through autopilot (know what exists today)
 2. Create patch files in patches/
-3. Update trigger/source-change.json (increment run!)
-4. Push to codex/* branch → auto-pr-codex.yml creates PR
-5. Merge PR → apply-source-change.yml triggers automatically
-6. Monitor until complete
+3. Validate locally in autopilot before any trigger
+4. Update trigger/source-change.json (increment run!)
+5. Push to codex/* branch -> PR -> merge
+6. Monitor apply-source-change until the corporate source SHA is known
+7. Monitor the corporate source SHA, workloads/check-runs, and image publication
+8. Only then is CAP/deploy tag promotion valid
 ```
 
 ---
@@ -75,9 +77,28 @@ No file needed — configured directly in trigger/source-change.json:
 
 ---
 
-## Step 3: Update trigger/source-change.json
+## Step 3: Run Local Validation in Autopilot
 
-This is the MOST IMPORTANT file. The workflow `apply-source-change.yml` reads this.
+Before opening the PR that will trigger the corporate flow, validate the local autopilot side:
+
+```bash
+# Recommended minimums for deploy metadata changes
+jq empty trigger/source-change.json
+jq empty contracts/codex-agent-contract.json
+
+# If workflows/contracts changed, parse them too
+scripts/codex/preflight-autopilot.sh
+```
+
+If the change also updates code patches, validate the patch content against the fetched corporate base and run the relevant local checks before triggering the corporate source pipeline.
+
+**RULE**: If local validation fails, do not trigger the corporate pipeline.
+
+---
+
+## Step 4: Update trigger/source-change.json
+
+This is the MOST IMPORTANT file. The workflow `apply-source-change.yml` reads this and it is the only valid path to reach the corporate source repo.
 
 ```json
 {
@@ -127,7 +148,7 @@ This is the MOST IMPORTANT file. The workflow `apply-source-change.yml` reads th
 
 ---
 
-## Step 4: Push to codex/* Branch
+## Step 5: Push to codex/* Branch
 
 ```bash
 # Create branch from latest main
@@ -160,7 +181,7 @@ gh pr create --base main --head codex/deploy-v3.6.4 \
 
 ---
 
-## Step 5: Merge the PR
+## Step 6: Merge the PR
 
 ```bash
 # Check PR status
@@ -171,10 +192,11 @@ gh pr merge <PR_NUMBER> --squash
 ```
 
 **After merge**: `apply-source-change.yml` triggers AUTOMATICALLY because `trigger/source-change.json` changed.
+This does not mean deploy is complete. It only means the corporate source change path started.
 
 ---
 
-## Step 6: Monitor the Deploy
+## Step 7: Monitor the Deploy
 
 ```bash
 # Check if workflow triggered (wait ~30s after merge)
@@ -192,10 +214,33 @@ gh api repos/lucassfreiree/autopilot/actions/runs/<RUN_ID>/jobs \
 | Setup | Reads workspace config | Check workspace.json |
 | Session Guard | Acquires lock | Wait if another agent has lock |
 | Apply & Push | Clone corporate repo, apply patches, push | Check patches are valid |
-| CI Gate | Waits for corporate CI (Esteira de Build NPM) | Check ci-logs |
-| Promote | Updates CAP values.yaml (agent + controller — BOTH auto-promote via GitHub API) | Check workspace.json CAP config |
+| CI Gate | Waits for the corporate source pipeline signal for the pushed SHA | Check ci-logs and phase 09 |
+| Promote | CAP/deploy tag update is only valid after source CI is green and image publication is confirmed | Block/correct if it happened early |
 | Save State | Records in autopilot-state | Retry |
 | Audit | Audit trail + release lock | Usually succeeds |
+
+### Mandatory source-repo follow-up
+
+After Stage 2, keep monitoring the exact corporate source SHA:
+
+```bash
+SHA="<corporate_source_sha>"
+REPO="bbvinet/psc-sre-automacao-controller"
+
+gh api "repos/$REPO/commits/$SHA/check-runs" \
+  --jq '.check_runs[] | {name, status, conclusion}'
+```
+
+If `workflow_runs` do not show the configured workflow name, do not assume nothing arrived. Some repos expose the source pipeline primarily via commit check-runs or differently named workloads. In that case, the source of truth is still the corporate commit SHA plus its checks and image publication evidence.
+
+### Promotion rule
+
+Only after all of the following are true is the deploy valid:
+
+1. The correct corporate source SHA finished green.
+2. The expected corporate workload/check-runs finished green.
+3. The target image version was published.
+4. The CAP/deploy repo tag matches that published version.
 
 ### If Deploy Fails:
 1. Check which step failed: `gh api repos/lucassfreiree/autopilot/actions/runs/<RUN_ID>/jobs`
@@ -235,6 +280,9 @@ gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/locks
 | Branch not codex/* | auto-pr doesn't trigger | Use `codex/deploy-*` prefix |
 | Duplicate version tag | CI rejects | Check registry, use next version |
 | Patch based on old code | Patch doesn't apply | Fetch current files first |
+| Missing source SHA monitoring | CAP can drift from source CI result | Always monitor the pushed corporate SHA |
+| Assume missing workflow_run means no CI | Source checks may exist only as check-runs/workloads | Check `commits/<sha>/check-runs` first |
+| Promote CAP before image publish | Deploy repo points to a version not validated in source CI | Block promotion until publish is confirmed |
 | Missing version bump in swagger | Version mismatch | Always bump all 3: package.json, package-lock.json, swagger.json |
 | validateTrustedUrl in fetch | Tests break (mock URLs) | NEVER — use parseSafeIdentifier on input |
 | ESLint no-use-before-define | CI fails | Define functions BEFORE using them |
@@ -479,9 +527,9 @@ gh api "repos/lucassfreiree/autopilot/contents/state/workspaces/ws-default/<LATE
 
 ---
 
-## ADVANCED: CAP Promote (Auto-promote for Agent + Controller)
+## ADVANCED: CAP Promote (Only After Source Repo Green)
 
-Stage 4 of `apply-source-change.yml` now auto-promotes BOTH components:
+Stage 4 of `apply-source-change.yml` or `promote-cap.yml` only becomes valid AFTER the source repo is green for the correct SHA and the expected image was published:
 
 | Component | CAP Repo (GitHub) | Values Path |
 |-----------|-------------------|-------------|
@@ -489,15 +537,15 @@ Stage 4 of `apply-source-change.yml` now auto-promotes BOTH components:
 | Controller | `bbvinet/psc_releases_cap_sre-aut-controller` | `releases/openshift/hml/deploy/values.yaml` |
 
 ### How it works:
-1. After CI Gate passes (corporate CI green)
+1. After the correct source SHA is green and image publication is confirmed
 2. Workflow reads `workspace.json` for CAP config (agent.capRepo or controller.capRepo)
 3. Reads current `values.yaml` from GitHub
 4. Updates image tag line: `image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-<component>:<NEW_TAG>`
 5. Commits to CAP repo via GitHub API with `BBVINET_TOKEN`
 
 ### When promote=true in trigger:
-- Promote runs AUTOMATICALLY after CI passes
-- No manual intervention needed
+- Promote may run from the workflow, but it is only valid after source CI/workloads and publish confirmation
+- Never use promote as a shortcut around a failing or unknown source pipeline
 - Both agent and controller CAP repos are on GitHub
 
 ### Image line in values.yaml:

--- a/contracts/codex-session-memory.json
+++ b/contracts/codex-session-memory.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 1,
-  "lastUpdated": "2026-04-02T14:24:00Z",
-  "sessionCount": 8,
+  "lastUpdated": "2026-04-22T21:07:44Z",
+  "sessionCount": 9,
   "currentState": {
-    "controllerVersion": "3.8.0-run94",
+    "controllerVersion": "3.9.3",
     "agentVersion": "2.2.9",
-    "lastTriggerRun": 94,
+    "lastTriggerRun": 111,
     "lastSuccessfulRun": 66,
     "workspace": "ws-default",
-    "pipelineStatus": "controller-run94-tsconfig-fix"
+    "pipelineStatus": "controller-source-ci-must-pass-before-cap-promotion"
   },
   "sessionsLog": [
     {
@@ -30,6 +30,11 @@
       "timestamp": "2026-04-02T14:24:00Z",
       "topic": "controller-run94-fix",
       "action": "Confirmed run 93 was a no-op because its tsconfig search string expected ignoreDeprecations to already exist. Triggered run 94 against the live 3.8.0 tsconfig prefix and kept the release line on 3.8.0."
+    },
+    {
+      "timestamp": "2026-04-22T21:07:44Z",
+      "topic": "controller-source-ci-promotion-protocol",
+      "action": "Registered the permanent rule that corporate source and deploy repos must be operated only through autopilot: fetch the live corporate base first, implement patches and validations in autopilot, trigger the corporate source pipeline through BBVINET_TOKEN, monitor the exact source commit SHA plus corporate workloads/check-runs, confirm image publication for the target version, and only then treat CAP/deploy tag promotion as valid."
     }
   ],
   "decisions": [
@@ -52,6 +57,11 @@
       "timestamp": "2026-04-02T14:24:00Z",
       "decision": "Run 94 must target the live tsconfig prefix \"compilerOptions\": {  \"types\": [\"node\"], rather than the intermediate ignoreDeprecations form used by run 93.",
       "reason": "The fresh fetch-files result proved that the corporate file never received the earlier patch, so reusing the run 93 search string would stay a no-op."
+    },
+    {
+      "timestamp": "2026-04-22T21:07:44Z",
+      "decision": "Corporate repos must always be changed through autopilot fetch/patch/test/trigger flow, and CAP release tag changes are blocked until the source repo is green with image publication confirmed.",
+      "reason": "Direct assumptions or premature promotion can desynchronize source and deploy state. The source repo commit, workloads/check-runs, and image publication are the required release gate."
     }
   ],
   "lessonsLearned": [
@@ -78,6 +88,14 @@
     {
       "timestamp": "2026-04-02T14:24:00Z",
       "lesson": "When a source-change run is a no-op, the fastest proof is the fetched corporate file itself; if it still shows the old prefix, fix the trigger search string before waiting on stale diagnosis output."
+    },
+    {
+      "timestamp": "2026-04-22T21:07:44Z",
+      "lesson": "Corporate repos are not edited directly from the session. Autopilot is the only control plane: fetch current files, prepare patches locally, validate locally, and let BBVINET_TOKEN workflows push to the corporate source repo."
+    },
+    {
+      "timestamp": "2026-04-22T21:07:44Z",
+      "lesson": "If workflow_runs are missing or differently named, that does not mean the corporate CI did not start. The source-of-truth monitor is the pushed corporate commit SHA plus its check-runs/workloads and image publication evidence."
     }
   ],
   "errorPatterns": {
@@ -111,6 +129,16 @@
       ],
       "rootCause": "The trigger searched for an intermediate tsconfig shape with ignoreDeprecations already present, but the live file never had that prefix.",
       "fix": "Patch the live prefix directly in a new source-change run while keeping the release on 3.8.0."
+    },
+    "corporate_ci_observability_gap": {
+      "observedAt": "2026-04-22T21:07:44Z",
+      "symptoms": [
+        "source commit was pushed to the corporate repo",
+        "actions workflow_runs do not show the expected workflow name",
+        "commit check-runs or workloads exist for the same SHA"
+      ],
+      "rootCause": "Monitoring relied too heavily on exact workflow_run name matching. Some corporate repos expose the source pipeline primarily through commit check-runs or differently named workloads.",
+      "fix": "Track the exact corporate commit SHA, use check-runs/workloads as the primary signal, confirm image publication for the expected version, and keep CAP promotion blocked until those signals are green."
     }
   }
 }

--- a/contracts/shared-agent-context.md
+++ b/contracts/shared-agent-context.md
@@ -1,7 +1,7 @@
 # Autopilot Shared Agent Context
 > This file is injected into ALL agent prompts (Claude, Codex, Copilot).
 > It contains the essential context every agent needs to operate correctly.
-> Last updated: 2026-04-04
+> Last updated: 2026-04-22
 
 ## What is Autopilot
 Web-only CI/CD control plane for multi-workspace, multi-agent release orchestration.
@@ -45,11 +45,11 @@ Internal autopilot references (CLAUDE.md, session memory, contracts) are OK — 
 - Every commit, issue, and PR for workspace-specific work MUST include workspace_id
 
 ## Current State (ws-default — Getronics/BB)
-- **Controller version**: 3.8.2 (deployed and verified)
+- **Controller target version**: 3.9.3 (source change prepared and under source CI gating)
 - **Agent version**: 2.3.3 (deployed and verified)
 - **Last successful deploy run**: #103
-- **Last trigger run**: 103
-- **Pipeline status**: operational
+- **Last trigger run**: 111
+- **Pipeline status**: source CI must pass and publish the image before CAP promotion is valid
 - **Autopilot product version**: 1.0.3
 
 ## Current State (ws-cit — CIT/Itau)
@@ -68,15 +68,16 @@ Internal autopilot references (CLAUDE.md, session memory, contracts) are OK — 
 ## Deploy Flow (Mandatory Steps)
 1. Fetch current corporate files via `fetch-files.yml`
 2. Create minimal patches in `patches/` from CURRENT corporate base
-3. Validate via `validate-patches.yml` (clone + npm ci + tsc + eslint + jest)
+3. Validate in autopilot first (`validate-patches.yml` and local preflight/checks when applicable)
 4. Update `trigger/source-change.json` (increment `run` field!)
 5. Update `references/controller-cap/values.yaml` + session memory
 6. Branch `claude/*` or `codex/*` > PR > squash merge to main
 7. Workflow auto-triggers on merge (path: trigger/source-change.json)
-8. Monitor workflow + corporate CI until Docker image published
+8. Monitor the exact pushed corporate source SHA plus check-runs/workloads until Docker image is published
+9. Only then is CAP/deploy tag promotion valid
 
 ## Versioning Rules
-- Current: 3.6.3. Next: 3.6.4 (or 3.7.0 if after 3.6.9)
+- Current controller target: 3.9.3. Next: 3.9.4 (or 3.10.0 if after 3.9.9)
 - Pattern: After X.Y.9 goes to X.(Y+1).0 - NEVER X.Y.10
 - 4 files must be aligned: package.json, package-lock.json (2 places), swagger.json
 - CI rejects duplicate tags - always check before bumping
@@ -117,7 +118,7 @@ Codex can commit via `codex-apply.yml` workflow:
 | Agent 401 internal-origin | Controller must mint JWT via mintInternalOriginJwt() | `Unauthorized` + internal-origin |
 | JWT scope claim wrong | Agent reads `payload.scope` (singular), NEVER `scopes` | `Insufficient scope` |
 | validateTrustedUrl in fetch | NEVER - breaks mock tests. Use parseSafeIdentifier on input | Test failures with mock URLs |
-| CI Gate pre-existing bug | CI Gate NOT reliable. Check ci-logs-controller-*.txt for REAL status | ci-failed-preexisting |
+| CI Gate / workflow name mismatch | Workflow runs may be absent or renamed. Check the pushed corporate SHA, commit check-runs, workloads, and image evidence for the REAL status | ci-failed-preexisting |
 | Swagger garbled chars | ASCII only, NEVER accents | UTF-8 encoding errors |
 | Push to main 403 | Always use branch + PR + squash merge | HTTP 403 |
 

--- a/ops/docs/deploy-process/01-overview-and-prerequisites.md
+++ b/ops/docs/deploy-process/01-overview-and-prerequisites.md
@@ -178,8 +178,9 @@ autopilot/
    --> Clone repo corporativo (BBVINET_TOKEN)
    --> Aplica patches no clone
    --> Push para main do repo corporativo
-   --> Esteira de Build NPM roda (CI corporativo)
-   --> Se CI passou: atualiza tag no CAP (auto-promote)
+   --> Esteira de Build NPM / workloads do source repo rodam
+   --> Confirmar source CI verde + imagem publicada
+   --> So entao atualizar tag no CAP
    --> Salva estado no autopilot-state
    --> Registra audit trail
 ```

--- a/ops/docs/deploy-process/05-version-bump.md
+++ b/ops/docs/deploy-process/05-version-bump.md
@@ -117,12 +117,12 @@ Se usar search-replace com `"3.6.6"` e o swagger estiver com `"3.5.14"`, o sed n
 **Metodo de atualizacao:** Edicao manual no autopilot
 
 ```yaml
-# Controller CAP Values - GitHub (auto-promote enabled)
+# Controller CAP Values - GitHub (promotion only after source CI + publish)
 # ...
 # Current tag: 3.6.6   <-- Atualizar aqui
 ```
 
-**NOTA**: Este arquivo e uma referencia LOCAL. A atualizacao REAL no CAP repo e feita automaticamente pelo Stage 4 (Promote) do workflow. Mas e importante manter a referencia local atualizada.
+**NOTA**: Este arquivo e uma referencia LOCAL. A atualizacao REAL no CAP repo so e valida depois que o source repo ficar verde e a imagem for publicada. Mas e importante manter a referencia local atualizada.
 
 Alem disso, a tag da imagem Docker dentro do values.yaml:
 ```yaml

--- a/ops/docs/deploy-process/08-monitor-autopilot-workflow.md
+++ b/ops/docs/deploy-process/08-monitor-autopilot-workflow.md
@@ -253,9 +253,9 @@ DATA=$(gh api "repos/$REPO/commits/$SHA/check-runs" --jq '{
 | Resultado | Significado | Proxima acao |
 |-----------|-------------|--------------|
 | `success` | Todos os checks passaram | Prosseguir para Stage 4 |
-| `failure` | Algum check falhou | Verificar se pre-existente |
-| `no-ci` | Nenhum check encontrado | Prosseguir com warning |
-| `timeout` | Checks nao completaram em 20 min | Prosseguir com warning |
+| `failure` | Algum check falhou | Bloquear promote e verificar logs/source SHA |
+| `no-ci` | Nenhum check encontrado | Bloquear promote ate encontrar checks/workloads do SHA |
+| `timeout` | Checks nao completaram em 20 min | Bloquear promote ate concluir source CI/workloads |
 
 #### Fase 3: Smart CI — Pre-existing Detection
 Se CI falhou, verifica se a falha ja existia ANTES do nosso commit:
@@ -269,12 +269,12 @@ Se CI falhou, verifica se a falha ja existia ANTES do nosso commit:
 | CI Result | Pre-existing | Decision | Acao |
 |-----------|:------------:|----------|------|
 | success | - | `pass` | Continua normalmente |
-| no-ci | - | `pass` | Continua com warning |
-| failure | true | `pass-preexisting` | Continua (falha nao e nossa) |
-| failure | unknown | `pass-unknown` | Continua com cautela |
+| no-ci | - | `block-no-ci` | **PARA** — sem evidencia suficiente do source pipeline |
+| failure | true | `block-preexisting` | **PARA** — falha pode ser pre-existente, mas promocao continua bloqueada |
+| failure | unknown | `block-unknown` | **PARA** — sem prova de source pipeline verde |
 | failure | false | `block` | **PARA** — nossa mudanca quebrou o CI |
 
-**ATENCAO**: A deteccao de pre-existing tem um bug conhecido. Pode reportar `failure` mesmo quando a esteira passou. Para resultado REAL, verificar os logs da esteira corporativa (ver fase 09).
+**ATENCAO**: A deteccao de pre-existing e o nome exato do workflow nao sao suficientes para aprovar o deploy. Para resultado REAL, verificar o SHA corporativo, seus check-runs/workloads e a evidencia de publish da imagem (ver fase 09).
 
 ---
 
@@ -283,7 +283,7 @@ Se CI falhou, verifica se a falha ja existia ANTES do nosso commit:
 **Job name**: `4. Promote to CAP (<component>)`
 **Runner**: `ubuntu-latest`
 **Depends on**: Setup, Apply & Push, CI Gate
-**Condicao**: `promote == 'true'` AND CI Gate nao falhou
+**Condicao**: `promote == 'true'` AND source CI/workloads verdes para o SHA correto AND imagem publicada
 **Duracao tipica**: 10-30 segundos
 
 **O que faz:**
@@ -291,6 +291,8 @@ Se CI falhou, verifica se a falha ja existia ANTES do nosso commit:
 2. Le o `values.yaml` atual do repo CAP via GitHub API
 3. Substitui a tag da imagem Docker usando sed com o `imagePattern`
 4. Faz commit no CAP repo via GitHub API
+
+**Regra operacional**: Se houver qualquer duvida sobre o estado do source repo, a promocao deve continuar bloqueada mesmo que o job exista ou o CI Gate inicial tenha retornado algum status parcial.
 
 **Para Controller:**
 ```bash
@@ -351,10 +353,10 @@ state/workspaces/<ws_id>/<component>-release-state.json
 **Status possiveis:**
 | Status | Significado |
 |--------|-------------|
-| `promoted` | CI passou + CAP atualizado |
-| `promoted-preexisting-ci-fail` | CI falhou (pre-existente) + CAP atualizado |
-| `ci-passed` | CI passou, promote nao habilitado |
-| `ci-failed-preexisting` | CI falhou (pre-existente), sem promote |
+| `promoted` | Source CI passou + imagem publicada + CAP atualizado |
+| `promoted-preexisting-ci-fail` | Estado historico invalido; investigar se houve promocao antecipada |
+| `ci-passed` | Source CI passou, promote nao habilitado |
+| `ci-failed-preexisting` | Source CI falhou/pre-existente, sem promote valido |
 | `ci-failed` | CI falhou por nossa mudanca |
 | `pending` | Status indefinido |
 
@@ -439,8 +441,9 @@ gh api repos/lucassfreiree/autopilot/actions/runs/<RUN_ID>/jobs \
 - [ ] Stage 1 (Setup) completou com sucesso
 - [ ] Stage 1.5 (Session Guard) adquiriu lock
 - [ ] Stage 2 (Apply & Push) pushou com sucesso (sha != null)
-- [ ] Stage 3 (CI Gate) completou (success/pass-preexisting)
-- [ ] Stage 4 (Promote) atualizou tag no CAP
+- [ ] Stage 3 (CI Gate) completou com um sinal valido para o SHA certo
+- [ ] Source CI/workloads do SHA correto terminaram verdes e com publish confirmado
+- [ ] Stage 4 (Promote) atualizou tag no CAP somente depois desse gate
 - [ ] Stage 5 (Save State) salvou estado
 - [ ] Stage 6 (Audit) registrou trail e liberou lock
 - [ ] Usuario notificado do resultado

--- a/ops/docs/deploy-process/09-monitor-corporate-ci.md
+++ b/ops/docs/deploy-process/09-monitor-corporate-ci.md
@@ -2,7 +2,7 @@
 
 ## Objetivo
 
-Acompanhar a Esteira de Build NPM que roda no repo corporativo APOS o push feito pelo Stage 2 do apply-source-change. Esta esteira e INDEPENDENTE do workflow do autopilot.
+Acompanhar o pipeline do source repo corporativo APOS o push feito pelo Stage 2 do apply-source-change. A esteira e INDEPENDENTE do workflow do autopilot e deve ser rastreada pelo commit SHA corporativo correto.
 
 ## CRITICO: apply-source-change SUCCESS != Deploy Completo
 
@@ -19,11 +19,13 @@ O workflow `apply-source-change.yml` verifica o CI Gate (Stage 3), mas isso e ap
 Use este protocolo como regra obrigatoria para qualquer deploy de source code:
 
 1. Monitorar o **commit SHA corporativo correto** gerado pelo Stage 2 do `apply-source-change.yml`
-2. Filtrar apenas a **esteira configurada no `workspace.json`** (`ciWorkflowName`)
+2. Usar a **esteira configurada no `workspace.json`** (`ciWorkflowName`) como pista inicial, mas validar sempre pelo commit SHA corporativo
 3. Esperar a esteira terminar com **`success`** para o SHA certo
 4. Confirmar nos logs do workflow bem-sucedido a **publicacao da imagem** da versao esperada
 5. So depois disso promover a tag no repositorio de deploy
 6. Se a esteira falhar, expirar ou terminar sem evidencia de publish, **bloquear a promocao**
+
+Se `workflow_runs` vier vazio, mas o SHA tiver `check-runs` ou workloads ativos, isso NAO significa ausencia de CI. Nesse caso, o source of truth continua sendo o commit SHA corporativo, seus checks e a evidencia de publish.
 
 Resumo direto:
 
@@ -91,7 +93,7 @@ Dispara o workflow `ci-status-check.yml` que verifica o status de CI no repo cor
   },
   "checkRuns": [
     {
-      "name": "Esteira de Build NPM",
+      "name": "CI / workflow-npm",
       "status": "completed",
       "conclusion": "success"
     }
@@ -119,6 +121,8 @@ WORKFLOW="Esteira de Build NPM"
 gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=20" \
   --jq --arg wf "$WORKFLOW" '.workflow_runs[] | select(.name == $wf) | {id, name, status, conclusion, html_url}'
 ```
+
+**Regra importante**: Se esse filtro nao retornar nada, volte para `check-runs` do commit. Alguns repositorios expoem a execucao real por nomes como `CI / workflow-npm`, `CI / sonarQube`, `CI / xRay` ou apenas como checks do SHA.
 
 ### Metodo 3: Via Audit Trail no autopilot-state
 
@@ -205,10 +209,21 @@ Check-runs: gh api "repos/bbvinet/psc-sre-automacao-controller/commits/def5678/c
 | Workflow run do autopilot | `gh api repos/lucassfreiree/autopilot/actions/runs/<run_id>` |
 | SHA do commit corporativo | `controller-release-state.json` no autopilot-state, campo `lastReleasedSha` |
 | Status da esteira | `ci-monitor-controller.json` no autopilot-state |
-| Workflow corporativo validado | `ci-monitor-controller.json`, campos `ciWorkflowName`, `matchedWorkflowRunId`, `matchedWorkflowRunUrl` |
+| Workflow corporativo validado | `ci-monitor-controller.json`, campos `ciWorkflowName`, `matchedWorkflowRunId`, `matchedWorkflowRunUrl`, ou os `checkRuns` do mesmo SHA |
 | Evidencia de publish | `ci-monitor-controller.json`, campos `artifactVerified`, `artifactEvidence` |
 | Logs da esteira | `ci-logs-controller-<job_id>.txt` no autopilot-state |
 | Tag promovida no CAP | `audit/source-change-*.json` no autopilot-state, campo `promoted` |
+
+## Quando parecer que nao chegou nada
+
+Se o monitor nao encontrar `workflow_runs` com o nome exato do `workspace.json`, faca esta validacao antes de concluir que a esteira nao disparou:
+
+1. Confirmar o SHA corporativo salvo pelo Stage 2.
+2. Ler `commits/<sha>/check-runs`.
+3. Verificar workloads/checks corporativos para o mesmo SHA.
+4. Procurar evidencia de publish da versao esperada.
+
+Se os checks do SHA existem, o commit chegou na esteira. O problema passa a ser de correlacao/observabilidade, nao de disparo.
 
 ## Se a Esteira Falhar
 
@@ -259,9 +274,9 @@ Agent:
 ## Checklist da Fase 09
 
 - [ ] SHA do commit corporativo identificado (output do Stage 2)
-- [ ] Esteira configurada no workspace acionada
+- [ ] Esteira configurada no workspace ou checks/workloads equivalentes acionados para o SHA correto
 - [ ] Status monitorado ate conclusao (success ou failure) para o SHA correto
-- [ ] Workflow corporativo correto identificado
+- [ ] Workflow corporativo correto identificado, ou checks corporativos do mesmo SHA identificados
 - [ ] Se failure: logs baixados e analisados
 - [ ] Se success: evidencia de publish da imagem da versao esperada confirmada
 - [ ] Se failure: patch corrigido e re-deploy iniciado

--- a/ops/docs/deploy-process/10-cap-tag-promotion.md
+++ b/ops/docs/deploy-process/10-cap-tag-promotion.md
@@ -2,7 +2,7 @@
 
 ## Objetivo
 
-Verificar e confirmar que a tag da imagem Docker foi atualizada no arquivo `values.yaml` do repositorio CAP. Esta e a etapa que efetivamente atualiza qual versao esta deployada no cluster Kubernetes.
+Verificar e confirmar que a tag da imagem Docker foi atualizada no arquivo `values.yaml` do repositorio CAP somente DEPOIS que o source repo corporativo ficou verde e publicou a imagem da versao esperada. Esta e a etapa que efetivamente atualiza qual versao esta deployada no cluster Kubernetes.
 
 ## O que e o CAP
 
@@ -28,7 +28,9 @@ image: ***REDACTED***/bb/psc/psc-sre-automacao-controller:3.6.7
 
 ### Stage 4 do apply-source-change.yml
 
-O Stage 4 (Promote) roda **automaticamente** se `promote=true` no trigger E o CI Gate passou.
+O Stage 4 (Promote) so pode ser considerado VALIDO se `promote=true` no trigger, o source repo corporativo estiver verde para o SHA correto e a imagem da versao esperada estiver publicada.
+
+Se existir atualizacao de CAP com source CI falhando, desconhecido, sem publish confirmado ou sem correlacao com o SHA correto, trate isso como inconsistencia operacional e bloqueie a promocao.
 
 **Fluxo interno:**
 
@@ -62,6 +64,13 @@ Branch: main
 ```
 
 ## Verificar se a Promocao Ocorreu
+
+Antes de aceitar a promocao como valida, confirme os 4 gates:
+
+1. `lastReleasedSha` aponta para o SHA corporativo correto
+2. O source repo terminou verde para esse SHA
+3. A imagem da versao esperada foi publicada
+4. O `values.yaml` do CAP aponta para a mesma versao publicada
 
 ### Metodo 1: Via Release State
 
@@ -126,6 +135,8 @@ Se o Stage 4 falhar por algum motivo, usar o workflow standalone `promote-cap.ym
 ### Mergear em main:
 O workflow `promote-cap.yml` dispara e atualiza a tag no CAP repo.
 
+**Regra**: o promote manual segue o mesmo gate. Nunca usar `promote-cap.yml` para contornar source CI falhando ou imagem ainda nao publicada.
+
 ## Atualizar Referencia Local
 
 Apos promote confirmado, atualizar a referencia local no autopilot:
@@ -152,19 +163,22 @@ image: ***REDACTED***/bb/psc/psc-sre-automacao-controller:3.6.7
    → npm ci → build → lint → test → Docker build → Docker push
    → Imagem: ***REDACTED***/bb/psc/psc-sre-automacao-controller:3.6.7
 
-3. CI Gate detecta success (Stage 3)
-   → check-runs: all completed, all success
+3. Source CI/workloads terminam verdes
+   → check-runs/workloads do SHA correto finalizados com success
 
-4. Promote atualiza CAP (Stage 4)
+4. Imagem da versao esperada e publicada
+   → registry corporativo contem a nova tag
+
+5. Promote atualiza CAP (Stage 4 ou promote-cap)
    → values.yaml: image tag → 3.6.7
    → Commit no CAP repo
 
-5. Pipeline de deploy do cluster le o CAP (externo ao autopilot)
+6. Pipeline de deploy do cluster le o CAP (externo ao autopilot)
    → Detecta mudanca no values.yaml
    → Faz rolling update do Deployment
    → Pod com nova imagem 3.6.7 sobe
 
-6. Aplicacao rodando com versao 3.6.7
+7. Aplicacao rodando com versao 3.6.7
    → Verificar: curl -s https://sre-aut-controller.psc.k8shmlbb111b.bb.com.br/health
 ```
 
@@ -177,10 +191,13 @@ image: ***REDACTED***/bb/psc/psc-sre-automacao-controller:3.6.7
 | `promoted=false` (sem erro) | sed nao encontrou o padrao | Verificar formato da linha `image:` no values.yaml |
 | `promoted=skipped` | Component nao tem CAP configurado | Configurar capRepo no workspace.json |
 | 403 no commit | Token sem permissao de escrita no CAP | Verificar scopes do BBVINET_TOKEN |
+| CAP atualizado antes do source verde | Gate operacional foi violado | Reverter o promote, corrigir o monitor/gate e aguardar source CI + publish |
 
 ## Checklist da Fase 10
 
-- [ ] Stage 4 (Promote) completou com `promoted=true`
+- [ ] Source CI/workloads do SHA correto terminaram verdes
+- [ ] Imagem da versao esperada foi publicada antes do promote
+- [ ] Stage 4 (Promote) ou promote-cap completou com `promoted=true`
 - [ ] Tag no CAP values.yaml atualizada para nova versao
 - [ ] Release state no autopilot-state mostra `status: "promoted"`
 - [ ] Referencia local (`references/controller-cap/values.yaml`) atualizada

--- a/ops/docs/deploy-process/README.md
+++ b/ops/docs/deploy-process/README.md
@@ -50,16 +50,21 @@
        +---> Stage 1: Setup (le workspace config)
        +---> Stage 1.5: Session Guard (adquire lock)
        +---> Stage 2: Apply & Push (clona repo corp, aplica patches, push)
-       +---> Stage 3: CI Gate (espera esteira corporativa)
-       +---> Stage 4: Promote (atualiza tag no CAP values.yaml)
+       +---> Stage 3: CI Gate inicial (identifica o sinal de CI do SHA pushado)
        +---> Stage 5: Save State (salva estado no autopilot-state)
        +---> Stage 6: Audit (registra trail + libera lock)
        |
        v
-[Monitorar Esteira de Build NPM (build, test, lint, Docker image)]
+[Monitorar commit SHA do source repo + check-runs/workloads]
        |
        v
-[Imagem Docker publicada no registry = DEPLOY COMPLETO]
+[Confirmar CI verde + imagem Docker publicada]
+       |
+       v
+[Promover repositorio CAP / atualizar tag de release]
+       |
+       v
+[Deploy consistente: source repo verde + CAP apontando para a versao publicada]
 ```
 
 ## Regras de Ouro
@@ -68,10 +73,11 @@
 2. **NUNCA** esquecer de incrementar o campo `run` no trigger — sem incremento o workflow NAO dispara
 3. **NUNCA** assumir que o workflow rodou — SEMPRE monitorar e verificar
 4. **NUNCA** criar patches sem ter a base corporativa ATUAL (fetch primeiro)
-5. **SEMPRE** fazer version bump nos 5 arquivos
-6. **SEMPRE** monitorar a esteira corporativa APOS o workflow do autopilot
+5. **SEMPRE** fazer version bump nos arquivos obrigatorios do source e da referencia local
+6. **SEMPRE** monitorar o commit SHA do source repo corporativo APOS o workflow do autopilot
 7. **SEMPRE** registrar falhas e solucoes na session memory
 8. Deploy so esta COMPLETO quando a imagem Docker e publicada no registry
+9. Promocao de tag no deploy repo so e valida depois que o source repo estiver verde
 
 ## Contexto
 
@@ -80,11 +86,12 @@
 - **Repo agent**: `bbvinet/psc-sre-automacao-agent` (codigo fonte)
 - **Repo CAP controller**: `bbvinet/psc_releases_cap_sre-aut-controller` (deploy K8s)
 - **Repo CAP agent**: `bbvinet/psc_releases_cap_sre-aut-agent` (deploy K8s)
+- **Regra operacional**: repos corporativos sao sempre acessados via autopilot + `BBVINET_TOKEN`, nunca por commit direto da sessao
 - **State branch**: `autopilot-state` (estado runtime, locks, audit)
 - **Token corporativo**: `BBVINET_TOKEN` (acesso repos bbvinet)
 - **Token autopilot**: `RELEASE_TOKEN` (acesso ao autopilot)
 
 ---
 
-*Ultima atualizacao: 2026-03-27*
+*Ultima atualizacao: 2026-04-22*
 *Gerado a partir do processo validado e operacional nas sessoes de 2026-03-23 a 2026-03-27*


### PR DESCRIPTION
## Summary
- persist the rule that corporate repos are operated only through autopilot
- require fetch + local validation in autopilot before corporate source changes
- require source SHA green status, workload/check-run confirmation, and image publication before CAP promotion is considered valid

## Validation
- jq empty contracts/codex-session-memory.json contracts/codex-agent-contract.json
- git diff --check
- scripts/codex/preflight-autopilot.sh (blocked in this host because `python` is unavailable)