### PR TITLE
fix: redeploy controller 3.9.5 package sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,7 +424,7 @@ All 4 repos below are on GitHub under `bbvinet` org. Access via `BBVINET_TOKEN`.
 
 | Repo | Role | Current Version | Stack | CI |
 |------|------|-----------------|-------|----|
-| [`bbvinet/psc-sre-automacao-controller`](https://github.com/bbvinet/psc-sre-automacao-controller) | Controller — orchestrates automations, dispatches to agents, manages execution logs | 3.9.4 | Node 22, TypeScript, Express, Jest | Esteira de Build NPM (corporate runner) |
+| [`bbvinet/psc-sre-automacao-controller`](https://github.com/bbvinet/psc-sre-automacao-controller) | Controller — orchestrates automations, dispatches to agents, manages execution logs | 3.9.5 | Node 22, TypeScript, Express, Jest | Esteira de Build NPM (corporate runner) |
 | [`bbvinet/psc-sre-automacao-agent`](https://github.com/bbvinet/psc-sre-automacao-agent) | Agent — executes automations on clusters, receives cronjob callbacks, pushes logs to controller | 2.3.6 | Node 22, TypeScript, Express, Jest, K8s client | Esteira de Build NPM (corporate runner) |
 
 **How to work with source repos:**
@@ -468,7 +468,7 @@ state/workspaces/ws-default/workspace.json
 - **CAP values path**: `releases/openshift/hml/deploy/values.yaml`
 - **Reference file**: `references/controller-cap/values.yaml`
 - **Image**: `docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller`
-- **Current deployed tag**: `3.9.4`
+- **Current deployed tag**: `3.9.5`
 - **Image line**: `image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:<TAG>`
 - **K8s Secret**: `psc-sre-automacao-controller-runtime` (11 keys: JWT_SECRET, AUTH_API_KEYS_SCOPES, SCOPE_*, AWS_REGION, OSS_*)
 - **K8s Secret**: `sre-controller-auth` (4 keys: OAS_TRUSTED_NAMESPACE, OAS_TRUSTED_SERVICE_ACCOUNT, OAS_ORIGIN_NAMESPACE_HEADERS, OAS_ORIGIN_SERVICE_ACCOUNT_HEADERS)

--- a/contracts/claude-session-memory.json
+++ b/contracts/claude-session-memory.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "contractId": "claude-session-memory",
   "description": "Memoria cumulativa de TUDO que foi feito, decidido e aprendido. Cada sessao DEVE ler isso e aplicar automaticamente. O objetivo e reduzir tempo de execucao e melhorar qualidade a cada sessao.",
-  "lastUpdated": "2026-04-23T16:44:41Z",
+  "lastUpdated": "2026-04-23T16:51:29Z",
   "lastSessionId": "session-autonomous-ops-20260411",
   "multiCompanyModel": {
     "description": "Control plane centralizado gerenciando multiplas empresas. Cada empresa e um contexto COMPLETAMENTE ISOLADO.",
@@ -22,7 +22,7 @@
           "bbvinet/psc-sre-automacao-controller": {
             "role": "Controller — orquestra automacoes, despacha para agents, gerencia logs de execucao",
             "type": "source-code",
-            "currentVersion": "3.9.4",
+            "currentVersion": "3.9.5",
             "stack": "Node 22, TypeScript, Express, Jest, SQLite, S3",
             "ci": "Esteira de Build NPM (corporate runner)",
             "actionsUrl": "https://github.com/bbvinet/psc-sre-automacao-controller/actions",
@@ -455,8 +455,8 @@
     ]
   },
   "versioningRules": {
-    "currentVersion": "3.9.4",
-    "previousVersion": "3.9.3",
+    "currentVersion": "3.9.5",
+    "previousVersion": "3.9.4",
     "rule": "Se a esteira ja gerou imagem para uma versao, a proxima DEVE incrementar o patch. CI rejeita tags duplicadas no registry.",
     "versioningPattern": "CRITICO: Apos X.Y.9, a proxima versao e X.(Y+1).0 — NUNCA X.Y.10. Exemplos: 3.5.9 → 3.6.0, 3.6.9 → 3.7.0, 3.9.9 → 3.10.0. O terceiro digito (patch) vai de 0 a 9 apenas.",
     "versionFiles": [

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -136,7 +136,7 @@
       "rule": "NUNCA mergear PR de deploy se validate-patches ou o preflight local falharem"
     },
     "versioningRules": {
-      "currentVersion": "3.9.4",
+      "currentVersion": "3.9.5",
       "pattern": "Apos X.Y.9 vai para X.(Y+1).0 — NUNCA X.Y.10",
       "checkRegistry": "SEMPRE verificar se tag ja existe antes de bumpar",
       "versionFiles": [

--- a/patches/controller-package-lock.json
+++ b/patches/controller-package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psc-sre-automacao-controller",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psc-sre-automacao-controller",
-      "version": "3.9.4",
+      "version": "3.9.5",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",

--- a/patches/controller-package.json
+++ b/patches/controller-package.json
@@ -1,6 +1,6 @@
 {
   "name": "psc-sre-automacao-controller",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "private": true,
   "description": "psc-sre-automacao-controller in node with expressjs",
   "repository": {
@@ -62,7 +62,7 @@
     "@smithy/node-http-handler": "^3.0.0",
     "@types/aws-sdk": "^0.0.42",
     "aws-sdk": "^2.1693.0",
-    "better-sqlite3": "^9.4.0",
+    "better-sqlite3": "^12.9.0",
     "body-parser": "1.20.3",
     "cors": "2.8.5",
     "date-fns": "^3.6.0",

--- a/patches/controller-swagger.json
+++ b/patches/controller-swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PSC SRE Automacao Controller",
     "description": "API do Controller de automacao SRE. Orquestra a execucao de automacoes nos Agents distribuidos por cluster, gerencia logs de execucao, autenticacao JWT e integracao com o OAS (Orquestrador de Automacao de Servicos).",
-    "version": "3.9.4",
+    "version": "3.9.5",
     "contact": {
       "name": "PSC SRE Automacao"
     }

--- a/references/controller-cap/values.yaml
+++ b/references/controller-cap/values.yaml
@@ -3,7 +3,7 @@
 # Source: bbvinet/psc_releases_cap_sre-aut-controller (GitHub)
 # Path: releases/openshift/hml/deploy/values.yaml
 # Image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller
-# Current tag: 3.9.4
+# Current tag: 3.9.5
 # Secret: psc-sre-automacao-controller-runtime
 # Auto-promote: Stage 4 of apply-source-change.yml updates tag
 #   after corporate CI passes (Esteira de Build NPM green)
@@ -116,7 +116,7 @@ sre-aut-controller:
               value: "true"
             containers:
             - name: "{{ .Values.global.servicoSigla }}-{{ .Values.global.servicoNome }}"
-              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.9.4
+              image: docker.binarios.intranet.bb.com.br/bb/psc/psc-sre-automacao-controller:3.9.5
               imagePullPolicy: "IfNotPresent"
               livenessProbe:
                 failureThreshold: 6

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -3,7 +3,7 @@
   "workspace_id": "ws-default",
   "component": "controller",
   "change_type": "multi-file",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "changes": [
     {
       "action": "replace-file",
@@ -41,8 +41,8 @@
       "content_ref": "patches/controller-swagger.json"
     }
   ],
-  "commit_message": "fix(controller): fallback trusted agent lookup by cluster",
+  "commit_message": "fix(controller): sync package lock for trusted agent fallback",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 112
+  "run": 113
 }


### PR DESCRIPTION
## Controller Redeploy\n- version: 3.9.5\n- reason: previous 3.9.4 source CI failed because autopilot patch package.json was stale relative to package-lock and corporate base\n- fix: sync package.json dependency set with current corporate base, preserving the trusted-agent fallback changes from 3.9.4\n\n## Validation\n- git diff --check\n- jq empty for trigger and contracts\n- package.json diff reduced to version-only against current local corporate base\n- diagnosis from ci log: npm ci failed on better-sqlite3 mismatch in 3.9.4