### PR TITLE
docs: enforce autonomous completion policy

### DIFF
--- a/.github/instructions/ops.instructions.md
+++ b/.github/instructions/ops.instructions.md
@@ -95,6 +95,10 @@ For any corporate deployment, follow the 12-phase guide in `ops/docs/deploy-proc
 | 11 | `11-diagnostics-and-troubleshooting.md` |
 | 12 | `12-quick-reference.md` |
 
+## Definition of Done for Corporate Changes
+
+Do not treat deploy work as done until Codex has implemented, validated, committed, pushed, merged, applied the source change, monitored the exact corporate SHA to green, confirmed image publication, promoted or verified CAP/deploy alignment, saved state/audit/monitor outputs, and persisted learnings. Known failures should be fixed and re-run automatically; stop only for real security, credential, permission, lock, destructive-risk, or missing-critical-context blockers.
+
 ## Adding New Scripts
 
 1. Place in the appropriate domain directory under `ops/scripts/`

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -37,6 +37,11 @@ Files in `.github/workflows/` are GitHub Actions workflows that power the Autopi
 - Log errors with `echo "::error ::"` for fatal issues
 - NEVER use `|| true` without logging first: `command || { echo "::warning::..."; true; }`
 
+## Autonomous Completion Rule
+- Source/deploy workflows must not define success before the end-to-end release evidence exists.
+- Required evidence: corporate source SHA green, expected image published, CAP/deploy repo promoted or aligned, release-state saved, audit trail saved, monitor state saved, and learnings persisted.
+- If a known failure is detected, the workflow or follow-up automation should diagnose, fix, re-trigger, and re-monitor. Escalate only for security, credential, permission, active lock, destructive-risk, or missing-critical-context blockers.
+
 ## Session Guard Pattern
 Any workflow that writes to `autopilot-state` or modifies corporate repos MUST call `session-guard.yml` first:
 ```yaml

--- a/.github/skills/deploy-flow/SKILL.md
+++ b/.github/skills/deploy-flow/SKILL.md
@@ -42,6 +42,19 @@ Read `contracts/copilot-session-memory.json` for full context.
 5. Save State → record on autopilot-state
 6. Audit → trail + release lock
 
+### Mandatory Definition of Done
+Codex must continue autonomously until the full release evidence exists. Do not stop after code changes, local tests, PR merge, source push, or one green CI signal.
+
+Required final state:
+- corporate source SHA known and green
+- expected image version published
+- CAP/deploy repo promoted or already aligned with that image tag
+- release-state, audit trail, and monitor state saved
+- deploy monitor green
+- errors, fixes, and learnings written back to memory/docs/auto-learn
+
+If a known failure happens, diagnose logs, fix, increment the trigger when needed, redeploy, and monitor again. Stop only for security, credential, permission, active lock, destructive-risk, or missing-critical-context blockers.
+
 ### Version Rules
 - 5 files must be bumped
 - After X.Y.9 → X.(Y+1).0 (NEVER X.Y.10)

--- a/.github/workflows/agent-quality-gate.yml
+++ b/.github/workflows/agent-quality-gate.yml
@@ -12,11 +12,15 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/**'
+      - '.github/skills/**'
+      - '.github/instructions/**'
       - 'schemas/**'
       - 'contracts/**'
       - 'panel/**'
       - 'version.json'
       - 'CHANGELOG.md'
+      - 'CLAUDE.md'
+      - 'README.md'
       - '.claude/agents/**'
       - '.claude/skills/**'
       - 'ops/**'
@@ -47,6 +51,8 @@ jobs:
       agents: ${{ steps.filter.outputs.agents }}
       triggers: ${{ steps.filter.outputs.triggers }}
       security: ${{ steps.filter.outputs.security }}
+      ops: ${{ steps.filter.outputs.ops }}
+      agent_context: ${{ steps.filter.outputs.agent_context }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -67,11 +73,18 @@ jobs:
             agents:
               - '.claude/agents/**'
               - '.claude/skills/**'
+              - '.github/skills/**'
+              - '.github/instructions/**'
             triggers:
               - 'trigger/**'
             security:
               - 'compliance/**'
               - '.claude/agents/security-agent.md'
+            ops:
+              - 'ops/**'
+            agent_context:
+              - 'CLAUDE.md'
+              - 'README.md'
 
   yaml-validation:
     name: YAML Validation
@@ -278,9 +291,52 @@ jobs:
           [ "$ERRORS" -eq 0 ] && echo "Dashboard ✓"
           [ "$ERRORS" -eq 0 ] || exit 1
 
+  autonomous-completion-policy:
+    name: Autonomous Completion Policy
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.contracts == 'true' ||
+      needs.detect-changes.outputs.workflows == 'true' ||
+      needs.detect-changes.outputs.triggers == 'true' ||
+      needs.detect-changes.outputs.ops == 'true' ||
+      needs.detect-changes.outputs.agents == 'true' ||
+      needs.detect-changes.outputs.agent_context == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify autonomous completion policy is preserved
+        run: |
+          set -euo pipefail
+          ERRORS=0
+
+          require_text() {
+            local file="$1"
+            local text="$2"
+            if [ ! -f "$file" ]; then
+              echo "::error file=$file::Required policy file is missing"
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if ! grep -qF "$text" "$file"; then
+              echo "::error file=$file::Missing autonomous completion marker: $text"
+              ERRORS=$((ERRORS + 1))
+            fi
+          }
+
+          require_text "contracts/codex-agent-contract.json" "completionDefinition"
+          require_text "contracts/codex-session-memory.json" "codex-autonomous-completion-policy"
+          require_text "contracts/codex-deploy-guide.md" "Mandatory Completion Policy"
+          require_text "ops/docs/agent-operational-parity.md" "Política obrigatória de conclusão autônoma"
+          require_text ".github/skills/deploy-flow/SKILL.md" "Mandatory Definition of Done"
+
+          [ "$ERRORS" -eq 0 ] && echo "Autonomous completion policy ✓"
+          [ "$ERRORS" -eq 0 ] || exit 1
+
   report:
     name: Quality Report
-    needs: [detect-changes, yaml-validation, json-validation, version-check, security-scan, trigger-validation, dashboard-check]
+    needs: [detect-changes, yaml-validation, json-validation, version-check, security-scan, trigger-validation, dashboard-check, autonomous-completion-policy]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -296,13 +352,15 @@ jobs:
           echo "| Security | ${{ needs.security-scan.result }} | |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Triggers | ${{ needs.trigger-validation.result }} | ${{ needs.trigger-validation.result == 'skipped' && 'No trigger changes' || '' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Dashboard | ${{ needs.dashboard-check.result }} | ${{ needs.dashboard-check.result == 'skipped' && 'No dashboard changes' || '' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Autonomous Completion | ${{ needs.autonomous-completion-policy.result }} | ${{ needs.autonomous-completion-policy.result == 'skipped' && 'No agent policy changes' || '' }} |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Gate decision
         if: |
           needs.yaml-validation.result == 'failure' ||
           needs.json-validation.result == 'failure' ||
           needs.version-check.result == 'failure' ||
-          needs.security-scan.result == 'failure'
+          needs.security-scan.result == 'failure' ||
+          needs.autonomous-completion-policy.result == 'failure'
         run: |
           echo "::error ::Quality gate FAILED — merge blocked"
           exit 1

--- a/.github/workflows/compliance-gate.yml
+++ b/.github/workflows/compliance-gate.yml
@@ -196,6 +196,18 @@ jobs:
             esac
           done
 
+          # ══ RULE 6E: Autonomous completion path must stay enabled ══
+          if [ "$CHANGES" != "[]" ] && [ "$CHANGES" != "null" ]; then
+            PROMOTE=$(echo "$TRIGGER" | jq -r '.promote // true')
+            SKIP_CI_WAIT=$(echo "$TRIGGER" | jq -r '.skip_ci_wait // false')
+            if [ "$SKIP_CI_WAIT" = "true" ]; then
+              viol "autonomous-completion-required" "skip_ci_wait=true bypasses corporate source monitoring; source/deploy changes must monitor the exact SHA to green" "error"
+            fi
+            if [ "$PROMOTE" != "true" ]; then
+              viol "autonomous-completion-required" "promote must stay true for source/deploy changes so CAP/deploy alignment is reached before completion" "error"
+            fi
+          fi
+
           # ══ RULE 7: search-replace single-line ══
           if [ "$CHANGES" != "[]" ] && [ "$CHANGES" != "null" ]; then
             echo "$CHANGES" | jq -c '.[]' 2>/dev/null | while read -r ch; do

--- a/.github/workflows/deploy-auto-learn.yml
+++ b/.github/workflows/deploy-auto-learn.yml
@@ -97,7 +97,7 @@ jobs:
           FAILURES=$(echo "${{ steps.collect.outputs.failures_b64 }}" | base64 -d 2>/dev/null || echo '[]')
 
           # ── Known error patterns from compliance gate ──
-          KNOWN_PATTERNS='[{"pattern":"no-nested-ternary","rule":"eslint_no_nested_ternary","fix":"Replace nested ternary with if/else","autofix":true},{"pattern":"no-use-before-define","rule":"eslint_no_use_before_define","fix":"Move function definition before usage","autofix":true},{"pattern":"TS2769.*overload","rule":"ts2769_jwt_sign","fix":"Use parseExpiresIn() with cast","autofix":false},{"pattern":"TS2339.*Property.*does not exist","rule":"ts_property_missing","fix":"Add property to interface","autofix":false},{"pattern":"duplicate.*tag|already exists","rule":"duplicate_tag","fix":"Increment patch version","autofix":true},{"pattern":"scope.*plural|scopes","rule":"jwt_scope_plural","fix":"Use scope (singular)","autofix":true},{"pattern":"Invalid scope.*Invalid scopes|Scope not allowed.*Scopes not allowed|required-scopes.*access values.*scope values","rule":"auth_scope_response_contract","fix":"Preserve existing API key scope error wording while keeping JWT claims singular","autofix":false},{"pattern":"no-require-imports|global-require|import/no-dynamic-require|Unexpected require","rule":"eslint_static_imports","fix":"Use static import syntax instead of require()","autofix":true},{"pattern":"no-useless-concat|Unexpected string concatenation of literals","rule":"eslint_no_useless_concat","fix":"Do not concatenate string literals to bypass scanners; fix scanner rule or use arrays/join when justified","autofix":true},{"pattern":"ASCII|garbled|encode","rule":"swagger_garbled","fix":"Remove accented characters","autofix":true},{"pattern":"validateTrustedUrl.*mock","rule":"validate_in_fetch","fix":"Remove from fetch, use at input","autofix":true},{"pattern":"403.*push|permission denied","rule":"push_403","fix":"Use agent branch prefix","autofix":false},{"pattern":"run.*not.*increment|trigger.*not.*fir","rule":"trigger_not_firing","fix":"Increment run field","autofix":true},{"pattern":"exit code 127|command not found","rule":"gha_command_not_found","fix":"Remove heredoc from run blocks","autofix":true},{"pattern":"heredoc.*EOF|EOFBODY|cat <<","rule":"gha_heredoc_in_run","fix":"Replace heredoc with inline variable","autofix":true},{"pattern":"Pre-push validation FAILED.*blocking push|continue-on-error.*pre-push","rule":"apply_pre_push_must_block","fix":"Never use continue-on-error on pre-push validation that protects corporate repos","autofix":false},{"pattern":"Cannot find name .*process|Cannot find name .*Buffer|Cannot find namespace .*NodeJS|Cannot find module .*(@aws-sdk/client-s3|prom-client)","rule":"prepush_dependency_baseline","fix":"Keep deterministic static and changed-file validation blocking; treat full-repo tsc dependency baseline as advisory until source deps are reproducible on generic runners","autofix":false},{"pattern":"properties/labels.*not an array|labels=\\\\[","rule":"github_issue_labels_array","fix":"Use repeated labels[]= fields for gh api issue creation","autofix":true}]'
+          KNOWN_PATTERNS='[{"pattern":"no-nested-ternary","rule":"eslint_no_nested_ternary","fix":"Replace nested ternary with if/else","autofix":true},{"pattern":"no-use-before-define","rule":"eslint_no_use_before_define","fix":"Move function definition before usage","autofix":true},{"pattern":"TS2769.*overload","rule":"ts2769_jwt_sign","fix":"Use parseExpiresIn() with cast","autofix":false},{"pattern":"TS2339.*Property.*does not exist","rule":"ts_property_missing","fix":"Add property to interface","autofix":false},{"pattern":"duplicate.*tag|already exists","rule":"duplicate_tag","fix":"Increment patch version","autofix":true},{"pattern":"scope.*plural|scopes","rule":"jwt_scope_plural","fix":"Use scope (singular)","autofix":true},{"pattern":"Invalid scope.*Invalid scopes|Scope not allowed.*Scopes not allowed|required-scopes.*access values.*scope values","rule":"auth_scope_response_contract","fix":"Preserve existing API key scope error wording while keeping JWT claims singular","autofix":false},{"pattern":"no-require-imports|global-require|import/no-dynamic-require|Unexpected require","rule":"eslint_static_imports","fix":"Use static import syntax instead of require()","autofix":true},{"pattern":"no-useless-concat|Unexpected string concatenation of literals","rule":"eslint_no_useless_concat","fix":"Do not concatenate string literals to bypass scanners; fix scanner rule or use arrays/join when justified","autofix":true},{"pattern":"ASCII|garbled|encode","rule":"swagger_garbled","fix":"Remove accented characters","autofix":true},{"pattern":"validateTrustedUrl.*mock","rule":"validate_in_fetch","fix":"Remove from fetch, use at input","autofix":true},{"pattern":"403.*push|permission denied","rule":"push_403","fix":"Use agent branch prefix","autofix":false},{"pattern":"run.*not.*increment|trigger.*not.*fir","rule":"trigger_not_firing","fix":"Increment run field","autofix":true},{"pattern":"exit code 127|command not found","rule":"gha_command_not_found","fix":"Remove heredoc from run blocks","autofix":true},{"pattern":"heredoc.*EOF|EOFBODY|cat <<","rule":"gha_heredoc_in_run","fix":"Replace heredoc with inline variable","autofix":true},{"pattern":"Pre-push validation FAILED.*blocking push|continue-on-error.*pre-push","rule":"apply_pre_push_must_block","fix":"Never use continue-on-error on pre-push validation that protects corporate repos","autofix":false},{"pattern":"Cannot find name .*process|Cannot find name .*Buffer|Cannot find namespace .*NodeJS|Cannot find module .*(@aws-sdk/client-s3|prom-client)","rule":"prepush_dependency_baseline","fix":"Keep deterministic static and changed-file validation blocking; treat full-repo tsc dependency baseline as advisory until source deps are reproducible on generic runners","autofix":false},{"pattern":"properties/labels.*not an array|labels=\\\\[","rule":"github_issue_labels_array","fix":"Use repeated labels[]= fields for gh api issue creation","autofix":true},{"pattern":"stop.*before.*deploy|missing.*CAP|missing.*monitor|not.*post-deploy|sem.*deploy|parou.*meio","rule":"autonomous_completion_required","fix":"Continue through source SHA green, image publication, CAP/deploy alignment, release-state, audit, monitor, and learning write-back before declaring done","autofix":false}]'
 
           # ── Match failures against patterns (FIX: avoid subshell variable loss) ──
           MATCHED=0
@@ -194,7 +194,7 @@ jobs:
           | Recent Successes | $SUCCESS_COUNT |
           | Recent Failures | $FAIL_COUNT |
 
-          ## Compliance Gate Rules (21 active)
+          ## Compliance Gate Rules (22 active)
 
           ### Pre-Deploy (Static Analysis)
           | # | Rule | What it checks | Severity |
@@ -205,6 +205,7 @@ jobs:
           | 4 | jwt-scope-singular | scope not scopes | 🔴 error |
           | 5 | no-validate-in-fetch | validateTrustedUrl not in fetch | 🔴 error |
           | 6 | no-nested-ternary | ESLint will reject | 🔴 error |
+          | 6E | autonomous-completion-required | Blocks skip_ci_wait/promote bypass for source/deploy changes | 🔴 error |
           | 7 | search-replace-newlines | sed can't handle \\n | 🔴 error |
           | 8 | run-not-incremented | Workflow won't fire | 🔴 error |
           | 9 | blocked-workspace | Third-party isolation | 🔴 error |
@@ -213,7 +214,7 @@ jobs:
           | 12 | security-dos-loop | Loop without MAX_RESULTS | 🔴 error |
           | 13 | hardcoded-secret | Secrets in patch files | 🔴 error |
           | 14 | use-before-define | Function called before defined | 🔴 error |
-          | 15-21 | deploy hardening | Corporate lint, GitHub labels, auth response contract, dependency baseline, and source apply guards | 🔴 error |
+          | 15-22 | deploy hardening | Corporate lint, GitHub labels, auth response contract, dependency baseline, autonomous completion, and source apply guards | 🔴 error |
 
           ### During Deploy (Pull & Test)
           | Step | What it does |
@@ -251,6 +252,7 @@ jobs:
           | auth scope response contract | API compatibility | ❌ |
           | GitHub labels array | GitHub API | ✅ |
           | pre-push dependency baseline | Corporate deps | ❌ |
+          | autonomous completion required | Release flow | ❌ |
           | garbled swagger | Encoding | ✅ |
           | validateTrustedUrl | Mock tests | ✅ |
           | 403 push | Branch protection | ❌ |
@@ -262,7 +264,7 @@ jobs:
            │
            ▼
           ┌─────────────────────────┐
-          │ Compliance Gate (21)    │ ← Static + Pull & Test + Tag Check
+          │ Compliance Gate (22)    │ ← Static + Pull & Test + Tag Check
           └───────────┬─────────────┘
                       │ ✅ Pass
                       ▼

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,8 +559,13 @@ Note: Some directories (`locks/`, `approvals/`, `metrics/`, `release-freeze.json
 **NUNCA deployar sem validar primeiro.** O pipeline de compliance roda automaticamente em PRs e pos-deploy.
 
 ```
-PR Created → Compliance Gate (21 checks) + Interface Check → apply-source-change (7 stages) → Post-Deploy Validation → Auto-Learn (with write-back)
+PR Created → Compliance Gate (22 checks) + Interface Check → apply-source-change (7 stages) → Post-Deploy Validation → Auto-Learn (with write-back)
 ```
+
+### Codex Autonomous Completion Policy
+Codex must not stop at implementation, local validation, commit, push, PR, merge, source push, or a partial green CI signal. For any source/deploy change, completion requires evidence that the exact corporate source SHA is green, the expected image is published, the CAP/deploy repo is promoted or already aligned, release-state and audit trail are saved, the post-deploy monitor is green, and learnings are written back to memory/docs/auto-learn.
+
+Known CI/deploy failures must be diagnosed, fixed, re-triggered, and re-monitored automatically. Human interruption is reserved for active locks, missing credentials/permissions, security conflicts, destructive-risk ambiguity, or critical context that cannot be derived from repo artifacts.
 
 #### Stage 1: Compliance Gate (PRE-DEPLOY — compliance-gate.yml)
 | # | Rule | What | Severity |
@@ -574,6 +579,7 @@ PR Created → Compliance Gate (21 checks) + Interface Check → apply-source-ch
 | 6B | eslint-corporate-blockers | Blocks require() and literal concatenation before corporate lint | error |
 | 6C | github-api-label-array | Blocks gh api issue labels sent as string JSON | error |
 | 6D | auth-scope-response-contract | Preserves API key scope error wording while JWT claims stay singular | error |
+| 6E | autonomous-completion-required | Blocks skipping source CI monitoring or CAP/deploy promotion for source/deploy changes | error |
 | 7 | search-replace-newlines | sed can't handle | error |
 | 8 | run-not-incremented | Workflow won't fire | error |
 | 9 | blocked-workspace | Third-party isolation | error |
@@ -605,7 +611,7 @@ Validates BOTH controller and agent sides BEFORE commit/deploy. Errors and vulne
 | Auto-Learn Write-back | `deploy-auto-learn.yml` Step 4 | Persists learned patterns to session memory + contract |
 | Resilience Patterns | `contracts/resilience-patterns.json` | 13 known failure patterns with automatic workarounds and fallback chains |
 
-**Flow**: `git commit` → PreToolUse hook → `pre-commit-validate.sh` → 12 checks → approve/block → PR → compliance-gate (21 checks + interface-check) → deploy → auto-learn (write-back)
+**Flow**: `git commit` → PreToolUse hook → `pre-commit-validate.sh` → 12 checks → approve/block → PR → compliance-gate (22 checks + interface-check) → deploy → auto-learn (write-back)
 
 ### Resilience & Self-Healing System
 Automatic failure recovery without human intervention. Maps known failures to workarounds, discovers new patterns autonomously.

--- a/contracts/codex-agent-contract.json
+++ b/contracts/codex-agent-contract.json
@@ -13,7 +13,8 @@
     "handoff-consumption",
     "pre-deploy-validation",
     "security-patching",
-    "direct-commits-via-codex-apply"
+    "direct-commits-via-codex-apply",
+    "end-to-end-autonomous-release-execution"
   ],
   "tools": {
     "primary": "codex-web",
@@ -102,7 +103,7 @@
     }
   },
     "deployFlow": {
-    "description": "FLUXO COMPLETO de deploy — o autopilot e a porta padrao para repos corporativos. Excecao: operacao direta so existe quando o usuario autoriza explicitamente na sessao atual.",
+    "description": "FLUXO COMPLETO de deploy — o autopilot e a porta padrao para repos corporativos. Excecao: operacao direta so existe quando o usuario autoriza explicitamente na sessao atual. Codex nao pode encerrar no meio: alteracao tecnica so termina apos source repo verde, imagem publicada, CAP/deploy promovido ou alinhado, estado/auditoria salvo, monitor pos-deploy verde e aprendizados registrados.",
     "steps": [
       "0. OBRIGATORIO: Usar o autopilot como unica porta para repos corporativos; nunca editar ou commitar diretamente neles",
       "1. OBRIGATORIO: Buscar arquivos corporativos ATUAIS via fetch-files (base correta)",
@@ -116,7 +117,10 @@
       "9. Monitorar o commit SHA corporativo correto pelos check-runs/workloads e pela esteira configurada no workspace ate conclusao verde",
       "10. Confirmar evidencia de publicacao da imagem da versao esperada",
       "11. So entao considerar valida a promocao da tag no CAP/deploy repo",
-      "12. Se falhar: ler logs, diagnosticar, corrigir, re-deploy AUTOMATICAMENTE sem promover o CAP antes do source repo ficar verde"
+      "12. Monitorar CAP/deploy repo ate confirmar tag aplicada ou alinhada com a imagem publicada",
+      "13. Salvar release-state, audit trail, monitor state e aprendizados na memoria/docs versionadas",
+      "14. Se falhar: ler logs, diagnosticar, corrigir, re-deploy AUTOMATICAMENTE sem promover o CAP antes do source repo ficar verde",
+      "15. Encerrar somente depois de apresentar evidencias de source SHA, CI run, versao/tag, CAP/deploy commit ou alinhamento, release-state e monitor"
     ],
     "directCorporateOverride": {
       "enabledOnlyWhen": "O usuario autoriza explicitamente operacao direta no repo corporativo na sessao atual",
@@ -200,7 +204,9 @@
   ],
   "autonomousExecutionPolicy": {
     "description": "Fluxo padrao obrigatorio para execucao autonoma do Codex em alteracoes tecnicas",
-    "rule": "Com contexto suficiente, executar sem pedir confirmacao: commit -> push -> PR -> merge (squash)",
+    "rule": "Com contexto suficiente, executar sem pedir confirmacao: entender -> alterar -> validar -> commit -> push -> PR -> merge (squash) -> aplicar no source corporativo -> monitorar CI/source SHA -> confirmar imagem -> promover/alinha CAP/deploy -> salvar estado/auditoria -> monitorar pos-deploy -> registrar aprendizados",
+    "completionDefinition": "Done significa evidencia final de release: PR mergeado, source SHA corporativo publicado e verde, imagem esperada publicada, CAP/deploy repo promovido ou comprovadamente alinhado, release-state atualizado, audit trail gravado, monitor pos-deploy verde e aprendizados persistidos em memoria/docs versionadas.",
+    "stopPolicy": "Nao parar no meio por default. Interromper somente se houver bloqueio real de seguranca, credencial, permissao, contexto critico ausente, risco destrutivo ou conflito que nao possa ser resolvido sem decisao humana. Falhas conhecidas de CI/deploy devem ser diagnosticadas, corrigidas e reexecutadas automaticamente.",
     "autopilotProductRule": "Toda alteracao local relevante no repo autopilot deve ser sincronizada com GitHub automaticamente no mesmo ciclo; nao deixar conhecimento apenas local/sessao.",
     "autopilotCommitTraceabilityRule": "Commits no repo autopilot devem incluir marcador de rastreio '[claude]' para facilitar visualizacao na esteira. Nao aplicar esse marcador em commits de esteiras/repositorios empresariais.",
     "guardrails": [
@@ -209,7 +215,8 @@
       "Nunca mergear PR de deploy se validate-patches falhar",
       "Nunca promover tag CAP/deploy se o source repo nao estiver verde com a imagem publicada",
       "Em modo direto, nunca sair do diretorio isolado corporativo e nunca persistir token em arquivo rastreado",
-      "Sempre monitorar workflows e esteira corporativa apos merge"
+      "Sempre monitorar workflows e esteira corporativa apos merge",
+      "Nunca declarar conclusao antes de CAP/deploy, release-state, audit, monitor e learnings ficarem completos"
     ],
     "sourceOfTruth": [
       "contracts/claude-session-memory.json#deployFlowGuide",
@@ -228,7 +235,11 @@
       "9. So depois disso permitir a promocao do deploy repo/CAP",
       "10. Resolver conflitos/falhas automaticamente quando possivel",
       "11. Realizar squash merge quando policy gates passarem",
-      "12. Monitorar pos-merge (workflows + esteira corporativa quando aplicavel)"
+      "12. Monitorar pos-merge (workflows + esteira corporativa quando aplicavel)",
+      "13. Confirmar CAP/deploy repo promovido ou alinhado com a imagem publicada",
+      "14. Confirmar release-state, audit trail e ci-monitor atualizados",
+      "15. Persistir erros, correcoes e aprendizados em memoria/docs/auto-learn",
+      "16. So entao responder ao usuario com evidencias e estado final"
     ],
     "autopilotCommitWorkflowChain": [
       "[Agent] Auto PR + Auto-Merge (Codex) (push)",

--- a/contracts/codex-deploy-guide.md
+++ b/contracts/codex-deploy-guide.md
@@ -26,7 +26,24 @@ Before deploying, you need:
 6. Monitor apply-source-change until the corporate source SHA is known
 7. Monitor the corporate source SHA, workloads/check-runs, and image publication
 8. Only then is CAP/deploy tag promotion valid
+9. Save release/audit state, confirm post-deploy monitor success, and persist learnings
 ```
+
+## Mandatory Completion Policy
+
+Codex must not stop at local implementation, PR creation, PR merge, source push, or an isolated green CI signal. A source/deploy task is complete only when Codex has autonomously reached and verified all of these points:
+
+1. Current corporate base fetched or otherwise verified.
+2. Patch implemented and locally validated in autopilot.
+3. Autopilot commit, push, PR, and squash merge completed.
+4. `apply-source-change.yml` completed through source apply and CI gate.
+5. Exact corporate source SHA monitored until the source pipeline/check-runs/workloads are green.
+6. Expected image version publication confirmed.
+7. CAP/deploy repo promoted or proven already aligned with that image tag.
+8. Release state, audit trail, and CI monitor state saved.
+9. Errors, corrections, and learnings written back to versioned memory/docs/auto-learn.
+
+If any known failure occurs, Codex diagnoses logs, applies the smallest safe fix, increments the trigger when needed, redeploys, and keeps monitoring. Human intervention is reserved for real blockers: missing credentials/permissions, active session lock by another agent, destructive-risk ambiguity, security policy conflict, or missing critical context that cannot be derived from the repo.
 
 ---
 
@@ -242,6 +259,9 @@ If `workflow_runs` do not show the configured workflow name, do not assume nothi
 Only after all of the following are true is the deploy valid:
 
 1. The correct corporate source SHA finished green.
+2. The expected corporate workload/check-runs finished green.
+3. The target image version was published.
+4. The CAP/deploy repo tag matches that published version.
 
 ---
 
@@ -282,9 +302,6 @@ chmod 700 "$ASKPASS"
 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$ASKPASS" GIT_TOKEN="$TOKEN" git push origin main
 rm -f "$ASKPASS"
 ```
-2. The expected corporate workload/check-runs finished green.
-3. The target image version was published.
-4. The CAP/deploy repo tag matches that published version.
 
 ### If Deploy Fails:
 1. Check which step failed: `gh api repos/lucassfreiree/autopilot/actions/runs/<RUN_ID>/jobs`

--- a/contracts/codex-session-memory.json
+++ b/contracts/codex-session-memory.json
@@ -1,14 +1,15 @@
 {
   "schemaVersion": 1,
-  "lastUpdated": "2026-04-22T22:30:00Z",
-  "sessionCount": 11,
+  "lastUpdated": "2026-04-24T22:13:24Z",
+  "sessionCount": 12,
   "currentState": {
-    "controllerVersion": "3.9.3",
+    "controllerVersion": "3.9.6",
     "agentVersion": "2.2.9",
-    "lastTriggerRun": 111,
-    "lastSuccessfulRun": 66,
+    "lastTriggerRun": 117,
+    "lastSuccessfulRun": 117,
     "workspace": "ws-default",
-    "pipelineStatus": "direct-corporate-controller-source-run-24804944785-success"
+    "pipelineStatus": "controller-3.9.6-source-ci-cap-monitor-success",
+    "autonomousCompletionRequired": true
   },
   "sessionsLog": [
     {
@@ -50,6 +51,11 @@
       "timestamp": "2026-04-22T22:30:00Z",
       "topic": "autopilot-monitor-hardening",
       "action": "Applied workflow and dashboard improvements so ci-monitor-loop now falls back from exact workflow name to same-SHA workflow runs and then to commit check-runs, records active signals and monitor strategy, checks CAP alignment before dispatching promote-cap, and marks release state promoted when CAP was already aligned after source success."
+    },
+    {
+      "timestamp": "2026-04-24T22:13:24Z",
+      "topic": "codex-autonomous-completion-policy",
+      "action": "Registered the permanent Codex rule that a technical change is not complete until Codex has understood, implemented, locally validated, committed, pushed, opened/merged PR, triggered the corporate source pipeline, monitored the exact source SHA to green, confirmed image publication, promoted or verified CAP/deploy alignment, saved release/audit state, run post-deploy monitoring, and documented learnings without stopping for user intervention except for security, credential, permission, or destructive-risk blockers."
     }
   ],
   "decisions": [
@@ -92,6 +98,11 @@
       "timestamp": "2026-04-22T22:30:00Z",
       "decision": "CAP already aligned to the target version must be treated as a valid post-source-success state, not as a failed promotion.",
       "reason": "The deploy repo may already point to the expected tag before the final source-green moment; after the source pipeline finishes green with publish confirmed, the state should become consistent without forcing a redundant CAP commit."
+    },
+    {
+      "timestamp": "2026-04-24T22:13:24Z",
+      "decision": "Codex must operate corporate changes as an end-to-end autonomous release loop and may not stop at implementation, local tests, PR merge, source push, or corporate CI alone.",
+      "reason": "Stopping before deploy/CAP alignment, state save, audit, monitor, and learning write-back creates partial releases, drift, and repeated manual recovery."
     }
   ],
   "lessonsLearned": [
@@ -146,6 +157,10 @@
     {
       "timestamp": "2026-04-22T22:30:00Z",
       "lesson": "When the deploy repo is already on the expected image tag, mark CAP as aligned and update release-state consistency after source success instead of demanding another commit to values.yaml."
+    },
+    {
+      "timestamp": "2026-04-24T22:13:24Z",
+      "lesson": "For source/deploy work, the definition of done is post-deploy evidence, not code change delivery: exact corporate SHA green, image published, CAP/deploy aligned, release-state and audit updated, monitor success, and learnings recorded."
     }
   ],
   "errorPatterns": {
@@ -209,6 +224,16 @@
       ],
       "rootCause": "The corporate .npmrc points package tarball downloads to the intranet Artifactory host, which is unreachable from the current network context.",
       "fix": "Do not treat this as a source-code failure by default. Record the network dependency, use local validation only when registry resolution is available, and rely on the corporate source pipeline as the authoritative package-install and test executor."
+    },
+    "codex_stop_before_post_deploy_done": {
+      "observedAt": "2026-04-24T22:13:24Z",
+      "symptoms": [
+        "Codex reports completion after local code, PR, merge, or source CI but before deploy/CAP and monitor evidence",
+        "User must manually ask whether the source repo passed or whether the deploy repo was changed",
+        "Release state, audit, or learnings are not updated in the same autonomous cycle"
+      ],
+      "rootCause": "The agent treated intermediate milestones as final completion instead of enforcing an end-to-end autonomous release definition of done.",
+      "fix": "Continue automatically until source SHA, image publication, CAP/deploy alignment, release-state, audit, monitor, and learning write-back are complete. Stop only for real security, credential, permission, destructive-risk, or missing-critical-context blockers."
     }
   }
 }

--- a/ops/docs/agent-operational-parity.md
+++ b/ops/docs/agent-operational-parity.md
@@ -75,6 +75,23 @@ Quando houver alteração de código/configuração, operar sempre em ciclo curt
 6. Repetir o ciclo (novo commit → novos checks) até todos os gates críticos ficarem verdes.
 7. Considerar a pipeline corporativa como validação final de release.
 
+## 7) Política obrigatória de conclusão autônoma
+
+Codex não pode parar em implementação local, commit, PR, merge, source push ou CI parcial. Para mudanças técnicas em source/deploy, o fluxo só está concluído quando houver evidência de ponta a ponta:
+
+1. Base corporativa atual entendida antes do patch.
+2. Alteração implementada com escopo mínimo e compatível.
+3. Validação local/autopilot executada.
+4. Commit, push, PR e squash merge concluídos.
+5. `apply-source-change.yml` executado até obter o SHA corporativo exato.
+6. SHA corporativo monitorado até a esteira/check-runs/workloads ficarem verdes.
+7. Publicação da imagem da versão esperada confirmada.
+8. CAP/deploy repo promovido ou comprovadamente alinhado com a imagem publicada.
+9. `release-state`, audit trail e monitor state atualizados.
+10. Erros, correções e aprendizados registrados em memória/docs/auto-learn.
+
+Falhas conhecidas devem ser diagnosticadas, corrigidas e reexecutadas automaticamente. Parar e pedir decisão humana só é aceitável quando houver bloqueio real de segurança, credencial, permissão, risco destrutivo, lock de outro agente ou contexto crítico que não possa ser inferido de artefatos do repo.
+
 ### Template de status para fechamento
 
 - Resumo do problema
@@ -85,7 +102,7 @@ Quando houver alteração de código/configuração, operar sempre em ciclo curt
 - Riscos remanescentes
 - Plano de rollback
 
-## 7) Referências canônicas
+## 8) Referências canônicas
 
 - `AGENTS.md`
 - `CLAUDE.md`

--- a/ops/inventory/agent-operational-memory.md
+++ b/ops/inventory/agent-operational-memory.md
@@ -19,12 +19,16 @@
    - Gerador `workflow-observability-report.py` com saídas Markdown/JSON.
 3. **Automação de PR (resiliência a ambiente sem gh)**
    - `auto-pr-merge.sh` com fallback via API (`CODEX_TOKEN`/`GITHUB_TOKEN`) quando `gh` não existir.
+4. **Conclusão autônoma de release**
+   - Codex só pode encerrar mudanças source/deploy depois de implementar, validar, commitar, publicar branch/PR, mergear, aplicar no source corporativo, monitorar o SHA exato até verde, confirmar imagem publicada, promover ou verificar CAP/deploy, salvar estado/auditoria, monitorar pós-deploy e registrar aprendizados.
+   - Falhas conhecidas devem gerar diagnóstico, correção e nova execução automaticamente, sem depender de nova cobrança do operador.
 
 ## Restrições e armadilhas conhecidas
 
 - Push/merge remoto pode falhar mesmo com URL correta, devido ao bloqueio de egress do ambiente.
 - Token nunca deve ser salvo em arquivo/repo; uso apenas em runtime via secret/env.
 - Em ausência de `gh`, auto-merge completo depende de etapa posterior com GraphQL/CLI disponível.
+- Não tratar PR mergeado, source push, CI verde isolado ou CAP já alinhado como fim do trabalho sem evidência de monitor, estado, auditoria e aprendizado persistidos.
 
 ## Comandos úteis validados
 


### PR DESCRIPTION
## Objetivo
Registrar a regra operacional permanente de que Codex nao encerra mudancas source/deploy antes do fluxo completo: implementacao, validacao, commit, push, PR/merge, source CI, imagem, CAP/deploy, estado, auditoria, monitor e aprendizados.

## Mudancas
- Atualiza memoria operacional versionada do Codex e contrato do agente.
- Documenta a definition of done no guia de deploy, docs de paridade, CLAUDE.md, instrucoes e skill de deploy.
- Adiciona regra 6E no compliance gate para bloquear skip_ci_wait/promote bypass em source/deploy.
- Adiciona guard no agent quality gate para impedir remocao da politica dos artefatos canonicos.
- Adiciona padrao no auto-learn para mapear paradas antes do pos-deploy.

## Validacao local
- jq empty nos contratos/trigger.
- YAML parse via Ruby dos workflows alterados.
- Parse JSON do KNOWN_PATTERNS.
- Verificacao dos marcadores da politica.
- git diff --check.