### PR TITLE
[codex] preserve api key scope response contract

### DIFF
--- a/.github/workflows/ci-diagnose.yml
+++ b/.github/workflows/ci-diagnose.yml
@@ -333,7 +333,9 @@ jobs:
               GH_TOKEN="$RELEASE_TOKEN" gh api "repos/$AUTOPILOT_REPO/issues" --method POST \
                 -f "title=CI Diagnosis: $COMPONENT failures — @claude fix needed" \
                 -f "body=$ESC_BODY" \
-                -f "labels=[\"needs-claude\",\"ci-diagnosis\",\"auto-generated\"]" 2>/dev/null || echo "::warning ::Failed to create issue"
+                -f "labels[]=needs-claude" \
+                -f "labels[]=ci-diagnosis" \
+                -f "labels[]=auto-generated" 2>/dev/null || echo "::warning ::Failed to create issue"
             fi
           fi
 

--- a/.github/workflows/compliance-gate.yml
+++ b/.github/workflows/compliance-gate.yml
@@ -185,6 +185,17 @@ jobs:
             fi
           done
 
+          # ══ RULE 6D: Auth scope API response contract must stay backward compatible ══
+          for f in $PATCH_TS; do
+            case "$f" in
+              *auth.controller.ts)
+                if grep -nP 'error:\s*"Invalid scope"\s*[,}]|error:\s*"Scope not allowed for API key"\s*[,}]|current access values' "$f" > /dev/null 2>&1; then
+                  viol "auth-scope-response-contract" "$f changed legacy API key scope error wording; preserve plural error messages and scope-values hint while keeping JWT claims singular" "error"
+                fi
+                ;;
+            esac
+          done
+
           # ══ RULE 7: search-replace single-line ══
           if [ "$CHANGES" != "[]" ] && [ "$CHANGES" != "null" ]; then
             echo "$CHANGES" | jq -c '.[]' 2>/dev/null | while read -r ch; do

--- a/.github/workflows/deploy-auto-learn.yml
+++ b/.github/workflows/deploy-auto-learn.yml
@@ -97,7 +97,7 @@ jobs:
           FAILURES=$(echo "${{ steps.collect.outputs.failures_b64 }}" | base64 -d 2>/dev/null || echo '[]')
 
           # ── Known error patterns from compliance gate ──
-          KNOWN_PATTERNS='[{"pattern":"no-nested-ternary","rule":"eslint_no_nested_ternary","fix":"Replace nested ternary with if/else","autofix":true},{"pattern":"no-use-before-define","rule":"eslint_no_use_before_define","fix":"Move function definition before usage","autofix":true},{"pattern":"TS2769.*overload","rule":"ts2769_jwt_sign","fix":"Use parseExpiresIn() with cast","autofix":false},{"pattern":"TS2339.*Property.*does not exist","rule":"ts_property_missing","fix":"Add property to interface","autofix":false},{"pattern":"duplicate.*tag|already exists","rule":"duplicate_tag","fix":"Increment patch version","autofix":true},{"pattern":"scope.*plural|scopes","rule":"jwt_scope_plural","fix":"Use scope (singular)","autofix":true},{"pattern":"no-require-imports|global-require|import/no-dynamic-require|Unexpected require","rule":"eslint_static_imports","fix":"Use static import syntax instead of require()","autofix":true},{"pattern":"no-useless-concat|Unexpected string concatenation of literals","rule":"eslint_no_useless_concat","fix":"Do not concatenate string literals to bypass scanners; fix scanner rule or use arrays/join when justified","autofix":true},{"pattern":"ASCII|garbled|encode","rule":"swagger_garbled","fix":"Remove accented characters","autofix":true},{"pattern":"validateTrustedUrl.*mock","rule":"validate_in_fetch","fix":"Remove from fetch, use at input","autofix":true},{"pattern":"403.*push|permission denied","rule":"push_403","fix":"Use agent branch prefix","autofix":false},{"pattern":"run.*not.*increment|trigger.*not.*fir","rule":"trigger_not_firing","fix":"Increment run field","autofix":true},{"pattern":"exit code 127|command not found","rule":"gha_command_not_found","fix":"Remove heredoc from run blocks","autofix":true},{"pattern":"heredoc.*EOF|EOFBODY|cat <<","rule":"gha_heredoc_in_run","fix":"Replace heredoc with inline variable","autofix":true},{"pattern":"Pre-push validation FAILED.*blocking push|continue-on-error.*pre-push","rule":"apply_pre_push_must_block","fix":"Never use continue-on-error on pre-push validation that protects corporate repos","autofix":false},{"pattern":"Cannot find name .*process|Cannot find name .*Buffer|Cannot find namespace .*NodeJS|Cannot find module .*(@aws-sdk/client-s3|prom-client)","rule":"prepush_dependency_baseline","fix":"Keep deterministic static and changed-file validation blocking; treat full-repo tsc dependency baseline as advisory until source deps are reproducible on generic runners","autofix":false},{"pattern":"properties/labels.*not an array|labels=\\\\[","rule":"github_issue_labels_array","fix":"Use repeated labels[]= fields for gh api issue creation","autofix":true}]'
+          KNOWN_PATTERNS='[{"pattern":"no-nested-ternary","rule":"eslint_no_nested_ternary","fix":"Replace nested ternary with if/else","autofix":true},{"pattern":"no-use-before-define","rule":"eslint_no_use_before_define","fix":"Move function definition before usage","autofix":true},{"pattern":"TS2769.*overload","rule":"ts2769_jwt_sign","fix":"Use parseExpiresIn() with cast","autofix":false},{"pattern":"TS2339.*Property.*does not exist","rule":"ts_property_missing","fix":"Add property to interface","autofix":false},{"pattern":"duplicate.*tag|already exists","rule":"duplicate_tag","fix":"Increment patch version","autofix":true},{"pattern":"scope.*plural|scopes","rule":"jwt_scope_plural","fix":"Use scope (singular)","autofix":true},{"pattern":"Invalid scope.*Invalid scopes|Scope not allowed.*Scopes not allowed|required-scopes.*access values.*scope values","rule":"auth_scope_response_contract","fix":"Preserve existing API key scope error wording while keeping JWT claims singular","autofix":false},{"pattern":"no-require-imports|global-require|import/no-dynamic-require|Unexpected require","rule":"eslint_static_imports","fix":"Use static import syntax instead of require()","autofix":true},{"pattern":"no-useless-concat|Unexpected string concatenation of literals","rule":"eslint_no_useless_concat","fix":"Do not concatenate string literals to bypass scanners; fix scanner rule or use arrays/join when justified","autofix":true},{"pattern":"ASCII|garbled|encode","rule":"swagger_garbled","fix":"Remove accented characters","autofix":true},{"pattern":"validateTrustedUrl.*mock","rule":"validate_in_fetch","fix":"Remove from fetch, use at input","autofix":true},{"pattern":"403.*push|permission denied","rule":"push_403","fix":"Use agent branch prefix","autofix":false},{"pattern":"run.*not.*increment|trigger.*not.*fir","rule":"trigger_not_firing","fix":"Increment run field","autofix":true},{"pattern":"exit code 127|command not found","rule":"gha_command_not_found","fix":"Remove heredoc from run blocks","autofix":true},{"pattern":"heredoc.*EOF|EOFBODY|cat <<","rule":"gha_heredoc_in_run","fix":"Replace heredoc with inline variable","autofix":true},{"pattern":"Pre-push validation FAILED.*blocking push|continue-on-error.*pre-push","rule":"apply_pre_push_must_block","fix":"Never use continue-on-error on pre-push validation that protects corporate repos","autofix":false},{"pattern":"Cannot find name .*process|Cannot find name .*Buffer|Cannot find namespace .*NodeJS|Cannot find module .*(@aws-sdk/client-s3|prom-client)","rule":"prepush_dependency_baseline","fix":"Keep deterministic static and changed-file validation blocking; treat full-repo tsc dependency baseline as advisory until source deps are reproducible on generic runners","autofix":false},{"pattern":"properties/labels.*not an array|labels=\\\\[","rule":"github_issue_labels_array","fix":"Use repeated labels[]= fields for gh api issue creation","autofix":true}]'
 
           # ── Match failures against patterns (FIX: avoid subshell variable loss) ──
           MATCHED=0
@@ -194,7 +194,7 @@ jobs:
           | Recent Successes | $SUCCESS_COUNT |
           | Recent Failures | $FAIL_COUNT |
 
-          ## Compliance Gate Rules (14 active)
+          ## Compliance Gate Rules (21 active)
 
           ### Pre-Deploy (Static Analysis)
           | # | Rule | What it checks | Severity |
@@ -213,6 +213,7 @@ jobs:
           | 12 | security-dos-loop | Loop without MAX_RESULTS | 🔴 error |
           | 13 | hardcoded-secret | Secrets in patch files | 🔴 error |
           | 14 | use-before-define | Function called before defined | 🔴 error |
+          | 15-21 | deploy hardening | Corporate lint, GitHub labels, auth response contract, dependency baseline, and source apply guards | 🔴 error |
 
           ### During Deploy (Pull & Test)
           | Step | What it does |
@@ -247,6 +248,9 @@ jobs:
           | TS2769 overload | TypeScript | ❌ |
           | duplicate tag | CI Registry | ✅ |
           | scopes plural | JWT | ✅ |
+          | auth scope response contract | API compatibility | ❌ |
+          | GitHub labels array | GitHub API | ✅ |
+          | pre-push dependency baseline | Corporate deps | ❌ |
           | garbled swagger | Encoding | ✅ |
           | validateTrustedUrl | Mock tests | ✅ |
           | 403 push | Branch protection | ❌ |
@@ -258,7 +262,7 @@ jobs:
            │
            ▼
           ┌─────────────────────────┐
-          │ Compliance Gate (14)    │ ← Static + Pull & Test + Tag Check
+          │ Compliance Gate (21)    │ ← Static + Pull & Test + Tag Check
           └───────────┬─────────────┘
                       │ ✅ Pass
                       ▼

--- a/.github/workflows/fix-corporate-ci.yml
+++ b/.github/workflows/fix-corporate-ci.yml
@@ -305,10 +305,12 @@ jobs:
             echo "::warning ::Auto-fix could not apply any changes — escalating to Claude Code"
 
             # Create notification issue for tracking
-            GH_TOKEN="$RELEASE_TOKEN" gh issue create \
-              --repo "$AUTOPILOT_REPO" \
-              --title "[AutoPilot] CI auto-fix blocked: $COMPONENT — no auto-fixable errors found" \
-              --body "fix-corporate-ci ran for component \`$COMPONENT\` (workspace \`$WS_ID\`) but could not apply any automatic fixes. The ESLint error may require a code-level patch update in autopilot. Check the CI logs on autopilot-state branch (ci-logs-${COMPONENT}-*.txt) for the specific error." \
+            GH_TOKEN="$RELEASE_TOKEN" gh api "repos/$AUTOPILOT_REPO/issues" --method POST \
+              -f "title=[AutoPilot] CI auto-fix blocked: $COMPONENT — no auto-fixable errors found" \
+              -f "body=fix-corporate-ci ran for component \`$COMPONENT\` (workspace \`$WS_ID\`) but could not apply any automatic fixes. The CI failure requires a code-level patch update in autopilot. Check the CI logs on autopilot-state branch (ci-logs-${COMPONENT}-*.txt) for the specific error." \
+              -f "labels[]=automated" \
+              -f "labels[]=ci-failure" \
+              -f "labels[]=auto-generated" \
               2>/dev/null || echo "::warning ::Could not create notification issue"
 
             # ── Auto-escalation: trigger Claude Code via @claude issue ──
@@ -357,12 +359,13 @@ jobs:
             if [ "$EXISTING_ESC" -gt 0 ]; then
               echo "::notice ::Escalation issue already exists for $COMPONENT — skipping duplicate"
             else
-              ESCALATION_URL=$(GH_TOKEN="$RELEASE_TOKEN" gh issue create \
-                --repo "$AUTOPILOT_REPO" \
-                --title "[AutoPilot] @claude CI fix needed: $COMPONENT — auto-fix insufficient" \
-                --label "automated,needs-claude,ci-failure" \
-                --body "$ESCALATION_BODY" \
-                2>/dev/null) && \
+              ESCALATION_RESPONSE=$(GH_TOKEN="$RELEASE_TOKEN" gh api "repos/$AUTOPILOT_REPO/issues" --method POST \
+                -f "title=[AutoPilot] @claude CI fix needed: $COMPONENT — auto-fix insufficient" \
+                -f "body=$ESCALATION_BODY" \
+                -f "labels[]=automated" \
+                -f "labels[]=needs-claude" \
+                -f "labels[]=ci-failure" 2>/dev/null) && \
+                ESCALATION_URL=$(echo "$ESCALATION_RESPONSE" | jq -r '.html_url // empty') && \
                 echo "::notice ::Claude Code escalation issue created: $ESCALATION_URL" || \
                 echo "::warning ::Could not create Claude escalation issue"
             fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,7 +559,7 @@ Note: Some directories (`locks/`, `approvals/`, `metrics/`, `release-freeze.json
 **NUNCA deployar sem validar primeiro.** O pipeline de compliance roda automaticamente em PRs e pos-deploy.
 
 ```
-PR Created → Compliance Gate (20 checks) + Interface Check → apply-source-change (7 stages) → Post-Deploy Validation → Auto-Learn (with write-back)
+PR Created → Compliance Gate (21 checks) + Interface Check → apply-source-change (7 stages) → Post-Deploy Validation → Auto-Learn (with write-back)
 ```
 
 #### Stage 1: Compliance Gate (PRE-DEPLOY — compliance-gate.yml)
@@ -573,6 +573,7 @@ PR Created → Compliance Gate (20 checks) + Interface Check → apply-source-ch
 | 6 | no-nested-ternary | ESLint rejects | error |
 | 6B | eslint-corporate-blockers | Blocks require() and literal concatenation before corporate lint | error |
 | 6C | github-api-label-array | Blocks gh api issue labels sent as string JSON | error |
+| 6D | auth-scope-response-contract | Preserves API key scope error wording while JWT claims stay singular | error |
 | 7 | search-replace-newlines | sed can't handle | error |
 | 8 | run-not-incremented | Workflow won't fire | error |
 | 9 | blocked-workspace | Third-party isolation | error |
@@ -604,7 +605,7 @@ Validates BOTH controller and agent sides BEFORE commit/deploy. Errors and vulne
 | Auto-Learn Write-back | `deploy-auto-learn.yml` Step 4 | Persists learned patterns to session memory + contract |
 | Resilience Patterns | `contracts/resilience-patterns.json` | 13 known failure patterns with automatic workarounds and fallback chains |
 
-**Flow**: `git commit` → PreToolUse hook → `pre-commit-validate.sh` → 12 checks → approve/block → PR → compliance-gate (18 rules + interface-check) → deploy → auto-learn (write-back)
+**Flow**: `git commit` → PreToolUse hook → `pre-commit-validate.sh` → 12 checks → approve/block → PR → compliance-gate (21 checks + interface-check) → deploy → auto-learn (write-back)
 
 ### Resilience & Self-Healing System
 Automatic failure recovery without human intervention. Maps known failures to workarounds, discovers new patterns autonomously.

--- a/patches/auth.controller.ts
+++ b/patches/auth.controller.ts
@@ -20,7 +20,7 @@ const DEFAULT_JWT_ISSUER = "psc-sre-automacao-controller";
 const LEGACY_SCOPE_FIELD = ["scope", "s"].join("");
 const REQUIRED_SCOPES_HINT = [
   "Use GET /auth/required-scopes with x-api-key",
-  "to discover the current access values for this environment.",
+  "to discover the current scope values for this environment.",
 ].join(" ");
 
 function getJwtSecretOrPrivateKey(): string {
@@ -168,7 +168,7 @@ export function issueToken(req: Request, res: Response): void {
   const validation = validateRequestedScopes(requested.scopeList);
   if (!validation.ok) {
     res.status(400).json({
-      error: "Invalid scope",
+      error: "Invalid scopes",
       hint: REQUIRED_SCOPES_HINT,
     });
     return;
@@ -177,7 +177,7 @@ export function issueToken(req: Request, res: Response): void {
   const validatedScopeList = readValidatedScopeList(validation);
   if (!isSubsetOfAllowed(validatedScopeList, allowedScopes)) {
     res.status(403).json({
-      error: "Scope not allowed for API key",
+      error: "Scopes not allowed for API key",
       hint: REQUIRED_SCOPES_HINT,
     });
     return;

--- a/trigger/source-change.json
+++ b/trigger/source-change.json
@@ -46,8 +46,8 @@
       "content_ref": "patches/controller-swagger.json"
     }
   ],
-  "commit_message": "fix(controller): apply lint-clean api key token flow",
+  "commit_message": "fix(controller): preserve api key scope error contract",
   "skip_ci_wait": false,
   "promote": true,
-  "run": 116
+  "run": 117
 }


### PR DESCRIPTION
## Summary
- preserve the legacy API key scope error response contract expected by corporate auth.scopes tests
- add compliance and auto-learn coverage for auth scope response contract regressions
- fix ci-diagnose/fix-corporate-ci issue labels to use GitHub API label arrays
- bump trigger/source-change.json run to 117 for the next corporate apply

## Validation
- YAML parse: ci-diagnose, fix-corporate-ci, deploy-auto-learn, compliance-gate
- jq empty: trigger/source-change.json
- git diff --check
- static guards for labels, require(), literal concat, and auth scope response contract
- focused Jest in controller validation snapshot: auth.scopes, oas-sre-controller.route, trusted-agent = 41/41 passed