### PR TITLE
fix: deploy controller 3.9.4 trusted agent fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,7 +424,7 @@ All 4 repos below are on GitHub under `bbvinet` org. Access via `BBVINET_TOKEN`.
 
 | Repo | Role | Current Version | Stack | CI |
 |------|------|-----------------|-------|----|
-| [`bbvinet/psc-sre-automacao-controller`](https://github.com/bbvinet/psc-sre-automacao-controller) | Controller — orchestrates automations, dispatches to agents, manages execution logs | 3.8.3 | Node 22, TypeScript, Express, Jest | Esteira de Build NPM (corporate runner) |
+| [`bbvinet/psc-sre-automacao-controller`](https://github.com/bbvinet/psc-sre-automacao-controller) | Controller — orchestrates automations, dispatches to agents, manages execution logs | 3.9.4 | Node 22, TypeScript, Express, Jest | Esteira de Build NPM (corporate runner) |
 | [`bbvinet/psc-sre-automacao-agent`](https://github.com/bbvinet/psc-sre-automacao-agent) | Agent — executes automations on clusters, receives cronjob callbacks, pushes logs to controller | 2.3.6 | Node 22, TypeScript, Express, Jest, K8s client | Esteira de Build NPM (corporate runner) |
 
 **How to work with source repos:**
@@ -468,7 +468,7 @@ state/workspaces/ws-default/workspace.json
 - **CAP values path**: `releases/openshift/hml/deploy/values.yaml`
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.8.3`
+- **Current deployed tag**: `3.9.4`
 - **Image line**: `image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:<TAG>`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractId": "claude-session-memory",
   "description": "Memoria cumulativa de TUDO que foi feito, decidido e aprendido. Cada sessao DEVE ler isso e aplicar automaticamente. O objetivo e reduzir tempo de execucao e melhorar qualidade a cada sessao.",
-  "lastUpdated": "2026-04-22T21:05:37Z",
+  "lastUpdated": "2026-04-23T16:42:10Z",
   "lastSessionId": "session-autonomous-ops-20260411",
   "multiCompanyModel": {
     "description": "Control plane centralizado gerenciando multiplas empresas. Cada empresa e um contexto COMPLETAMENTE ISOLADO.",
@@ -22,7 +22,7 @@
           "bbvinet/psc-sre-automacao-controller": {
             "role": "Controller — orquestra automacoes, despacha para agents, gerencia logs de execucao",
             "type": "source-code",
-            "currentVersion": "3.8.3",
+            "currentVersion": "3.9.4",
             "stack": "Node 22, TypeScript, Express, Jest, SQLite, S3",
             "ci": "Esteira de Build NPM (corporate runner)",
             "actionsUrl": "https://github.com/bbvinet/psc-sre-automacao-controller/actions",
@@ -455,8 +455,8 @@
     ]
   },
   "versioningRules": {
-    "currentVersion": "3.8.3",
-    "previousVersion": "3.8.2",
+    "currentVersion": "3.9.4",
+    "previousVersion": "3.9.3",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versioningPattern": "CRITICO: Apos X.Y.9, a proxima versao e X.(Y+1).0 — NUNCA X.Y.10. Exemplos: 3.5.9 → 3.6.0, 3.6.9 → 3.7.0, 3.9.9 → 3.10.0. O terceiro digito (patch) vai de 0 a 9 apenas.",
     "versionFiles": [

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -136,7 +136,7 @@
       "rule": "NUNCA mergear PR de deploy se validate-patches ou o preflight local falharem"
     },
     "versioningRules": {
-      "currentVersion": "3.9.3",
+      "currentVersion": "3.9.4",
       "pattern": "Apos X.Y.9 vai para X.(Y+1).0 — NUNCA X.Y.10",
       "checkRegistry": "SEMPRE verificar se tag ja existe antes de bumpar",
       "versionFiles": [

--- a/patches/controller-package-lock.json
+++ b/patches/controller-package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psc-sre-automacao-controller",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psc-sre-automacao-controller",
-      "version": "3.9.3",
+      "version": "3.9.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",

--- a/patches/controller-package.json
+++ b/patches/controller-package.json
@@ -1,6 +1,6 @@
 {
   "name": "psc-sre-automacao-controller",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "private": true,
   "description": "psc-sre-automacao-controller in node with expressjs",
   "repository": {

--- a/patches/controller-swagger.json
+++ b/patches/controller-swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PSC SRE Automacao Controller",
     "description": "API do Controller de automacao SRE. Orquestra a execucao de automacoes nos Agents distribuidos por cluster, gerencia logs de execucao, autenticacao JWT e integracao com o OAS (Orquestrador de Automacao de Servicos).",
-    "version": "3.9.3",
+    "version": "3.9.4",
     "contact": {
       "name": "PSC SRE Automacao"
     }

--- a/patches/controller-trusted-agent.test.ts
+++ b/patches/controller-trusted-agent.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("trusted agent resolution", () => {
+  const originalEnv = process.env;
+  let tmpDir = "";
+  let dbPath = "";
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trusted-agent-"));
+    dbPath = path.join(tmpDir, "test.db");
+    process.env = {
+      ...originalEnv,
+      DB_PATH: dbPath,
+      AGENT_BASE_URL_TEMPLATE: "https://agent.{cluster}.svc.local",
+      AGENT_EXECUTE_URL_TEMPLATE: "",
+      AGENT_BASE_URL: "",
+      AGENT_EXECUTE_URL: "",
+    };
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup for temp dir.
+    }
+  });
+
+  test("returns null when cluster is not registered", async () => {
+    const {
+      resolveTrustedRegisteredAgentByCluster,
+      resolveTrustedRegisteredAgentExecuteUrlByCluster,
+      resolveTrustedRegisteredAgentExecuteTarget,
+    } = await import("../../util/trusted-agent");
+
+    expect(
+      resolveTrustedRegisteredAgentExecuteUrlByCluster("cluster-a"),
+    ).toBeNull();
+    expect(resolveTrustedRegisteredAgentByCluster("cluster-a")).toBeNull();
+    expect(
+      resolveTrustedRegisteredAgentExecuteTarget({
+        cluster: "cluster-a",
+        namespace: "target-ns",
+      }),
+    ).toBeNull();
+  });
+
+  test("resolves agent URL for registered cluster regardless of namespace", async () => {
+    const { AgentsRepo } = await import("../../repository/agentsRepo");
+    const { resolveTrustedRegisteredAgentExecuteUrlByCluster } = await import(
+      "../../util/trusted-agent"
+    );
+
+    AgentsRepo.upsertAgent({
+      Namespace: "psc-agent",
+      Cluster: "cluster-a",
+      environment: "hml",
+    });
+
+    expect(
+      resolveTrustedRegisteredAgentExecuteUrlByCluster("cluster-a"),
+    ).toBe("https://agent.cluster-a.svc.local/agent/execute");
+  });
+
+  test("returns null for unregistered cluster even if another cluster is registered", async () => {
+    const { AgentsRepo } = await import("../../repository/agentsRepo");
+    const { resolveTrustedRegisteredAgentExecuteUrlByCluster } = await import(
+      "../../util/trusted-agent"
+    );
+
+    AgentsRepo.upsertAgent({
+      Namespace: "psc-agent",
+      Cluster: "cluster-a",
+      environment: "hml",
+    });
+
+    expect(
+      resolveTrustedRegisteredAgentExecuteUrlByCluster("cluster-b"),
+    ).toBeNull();
+  });
+
+  test("prefers exact cluster/namespace matches when available", async () => {
+    const { AgentsRepo } = await import("../../repository/agentsRepo");
+    const { resolveTrustedRegisteredAgentExecuteTarget } = await import(
+      "../../util/trusted-agent"
+    );
+
+    AgentsRepo.upsertAgent({
+      Namespace: "psc-agent",
+      Cluster: "cluster-a",
+      environment: "hml",
+    });
+    AgentsRepo.upsertAgent({
+      Namespace: "target-ns",
+      Cluster: "cluster-a",
+      environment: "hml",
+    });
+
+    expect(
+      resolveTrustedRegisteredAgentExecuteTarget({
+        cluster: "cluster-a",
+        namespace: "target-ns",
+      }),
+    ).toEqual({
+      agentUrl: "https://agent.cluster-a.svc.local/agent/execute",
+      cluster: "cluster-a",
+      namespace: "target-ns",
+      lookupStrategy: "cluster+namespace",
+    });
+  });
+
+  test("falls back to cluster when target namespace is not the registered agent namespace", async () => {
+    const { AgentsRepo } = await import("../../repository/agentsRepo");
+    const { resolveTrustedRegisteredAgentExecuteTarget } = await import(
+      "../../util/trusted-agent"
+    );
+
+    AgentsRepo.upsertAgent({
+      Namespace: "psc-agent",
+      Cluster: "cluster-a",
+      environment: "hml",
+    });
+
+    expect(
+      resolveTrustedRegisteredAgentExecuteTarget({
+        cluster: "cluster-a",
+        namespace: "some-target-ns",
+      }),
+    ).toEqual({
+      agentUrl: "https://agent.cluster-a.svc.local/agent/execute",
+      cluster: "cluster-a",
+      namespace: "psc-agent",
+      lookupStrategy: "cluster",
+    });
+  });
+});

--- a/patches/controller-trusted-agent.ts
+++ b/patches/controller-trusted-agent.ts
@@ -1,10 +1,33 @@
 import { AgentsRepo } from "../repository/agentsRepo";
+import type { AgentRow } from "../db/sqlite";
 import { resolveAgentExecuteUrl } from "./agent-url";
 
 type TrustedAgentInput = {
   cluster: string;
   namespace: string;
 };
+
+export type TrustedRegisteredAgentResolution = {
+  agentUrl: string;
+  cluster: string;
+  namespace: string;
+  lookupStrategy: "cluster+namespace" | "cluster";
+};
+
+function buildResolution(
+  registeredAgent: AgentRow,
+  lookupStrategy: TrustedRegisteredAgentResolution["lookupStrategy"],
+): TrustedRegisteredAgentResolution | null {
+  const agentUrl = resolveAgentExecuteUrl({ cluster: registeredAgent.Cluster });
+  if (!agentUrl) return null;
+
+  return {
+    agentUrl,
+    cluster: registeredAgent.Cluster,
+    namespace: registeredAgent.Namespace,
+    lookupStrategy,
+  };
+}
 
 export function resolveTrustedRegisteredAgentExecuteUrl(
   input: TrustedAgentInput,
@@ -18,11 +41,31 @@ export function resolveTrustedRegisteredAgentExecuteUrl(
   return resolveAgentExecuteUrl({ cluster: registeredAgent.Cluster });
 }
 
-export function resolveTrustedRegisteredAgentExecuteUrlByCluster(
+export function resolveTrustedRegisteredAgentByCluster(
   cluster: string,
-): string | null {
+): TrustedRegisteredAgentResolution | null {
   const registeredAgent = AgentsRepo.getAgentByCluster(cluster);
   if (!registeredAgent) return null;
 
-  return resolveAgentExecuteUrl({ cluster: registeredAgent.Cluster });
+  return buildResolution(registeredAgent, "cluster");
+}
+
+export function resolveTrustedRegisteredAgentExecuteTarget(
+  input: TrustedAgentInput,
+): TrustedRegisteredAgentResolution | null {
+  const registeredAgent = AgentsRepo.getAgentByClusterAndNamespace(
+    input.cluster,
+    input.namespace,
+  );
+  if (registeredAgent) {
+    return buildResolution(registeredAgent, "cluster+namespace");
+  }
+
+  return resolveTrustedRegisteredAgentByCluster(input.cluster);
+}
+
+export function resolveTrustedRegisteredAgentExecuteUrlByCluster(
+  cluster: string,
+): string | null {
+  return resolveTrustedRegisteredAgentByCluster(cluster)?.agentUrl || null;
 }

--- a/patches/oas-sre-controller.controller.ts
+++ b/patches/oas-sre-controller.controller.ts
@@ -8,8 +8,9 @@ import {
 import type { OasOriginAuthDecision } from "../middleware/oas-origin-auth";
 import { timestampSP } from "../util/time";
 import {
-  resolveTrustedRegisteredAgentExecuteUrl,
-  resolveTrustedRegisteredAgentExecuteUrlByCluster,
+  resolveTrustedRegisteredAgentByCluster,
+  resolveTrustedRegisteredAgentExecuteTarget,
+  type TrustedRegisteredAgentResolution,
 } from "../util/trusted-agent";
 import { readSyncTimeoutMs } from "../util/sync-timeout";
 
@@ -26,6 +27,8 @@ type DispatchPlan = {
 
 type ResolvedDispatchPlan = DispatchPlan & {
   agentUrl: string;
+  lookupStrategy: TrustedRegisteredAgentResolution["lookupStrategy"];
+  registeredNamespace: string;
 };
 
 type ValidationResult =
@@ -605,9 +608,15 @@ export async function postOasSreController(
     if (validation.requestType === "legacy") {
       const resolvedPlans: Array<ResolvedDispatchPlan | null> =
         validation.clustersNames.map((cluster) => {
-          const agentUrl =
-            resolveTrustedRegisteredAgentExecuteUrlByCluster(cluster);
-          return agentUrl ? { cluster, agentUrl } : null;
+          const resolvedAgent = resolveTrustedRegisteredAgentByCluster(cluster);
+          return resolvedAgent
+            ? {
+                cluster,
+                agentUrl: resolvedAgent.agentUrl,
+                lookupStrategy: resolvedAgent.lookupStrategy,
+                registeredNamespace: resolvedAgent.namespace,
+              }
+            : null;
         });
 
       const missingTargets = validation.clustersNames.filter(
@@ -627,11 +636,11 @@ export async function postOasSreController(
         (plan): plan is ResolvedDispatchPlan => plan !== null,
       );
     } else {
-      const agentUrl = resolveTrustedRegisteredAgentExecuteUrl({
+      const resolvedAgent = resolveTrustedRegisteredAgentExecuteTarget({
         cluster: validation.cluster,
         namespace: validation.namespace,
       });
-      if (!agentUrl) {
+      if (!resolvedAgent) {
         res.status(404).json({
           ok: false,
           error: "Agent not registered for given cluster/namespace",
@@ -641,7 +650,25 @@ export async function postOasSreController(
         return;
       }
 
-      plans = [{ cluster: validation.cluster, agentUrl }];
+      if (resolvedAgent.lookupStrategy === "cluster") {
+        console.warn(
+          "[oas-sre-controller] agent lookup fallback execId=%s cluster=%s requestedNamespace=%s registeredNamespace=%s strategy=%s",
+          safeLogValue(execId),
+          safeLogValue(validation.cluster),
+          safeLogValue(validation.namespace),
+          safeLogValue(resolvedAgent.namespace),
+          safeLogValue(resolvedAgent.lookupStrategy),
+        );
+      }
+
+      plans = [
+        {
+          cluster: validation.cluster,
+          agentUrl: resolvedAgent.agentUrl,
+          lookupStrategy: resolvedAgent.lookupStrategy,
+          registeredNamespace: resolvedAgent.namespace,
+        },
+      ];
     }
 
     if (plans.length === 0) {
@@ -681,9 +708,11 @@ export async function postOasSreController(
               };
 
         console.info(
-          "[oas-sre-controller] dispatch execId=%s cluster=%s url=%s",
+          "[oas-sre-controller] dispatch execId=%s cluster=%s lookup=%s registeredNamespace=%s url=%s",
           safeLogValue(execId),
           safeLogValue(plan.cluster),
+          safeLogValue(plan.lookupStrategy),
+          safeLogValue(plan.registeredNamespace),
           safeLogValue(plan.agentUrl),
         );
 

--- a/patches/oas-sre-controller.route.test.ts
+++ b/patches/oas-sre-controller.route.test.ts
@@ -290,6 +290,46 @@ describe("POST /oas/sre-controller", () => {
     expect(callBody.function).toBe("get_pods");
   });
 
+  test("falls back to cluster registration when function target namespace differs from agent namespace", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { message: "ok" }));
+
+    const payload = buildFunctionPayload({
+      cluster: "cluster-a",
+      namespace: "some-target-ns",
+    });
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const app = await makeApp();
+      const res = await request(app)
+        .post("/oas/sre-controller")
+        .set("Authorization", bearer([EXECUTE_SCOPE]))
+        .send(payload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.cluster).toBe("cluster-a");
+      expect(res.body.namespace).toBe("some-target-ns");
+
+      const callBody = JSON.parse(
+        String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body),
+      ) as Record<string, unknown>;
+      expect(callBody.cluster).toBe("cluster-a");
+      expect(callBody.namespace).toBe("some-target-ns");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[oas-sre-controller] agent lookup fallback execId=%s cluster=%s requestedNamespace=%s registeredNamespace=%s strategy=%s",
+        payload.execId,
+        "cluster-a",
+        "some-target-ns",
+        "teste",
+        "cluster",
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   test("accepts function=get_all_resources", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(200, { message: "ok" }));
 
@@ -446,7 +486,7 @@ describe("POST /oas/sre-controller", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.details).toContain(
-      "Field 'envs' is required for function 'copy_resources_origem'.",
+      "Field envs is required for function copy_resources_origem.",
     );
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -469,7 +509,7 @@ describe("POST /oas/sre-controller", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.details).toContain(
-      "Field 'envs.NAMESPACE_ENVIRONMENT' is required for function 'copy_resources_origem'.",
+      "Field envs.NAMESPACE_ENVIRONMENT is required for function copy_resources_origem.",
     );
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -493,7 +533,7 @@ describe("POST /oas/sre-controller", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.details).toContain(
-      "Field 'envs.ACTION' has invalid value 'rename'. Allowed values: copy, apply, remove.",
+      "Field envs.ACTION has invalid value rename. Allowed values: copy, apply, remove.",
     );
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -3,7 +3,7 @@
 # Source: bbvinet/psc_releases_cap_sre-aut-controller (GitHub)
 # Path: releases/openshift/hml/deploy/values.yaml
 # Image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller
-# Current tag: 3.9.3
+# Current tag: 3.9.4
 # Secret: psc-sre-automacao-controller-runtime
 # Auto-promote: Stage 4 of apply-source-change.yml updates tag
 #   after corporate CI passes (Esteira de Build NPM green)
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.9.3
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.9.4
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,12 +3,17 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "changes": [
     {
       "action": "replace-file",
       "target_path": "package.json",
       "content_ref": "patches/controller-package.json"
+    },
+    {
+      "action": "replace-file",
+      "target_path": "package-lock.json",
+      "content_ref": "patches/controller-package-lock.json"
     },
     {
       "action": "replace-file",
@@ -27,12 +32,17 @@
     },
     {
       "action": "replace-file",
+      "target_path": "src/__tests__/unit/trusted-agent.test.ts",
+      "content_ref": "patches/controller-trusted-agent.test.ts"
+    },
+    {
+      "action": "replace-file",
       "target_path": "src/swagger/swagger.json",
       "content_ref": "patches/controller-swagger.json"
     }
   ],
-  "commit_message": "fix(controller): support new oas sre functions",
+  "commit_message": "fix(controller): fallback trusted agent lookup by cluster",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 111
+  "run": 112
 }


### PR DESCRIPTION
## Controller Deploy\n- version: 3.9.4\n- fix: OAS function-mode now falls back from cluster+namespace to cluster when the target namespace differs from the registered agent namespace\n- updates: trusted-agent resolver, OAS routing tests, trusted-agent unit coverage, controller CAP reference, deploy trigger\n\n## Validation\n- git diff --check\n- jq empty for trigger and contracts\n- patch files aligned with current local corporate base\n- scripts/codex/preflight-autopilot.sh